### PR TITLE
Replace deprecated codesign --deep with recursive inside-out signing

### DIFF
--- a/.agents/artifacts/adr_codesign_inside_out_signing.md
+++ b/.agents/artifacts/adr_codesign_inside_out_signing.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 
-**Status:** Accepted
+**Status:** Superseded
 **Date:** 2026-03-06
 **Deciders:** mherwig
 **Beads Issue:** N/A
@@ -11,7 +11,7 @@
 - [x] Decision follows Golden Path in `.claude/rules/tech-strategy.md`
 **Domain Tags:** security
 **Supersedes:** N/A
-**Superseded By:** N/A
+**Superseded By:** `adr_codesign_per_file_signing.md`
 
 ## Context
 

--- a/.agents/artifacts/adr_codesign_inside_out_signing.md
+++ b/.agents/artifacts/adr_codesign_inside_out_signing.md
@@ -1,0 +1,179 @@
+# ADR: Replace `codesign --deep` with Recursive Inside-Out Signing
+
+## Metadata
+
+**Status:** Accepted
+**Date:** 2026-03-06
+**Deciders:** mherwig
+**Beads Issue:** N/A
+**Related PRD:** N/A
+**Tech Strategy Alignment:**
+- [x] Decision follows Golden Path in `.claude/rules/tech-strategy.md`
+**Domain Tags:** security
+**Supersedes:** N/A
+**Superseded By:** N/A
+
+## Context
+
+ocx automatically ad-hoc signs Mach-O binaries after extracting packages on macOS, since unsigned binaries are terminated immediately on Apple Silicon (`Killed: 9`) and blocked by Gatekeeper on Intel.
+
+The previous implementation used a flat directory walk to collect all sign targets, then signed standalone Mach-O binaries individually and `.app`/`.framework` bundles with `codesign --sign - --force --deep`. This had three problems:
+
+1. **`--deep` is deprecated since macOS 13.0 (Ventura).** Apple recommends signing each component individually in inside-out order. `--deep` has poorly-specified ordering guarantees for nested frameworks — particularly relevant for packages like CMake that embed Qt frameworks with multi-level symlink structures (`Versions/Current → 5`).
+
+2. **No inode deduplication.** Packages may contain hardlinked binaries (same inode, multiple paths). The previous implementation signed each path independently, wasting time on redundant work.
+
+3. **No retry on codesign failure.** A known Apple bug causes `codesign` to fail on certain inodes. Homebrew works around this by copying the file to a new inode, signing, and moving it back. ocx had no such fallback.
+
+## Decision Drivers
+
+- Apple deprecated `--deep` and recommends inside-out per-component signing
+- Homebrew — the de facto standard for macOS binary management — uses per-file signing without `--deep`
+- Packages with nested framework bundles (e.g., CMake with Qt) require correct signing order
+- Hardlinked binaries in packages cause redundant signing work
+- Known Apple `codesign` bug requires a copy-to-new-inode workaround
+
+## Considered Options
+
+### Option 1: Keep `--deep`, add inode dedup
+
+**Description:** Keep the current two-pass approach (standalone binaries + `--deep` for bundles), but add inode tracking to skip hardlinked duplicates.
+
+| Pros | Cons |
+|------|------|
+| Minimal code change | `--deep` is deprecated and may be removed |
+| Known working approach | No control over signing order within bundles |
+| | Does not address the Apple inode bug |
+
+### Option 2: Flat walk with topological sort
+
+**Description:** Collect all sign targets in a flat list, sort by path depth (deepest first), sign individually without `--deep`.
+
+| Pros | Cons |
+|------|------|
+| Inside-out order achieved via sort | Requires separate bundle detection pass |
+| Single flat list, easy to reason about | Sort-based ordering is fragile for edge cases |
+| | Two-pass design (collect, then sign) adds complexity |
+
+### Option 3: Recursive inside-out with inode dedup
+
+**Description:** Replace the flat walk with a recursive function that naturally enforces inside-out order: recurse into subdirectories first, sign files in current directory, then seal the bundle if applicable. Track signed inodes via a shared `HashSet<u64>` to skip hardlinked duplicates. Retry failed signings with a copy-to-new-inode workaround.
+
+| Pros | Cons |
+|------|------|
+| Inside-out order is structural, not sort-based | Recursive async requires `Box::pin` |
+| Inode dedup prevents redundant work | Mutex on inode set (low contention in practice) |
+| Matches Homebrew's per-file approach | |
+| Retry workaround handles known Apple bug | |
+| Symlinks naturally skipped (`file_type()` doesn't follow) | |
+
+## Decision Outcome
+
+**Chosen Option:** Option 3 — Recursive inside-out with inode dedup
+
+**Rationale:** The recursive approach makes inside-out ordering a structural guarantee rather than relying on sort order. It naturally handles arbitrary nesting depth and matches Homebrew's proven approach. The inode deduplication and retry-with-copy workaround address real-world edge cases that the previous implementation ignored.
+
+### Consequences
+
+**Positive:**
+- Correct signing order for arbitrarily nested bundles (frameworks inside `.app` bundles)
+- No dependency on deprecated `--deep` flag
+- Hardlinked binaries signed only once
+- Resilient to known Apple `codesign` inode bug
+- Symlinks are never followed — `DirEntry::file_type()` returns `is_symlink()` on Unix, so symlink entries are neither recursed into nor signed
+- Aligns with Homebrew's approach, the de facto standard
+
+**Negative:**
+- Recursive async function requires `Box::pin` for the recursive call
+- Slightly more code than the flat walk approach
+
+**Risks:**
+- `Mutex<HashSet<u64>>` could theoretically contend under high parallelism, but in practice signing is I/O-bound and directory-level parallelism is limited. Mitigated by checking `is_macho` before acquiring the lock.
+
+## Technical Details
+
+### Architecture
+
+```
+sign_directory(content/)
+├── sign_directory(App.app/)              ← recurse first
+│   ├── sign_directory(Contents/)
+│   │   ├── sign_directory(Frameworks/)
+│   │   │   └── sign_directory(Qt.framework/)
+│   │   │       └── sign_directory(Versions/)
+│   │   │           ├── sign_directory(5/)
+│   │   │           │   └── sign_binary(QtCore)     ← inode recorded
+│   │   │           └── (Current → 5)               ← symlink, skipped
+│   │   │       then: sign_bundle(Qt.framework)     ← bundle sealed
+│   │   └── sign_directory(MacOS/)
+│   │       └── sign_binary(app)                    ← inode recorded
+│   then: sign_bundle(App.app)                      ← .app sealed LAST
+├── sign_binary(standalone-tool)                    ← standalone binary
+```
+
+### Key Functions
+
+```rust
+/// Recursive inside-out signing. Symlinks not followed.
+async fn sign_directory(path: &Path, signed_inodes: &Mutex<HashSet<u64>>)
+
+/// Signs a Mach-O binary with --preserve-metadata. Retries via copy on failure.
+async fn sign_binary(path: &Path)
+
+/// Signs a bundle (.app/.framework) without --deep, after contents are signed.
+async fn sign_bundle(path: &Path)
+
+/// Returns true for .app and .framework extensions.
+fn is_bundle(path: &Path) -> bool
+
+/// Returns the inode number (unix only, None on other platforms).
+async fn file_inode(path: &Path) -> Option<u64>
+
+/// Runs codesign, returns true on success.
+async fn try_codesign(args: &[&str], path: &Path) -> bool
+
+/// Copy to temp (new inode) → sign → move back. Apple codesign bug workaround.
+async fn retry_sign_with_copy(args: &[&str], path: &Path) -> std::io::Result<()>
+```
+
+### Signing Commands
+
+Individual Mach-O binaries:
+```sh
+codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime <binary>
+```
+
+Bundle sealing (after contents are signed):
+```sh
+codesign --sign - --force <bundle>
+```
+
+## Implementation Plan
+
+1. [x] Replace flat walk with recursive `sign_directory`
+2. [x] Add inode deduplication via `Mutex<HashSet<u64>>`
+3. [x] Add retry-with-copy fallback for Apple codesign bug
+4. [x] Remove `--deep` from bundle signing
+5. [x] Update tests (22 tests covering all paths)
+6. [x] Update FAQ documentation to reflect new approach
+
+## Validation
+
+- [x] All 130 workspace tests pass (`cargo nextest run --workspace`)
+- [x] Clippy clean (`cargo clippy --workspace`)
+- [x] FAQ documentation updated — no `--deep` references remain
+
+## Links
+
+- [PR #3: Replace codesign --deep with recursive inside-out signing](https://github.com/ocx-sh/ocx/pull/3)
+- [Apple codesign man page](https://keith.github.io/xcode-man-pages/codesign.1.html)
+- [Homebrew codesign implementation](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/extend/os/mac/keg.rb)
+- [MADR format](https://adr.github.io/madr/)
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-06 | mherwig | Accepted — implemented in PR #3 |

--- a/.agents/artifacts/adr_codesign_per_file_signing.md
+++ b/.agents/artifacts/adr_codesign_per_file_signing.md
@@ -115,13 +115,34 @@ Check each binary first; only re-sign if not already ad-hoc signed.
 ### Signing command
 
 ```sh
-codesign --sign - --force --preserve-metadata=entitlements,flags,runtime <binary>
+codesign --sign - --force --preserve-metadata=entitlements <binary>
 ```
 
 - `--sign -`: ad-hoc signature (no Team ID)
 - `--force`: replace any existing signature (required for certificate-signed third-party binaries)
-- `--preserve-metadata=entitlements,flags,runtime`: preserve app-declared capabilities, code signing flags (`CS_HARD`, `CS_KILL`, etc.), and hardened runtime — all relevant to correct execution behavior
-- `requirements` is intentionally dropped: the original Designated Requirement encodes the issuing certificate's Team ID, which an ad-hoc signature cannot satisfy, causing dyld "different Team IDs" errors for third-party binaries (Qt, etc.)
+- `--preserve-metadata=entitlements`: preserve app-declared capabilities only (JIT, network extensions, sandbox entitlements)
+
+**Why `flags` and `runtime` are NOT preserved:**
+
+`flags` contains code signing flags including `CS_RUNTIME` (hardened runtime, `0x10000`). When a
+Developer-ID-signed binary (e.g. Kitware's cmake-gui, Qt Company's Qt frameworks) is re-signed
+with `--preserve-metadata=flags`, `CS_RUNTIME` is preserved. This enables Library Validation,
+which requires all loaded libraries to have the same Team ID as the process.
+
+After ad-hoc re-signing, every binary has Team ID = "" (none). Apple treats "" as "no Team ID"
+rather than a valid matchable Team ID — so Library Validation **rejects** ad-hoc libraries even
+when both the process and library have identical empty Team IDs. This produces the
+"different Team IDs" dyld error at runtime.
+
+**Key difference from Homebrew**: Homebrew uses `--preserve-metadata=entitlements,requirements,flags,runtime`
+and it works because Homebrew builds its own binaries from source — those binaries never have
+`CS_RUNTIME` set by a third-party developer. OCX re-signs third-party pre-built binaries (Kitware,
+Qt Company, etc.) which do have `CS_RUNTIME`. Dropping `flags` is required for OCX's use case.
+
+`runtime` is SDK version metadata only; no effect on execution behavior.
+
+`requirements` is intentionally dropped: the original Designated Requirement encodes the issuing
+certificate's Team ID, which an ad-hoc signature cannot satisfy.
 
 ### What changes
 
@@ -155,10 +176,10 @@ No ordering requirement. Parallelism within each directory.
 
 ## Validation
 
-- [ ] All workspace unit tests pass
-- [ ] On macOS ARM64: `ocx exec cmake -- cmake-gui` launches without dyld errors
-- [ ] On macOS ARM64: standalone tool (`ocx exec cmake -- cmake --version`) works
-- [ ] On macOS: `OCX_DISABLE_CODESIGN=1` still disables signing
+- [x] All workspace unit tests pass (17/17 codesign tests)
+- [x] On macOS ARM64: `ocx exec dev.ocx.sh/cmake -- cmake-gui --version` launches without dyld errors
+- [x] On macOS ARM64: standalone tool (`ocx exec dev.ocx.sh/cmake -- cmake --version`) works
+- [x] On macOS: `OCX_DISABLE_CODESIGN=1` still disables signing
 
 ---
 

--- a/.agents/artifacts/adr_codesign_per_file_signing.md
+++ b/.agents/artifacts/adr_codesign_per_file_signing.md
@@ -1,0 +1,169 @@
+# ADR: Replace Bundle Signing with Per-File Mach-O Signing
+
+## Metadata
+
+**Status:** Accepted
+**Date:** 2026-03-11
+**Supersedes:** `adr_codesign_inside_out_signing.md` (the inside-out bundle signing approach)
+**Related analysis:** `analysis_codesign_team_id_mismatch.md`
+
+---
+
+## Context
+
+The inside-out recursive signing approach (see `adr_codesign_inside_out_signing.md`) was designed to replace deprecated `--deep` while maintaining proper bundle seals. It introduced `sign_bundle()`, `is_bundle()`, `is_versioned_framework()`, and `is_framework_version_dir()` to detect and seal `.app` and `.framework` bundles.
+
+Despite three rounds of patches, the approach still produces "different Team IDs" dyld errors for cmake-gui loading Qt frameworks. The root cause is that bundle sealing for versioned frameworks is difficult to implement correctly — specifically, the interaction between individual file signing (with `--preserve-metadata=requirements`) and subsequent bundle sealing creates Team ID conflicts. Each fix has added complexity without fully resolving the underlying issue.
+
+**The implementation has become a collection of special cases:**
+- Skip top-level `.framework/` files (commit `0cf16fc`)
+- Skip files inside `Versions/N/` (session fix #1)
+- Remove `requirements` from `--preserve-metadata` (session fix #2)
+- Inside-out ordering requirement with `Box::pin` recursive async
+- Four different bundle-detection predicates
+
+---
+
+## Core Insight
+
+**macOS at runtime only checks the binary's own embedded signature, not the `_CodeSignature/CodeResources` bundle seal.**
+
+The bundle seal (`_CodeSignature/CodeResources`) is checked by:
+1. Gatekeeper — when the user opens an app through Finder / double-click
+2. Explicit `codesign --verify --deep`
+
+OCX packages are run via `ocx exec` (direct process invocation), not through Finder. The macOS kernel only needs:
+- Each Mach-O being executed has a valid signature
+- All binaries in a loading chain have a consistent Team ID (all ad-hoc = Team ID none, or all from the same developer certificate)
+
+**Bundle sealing is unnecessary for OCX's use case.** Making the bundle seals correct is both complex and fragile for third-party packages.
+
+---
+
+## Decision Drivers
+
+- Bundle sealing for third-party packages (Qt frameworks signed by The Qt Company) requires overwriting existing `_CodeSignature/CodeResources` that reference a foreign Team ID — this is the source of all Team ID conflicts
+- Homebrew uses per-file signing only and it works reliably for macOS binary distribution
+- Apple TN2206 recommends per-component signing, but "component" for our use case is the individual Mach-O binary, not the bundle directory
+- OCX packages are run via `ocx exec`, not through Finder; the bundle seal is irrelevant for this execution path
+- KISS: per-file signing has zero special cases vs. five with bundle sealing
+
+---
+
+## Considered Options
+
+### Option A: Continue patching the bundle sealing approach (status quo)
+
+Continue adding special cases to handle edge cases in bundle detection and signing order.
+
+| Pros | Cons |
+|------|------|
+| Produces valid bundle seals for `codesign --verify --deep` | Complexity accumulates with each new package type |
+| Useful if packages are ever opened via Finder | Bundle sealing of third-party frameworks has fundamental Team ID conflicts |
+| | Every new framework variant (Qt5 vs Qt6, different versioning) may need another fix |
+| | Tests cannot verify real signing on Linux CI |
+
+### Option B: Per-file signing only (Homebrew approach)
+
+Walk the content tree, sign every Mach-O regular file. No bundle directory signing.
+
+| Pros | Cons |
+|------|------|
+| Zero special cases — one rule for everything | `codesign --verify --deep` on a signed `.app` bundle will fail |
+| Proven by Homebrew for macOS binary distribution | Opening via Finder may show security warning (stale bundle seal) |
+| No Team ID conflicts (no `--preserve-metadata=requirements`) | |
+| Handles any package structure automatically | |
+| Significantly less code | |
+
+### Option C: Per-file, skip if already ad-hoc signed
+
+Check each binary first; only re-sign if not already ad-hoc signed.
+
+| Pros | Cons |
+|------|------|
+| Preserves already-correct signatures | Fragile: a binary could be ad-hoc signed with a different Team ID |
+| Reduces re-signing for packages that ship pre-signed | Cannot tell if the existing ad-hoc signature is compatible with the rest |
+| | Certificate-signed binaries (Qt Team ID) would be kept → still causes Team ID conflicts |
+
+---
+
+## Decision Outcome
+
+**Chosen Option: B — Per-file signing only**
+
+**Rationale:**
+
+1. **Correctness for OCX's use case**: `ocx exec` bypasses Gatekeeper bundle-seal checks entirely. The kernel only verifies individual binary signatures at load time. Per-file signing produces valid individual signatures.
+
+2. **Team ID consistency**: All Mach-O files get a fresh ad-hoc signature (Team ID = none). There is no mechanism for a Team ID conflict when every binary is independently signed to the same identity.
+
+3. **Third-party package robustness**: Packages from any publisher — whether they use `.app` bundles, versioned Qt frameworks, flat dylib directories, or custom layouts — all work with the same one rule: sign every Mach-O file.
+
+4. **Proven approach**: Homebrew has used per-file signing since removing `--deep` support and handles millions of macOS package installations.
+
+5. **Simpler code**: Removes ~100 lines of bundle-detection logic. The signing loop becomes a straightforward recursive Mach-O file walk.
+
+**Trade-off accepted:** `codesign --verify --deep` on a package's `.app` bundle will fail because the bundle seals are stale (original developer seals, binaries re-signed). This is acceptable because:
+- OCX users run packages via `ocx exec`, not by opening `.app` bundles in Finder
+- For Finder access, the user can set `OCX_DISABLE_CODESIGN=1` and manage signing manually, or the package publisher can ship a properly signed package
+- The content-addressed object store is immutable; stale seals are a one-time state, not a security regression
+
+---
+
+## Implementation
+
+### Signing command
+
+```sh
+codesign --sign - --force --preserve-metadata=entitlements,flags,runtime <binary>
+```
+
+- `--sign -`: ad-hoc signature (no Team ID)
+- `--force`: replace any existing signature (required for certificate-signed third-party binaries)
+- `--preserve-metadata=entitlements,flags,runtime`: preserve app-declared capabilities, code signing flags (`CS_HARD`, `CS_KILL`, etc.), and hardened runtime — all relevant to correct execution behavior
+- `requirements` is intentionally dropped: the original Designated Requirement encodes the issuing certificate's Team ID, which an ad-hoc signature cannot satisfy, causing dyld "different Team IDs" errors for third-party binaries (Qt, etc.)
+
+### What changes
+
+**Remove:**
+- `sign_bundle()` — no bundle directory signing
+- `is_bundle()` — not needed
+- `is_versioned_framework()` — not needed
+- `is_framework_version_dir()` — not needed
+- The inside-out ordering requirement (no longer matters without bundle sealing)
+
+**Simplify:**
+- `sign_directory()` → straightforward recursive file walk; no step 2/3 distinction, no skip conditions
+
+**Keep:**
+- `sign_binary()` with `--preserve-metadata=entitlements,flags,runtime`
+- `try_codesign()`, `retry_sign_with_copy()` (inode bug workaround)
+- `is_macho()`, `file_inode()` (Mach-O detection and hardlink dedup)
+- `remove_quarantine()` (still useful)
+
+### Signing walk (pseudocode)
+
+```
+for each entry in directory (recursively, symlinks not followed):
+    if regular file AND is_macho AND inode not already seen:
+        codesign --sign - --force --preserve-metadata=entitlements,flags,runtime <file>
+```
+
+No ordering requirement. Parallelism within each directory.
+
+---
+
+## Validation
+
+- [ ] All workspace unit tests pass
+- [ ] On macOS ARM64: `ocx exec cmake -- cmake-gui` launches without dyld errors
+- [ ] On macOS ARM64: standalone tool (`ocx exec cmake -- cmake --version`) works
+- [ ] On macOS: `OCX_DISABLE_CODESIGN=1` still disables signing
+
+---
+
+## Links
+
+- [Homebrew keg.rb — per-file signing reference](https://raw.githubusercontent.com/Homebrew/brew/master/Library/Homebrew/extend/os/mac/keg.rb)
+- [Apple TN2206: macOS Code Signing In Depth](https://developer.apple.com/library/archive/technotes/tn2206/_index.html)
+- [Analysis: Team ID mismatch root cause](./analysis_codesign_team_id_mismatch.md)

--- a/.agents/artifacts/analysis_codesign_team_id_mismatch.md
+++ b/.agents/artifacts/analysis_codesign_team_id_mismatch.md
@@ -1,0 +1,154 @@
+# Analysis: "different Team IDs" codesign error for cmake-gui Qt frameworks
+
+**Date:** 2026-03-11
+**Branch:** fix/codesign-inside-out-signing
+**Symptom:** `cmake-gui` fails to launch with dyld error:
+```
+'QtWidgets.framework/Versions/5/QtWidgets' not valid for use in process:
+mapping process and mapped file (non-platform) have different Team IDs
+```
+
+---
+
+## Root Cause
+
+### The signing sequence for `CMake.app/Contents/Frameworks/QtWidgets.framework/`
+
+When `sign_directory` processes this framework, the flow is:
+
+1. `sign_directory(QtWidgets.framework/)`:
+   - `is_versioned_framework()` → TRUE → **skip step 2** (no individual file signing) ✓
+   - `is_bundle()` + `sign_bundle()` → returns early because `is_versioned_framework` → **skip bundle signing** ✗
+
+2. `sign_directory(Versions/)`:
+   - No files, no bundle → nothing signed
+
+3. `sign_directory(Versions/5/)`:
+   - `is_versioned_framework(Versions/5/)` → FALSE (no `.framework` extension)
+   - **Step 2 runs**: signs `QtWidgets` binary with `--preserve-metadata=entitlements,requirements,flags,runtime`
+   - `is_framework_version_dir(Versions/5/)` → TRUE → `sign_bundle(Versions/5/)` called
+
+4. `sign_bundle(Versions/5/)`:
+   - `codesign --sign - --force Versions/5/`
+
+### Why the binary ends up with a Team ID conflict
+
+The original `QtWidgets.framework/Versions/5/QtWidgets` was signed by Qt/The Qt Company with a real Apple Developer certificate. Their **Designated Requirement (DR)** looks like:
+```
+identifier "org.qt-project.QtWidgets" and anchor apple generic and
+certificate leaf[subject.OU] = "XXXXXXXX"
+```
+where `XXXXXXXX` is Qt's Team ID.
+
+In step 3's individual signing with `--preserve-metadata=requirements`:
+- The binary gets an **ad-hoc signature** (no Team ID)
+- But the **DR is preserved** from the original Qt certificate signing, requiring `subject.OU = Qt's Team ID`
+
+When macOS later loads `QtWidgets` into `cmake-gui` (which has a clean ad-hoc signature, no Team ID), it evaluates the DR. The DR says "must have Qt's Team ID" but the loading process has no Team ID → **"different Team IDs"**.
+
+### Why commit `0cf16fc` did not fix this
+
+Commit `0cf16fc` added `is_versioned_framework()` to skip signing files at the **top-level `.framework/` directory** (e.g., `QtWidgets.framework/QtWidgets`). That file gets the "ambiguous bundle format" error from codesign.
+
+**But `Versions/5/QtWidgets` is NOT in the top-level framework dir** — it's in `Versions/5/`. `is_versioned_framework(Versions/5/)` → FALSE, so step 2 still runs and still uses `--preserve-metadata=requirements`.
+
+The fix relied on `sign_bundle(Versions/5/)` to override the individual signing. If that call successfully re-signs the binary without `--preserve-metadata`, the requirements would be cleared. However:
+
+- **If** codesign doesn't properly treat `Versions/5/` as a bundle (since it lacks a `.framework` extension, codesign's bundle detection depends on finding `Resources/Info.plist`), the bundle signing might fail silently, leaving the binary with the preserved requirements.
+- Even if it succeeds, the individual signing in step 2 first modifies the binary, invalidating the existing `_CodeSignature/CodeResources` (from Qt's original signing). The bundle re-sign then needs to rebuild this seal.
+
+---
+
+## Homebrew Comparison
+
+Homebrew's approach (from `Library/Homebrew/extend/os/mac/keg.rb`):
+- Signs **individual Mach-O files only** — no bundle directory signing
+- Uses `--preserve-metadata=entitlements,requirements,flags,runtime` (same as us)
+- On **Intel**: only re-signs if `codesign --verify` returns `invalid signature` (i.e., only patched binaries)
+- On **ARM**: always re-signs (all Mach-O must be signed on Apple Silicon)
+
+Homebrew never gets the Team ID error because:
+1. On Intel it skips already-valid signatures
+2. It doesn't do bundle sealing, so there's no sign→seal→sign double-signing problem
+3. Its binaries are typically built FROM SCRATCH by Homebrew with its own provisioning — the DRs don't reference a foreign Team ID
+
+**Key difference**: We're re-signing THIRD-PARTY binaries (Qt signed by The Qt Company) whose DRs reference their certificate chain. Homebrew builds its own bottles, so the DRs it preserves were written by Homebrew's own signing.
+
+---
+
+## Apple TN2206 Guidance
+
+From [Apple TN2206](https://developer.apple.com/library/archive/technotes/tn2206/_index.html):
+
+> For multi-versioned frameworks, sign each specific version:
+> ```
+> # Correct:
+> codesign -s identity ../FooBarBaz.framework/Versions/A
+> ```
+
+The binary inside should be signed AS PART OF the bundle seal at `Versions/5/`, not individually before the bundle seal.
+
+---
+
+## Fix Plan
+
+### Fix 1 (primary): Skip individual file signing inside framework version directories
+
+In `sign_directory`, step 2 should also skip if `is_framework_version_dir(path)` is true.
+
+**Rationale**: Files inside `Versions/5/` are part of the framework bundle. They should be signed ONLY by the `sign_bundle(Versions/5/)` call (step 3), not individually first. The individual pre-signing:
+- Uses `--preserve-metadata=requirements` → embeds conflicting Team ID constraint
+- Creates a double-signing race: individual sign modifies the binary, invalidating the existing `_CodeSignature/CodeResources`, then `sign_bundle` must rebuild the seal
+
+**Change in `sign_directory`**:
+```rust
+// Before:
+if !is_versioned_framework(path).await {
+    // sign files individually
+
+// After:
+if !is_versioned_framework(path).await && !is_framework_version_dir(path) {
+    // sign files individually
+```
+
+### Fix 2 (safety net): Remove `requirements` from `--preserve-metadata`
+
+Remove `requirements` from `sign_binary`'s `--preserve-metadata` flag:
+```
+Before: "--preserve-metadata=entitlements,requirements,flags,runtime"
+After:  "--preserve-metadata=entitlements,flags,runtime"
+```
+
+**Rationale**: For ad-hoc signing of THIRD-PARTY binaries, preserving the original certificate-based DR is counterproductive. The DR references a Team ID that the ad-hoc signature cannot satisfy. `entitlements`, `flags`, and `runtime` are still worth preserving (e.g., sandbox entitlements, hardened runtime). Homebrew's use of `--preserve-metadata=requirements` is safe for its own builds but not for third-party certificate-signed binaries.
+
+This is a safety net: even if Fix 1 is correct and the individual signing of framework binaries is skipped, `sign_binary` is still called for standalone binaries from other publishers. Those binaries might also have Team ID DRs. Removing `requirements` ensures they all get clean ad-hoc signatures.
+
+### Impact assessment
+
+- Fix 1 changes which binaries get individually signed (framework version dir binaries are skipped, signed only via bundle seal)
+- Fix 2 changes what metadata is preserved when signing any individual binary
+- Both fixes are conservative: they produce CLEANER ad-hoc signatures (no conflicting requirements)
+- No loss of meaningful behavior: for ad-hoc signing, the original certificate requirements are meaningless
+
+### Test plan
+
+1. Run `cargo nextest run --workspace` to verify no unit test regressions
+2. Build cmake package and test on macOS ARM64:
+   - `ocx exec cmake -- cmake-gui` should launch without dyld error
+   - `codesign --verify --deep CMake.app` should pass
+3. Verify `OCX_DISABLE_CODESIGN=1` still works as escape hatch
+
+---
+
+## Files to change
+
+- `crates/ocx_lib/src/codesign.rs` — two targeted changes
+
+---
+
+## Related commits
+
+- `ac46b2a` — initial inside-out signing (replaced `--deep`)
+- `1de0d74` — added `is_framework_version_dir` and `sign_bundle(Versions/5/)` approach
+- `0cf16fc` — skipped top-level framework file signing (partial fix)
+- This fix — skips framework version dir file signing + removes `requirements` from preserve-metadata

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ cd test && uv run pytest tests/test_install.py::test_install_creates_candidate_s
 
 **Coverage**: `task coverage` (cargo-llvm-cov), `task coverage:open` to view HTML report.
 
+**Verification**: `task verify` runs format check, clippy, build, unit tests, and acceptance tests. **Always run `task verify` after completing an implementation** to confirm nothing is broken.
+
+**Before committing**: Always run `cargo fmt` before creating a commit to ensure code is properly formatted.
+
 ## Architecture
 
 **Workspace layout**: Two crates — `crates/ocx_lib` (core library) and `crates/ocx_cli` (thin CLI shell using clap). Rust edition 2024, resolver v3.

--- a/crates/ocx_lib/src/codesign.rs
+++ b/crates/ocx_lib/src/codesign.rs
@@ -17,10 +17,10 @@ use crate::{Result, log};
 /// This is safe because:
 /// - OCX packages are run via `ocx exec`, not launched through Finder. The kernel only checks
 ///   each binary's own embedded signature at load time — not the bundle-level `CodeResources`.
-/// - Signing at the individual file level avoids all "bundle format is ambiguous" errors and
-///   Team ID conflicts that arise from re-sealing third-party bundles (e.g. Qt frameworks signed
-///   by The Qt Company with their own Team ID requirements).
-/// - This matches Homebrew's approach, which is the de-facto standard for macOS binary patching.
+/// - Signing at the individual file level avoids "bundle format is ambiguous" errors and Team ID
+///   conflicts from re-sealing third-party bundles (e.g. Qt frameworks signed by The Qt Company).
+/// - Only `entitlements` are preserved (`flags` and `requirements` are intentionally dropped —
+///   see `sign_binary` for the full rationale).
 ///
 /// Hardlinked files (same inode) are signed only once. Symlinks are not followed.
 ///
@@ -199,27 +199,28 @@ async fn remove_quarantine(content_path: &Path) {
 /// Preserved metadata from the original signature:
 /// - `entitlements`: app-declared capabilities (JIT, network extensions, sandbox) — must be
 ///   retained so the binary runs correctly under its intended privilege model.
-/// - `flags`: code signing flags (`CS_HARD`, `CS_KILL`, `CS_RESTRICT`, etc.) — preserve the
-///   binary's intended hardening posture.
-/// - `runtime`: hardened runtime flag — required for binaries that depend on restricted JIT or
-///   library validation.
 ///
 /// Intentionally NOT preserved:
+/// - `flags`: code signing flags such as `CS_RUNTIME` (hardened runtime). Preserving `CS_RUNTIME`
+///   from a Developer-ID-signed binary (e.g. Kitware's cmake-gui, Qt Company's Qt frameworks)
+///   enables Library Validation, which requires all loaded libraries to have the same Team ID as
+///   the process. After ad-hoc re-signing, every binary has Team ID = "" (none). Apple treats
+///   "" as "no Team ID" rather than a real Team ID, so Library Validation rejects ad-hoc libraries
+///   even when both the process and library have identical empty Team IDs — causing the
+///   "different Team IDs" dyld error at runtime. Dropping `flags` disables Library Validation,
+///   allowing ad-hoc libraries to load. Note: Homebrew's `--preserve-metadata=flags` works because
+///   Homebrew builds its own binaries from source; those binaries never have `CS_RUNTIME` to begin
+///   with. OCX re-signs third-party pre-built binaries which do.
 /// - `requirements`: the original Designated Requirement encodes the issuing certificate's Team ID.
-///   An ad-hoc signature cannot satisfy a third-party Team ID constraint, which would cause
-///   "different Team IDs" dyld errors when loading Qt frameworks and similar third-party bundles.
+///   An ad-hoc signature cannot satisfy a third-party Team ID constraint.
+/// - `runtime`: SDK version metadata only; no effect on execution behavior.
 ///
 /// If the first attempt fails (known Apple `codesign` bug with certain inodes), the file is
 /// copied to a temp path (new inode), signed there, and moved back.
 async fn sign_binary(path: &Path) {
     log::debug!("Signing Mach-O binary: {}", path.display());
 
-    let args = &[
-        "--sign",
-        "-",
-        "--force",
-        "--preserve-metadata=entitlements,flags,runtime",
-    ];
+    let args = &["--sign", "-", "--force", "--preserve-metadata=entitlements"];
 
     if try_codesign(args, path).await {
         return;

--- a/crates/ocx_lib/src/codesign.rs
+++ b/crates/ocx_lib/src/codesign.rs
@@ -1,17 +1,27 @@
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::{Result, log};
 
-/// Applies ad-hoc code signatures to Mach-O binaries after extraction.
+/// Applies ad-hoc code signatures to all Mach-O binaries after extraction.
 ///
 /// On macOS, unsigned Mach-O binaries are killed on Apple Silicon (`Killed: 9`) and blocked
 /// by Gatekeeper on Intel. This function recursively walks the extracted content directory,
 /// detects Mach-O files by their magic bytes, and applies ad-hoc signatures via `codesign --sign -`.
 ///
-/// Signing is performed inside-out: subdirectories are processed before the current directory,
-/// so nested bundles (`.framework`, `.app`) are sealed after their contents are signed.
+/// **Design: per-file signing only, no bundle sealing.**
+///
+/// Only individual Mach-O files are signed. Bundle seals (`_CodeSignature/CodeResources` inside
+/// `.app` / `.framework` directories) are intentionally left as-is (stale after re-signing).
+/// This is safe because:
+/// - OCX packages are run via `ocx exec`, not launched through Finder. The kernel only checks
+///   each binary's own embedded signature at load time — not the bundle-level `CodeResources`.
+/// - Signing at the individual file level avoids all "bundle format is ambiguous" errors and
+///   Team ID conflicts that arise from re-sealing third-party bundles (e.g. Qt frameworks signed
+///   by The Qt Company with their own Team ID requirements).
+/// - This matches Homebrew's approach, which is the de-facto standard for macOS binary patching.
+///
 /// Hardlinked files (same inode) are signed only once. Symlinks are not followed.
 ///
 /// On non-macOS platforms this is a no-op.
@@ -35,8 +45,8 @@ pub async fn sign_extracted_content(content_path: &Path) -> Result<()> {
 
     remove_quarantine(content_path).await;
 
-    let signed_inodes = Mutex::new(HashSet::new());
-    sign_directory(content_path, &signed_inodes).await;
+    let signed_inodes = Arc::new(Mutex::new(HashSet::new()));
+    sign_directory(content_path.to_path_buf(), signed_inodes).await;
 
     Ok(())
 }
@@ -70,71 +80,73 @@ async fn is_macho(path: &Path) -> bool {
     MACHO_MAGIC.contains(&value)
 }
 
-// -- Recursive inside-out signing ---------------------------------------------
+// -- Recursive per-file signing -----------------------------------------------
 
-/// Recursively signs all Mach-O binaries and bundles in inside-out order.
+/// Recursively signs all Mach-O regular files under `path`.
 ///
-/// 1. Recurse into real subdirectories (symlinks are not followed)
-/// 2. Sign Mach-O files in this directory in parallel (deduplicated by inode)
-/// 3. If this directory is a bundle (`.app` / `.framework`), sign the bundle itself
+/// - Recurses into subdirectories in parallel (symlinks are not followed).
+/// - Signs each regular Mach-O file in parallel within each directory, deduplicated by inode.
+/// - Bundle directories (`.app`, `.framework`) are recursed into but not
+///   sealed — only the individual Mach-O files inside are signed.
 ///
-/// Inode tracking via `signed_inodes` prevents signing the same physical file
-/// twice when hardlinks exist across directories.
-async fn sign_directory(path: &Path, signed_inodes: &Mutex<HashSet<u64>>) {
-    let Ok(mut read_dir) = tokio::fs::read_dir(path).await else {
-        return;
-    };
-
-    let mut subdirs = Vec::new();
-    let mut files = Vec::new();
-
-    while let Ok(Some(entry)) = read_dir.next_entry().await {
-        let Ok(ft) = entry.file_type().await else {
-            continue;
+/// Returns an explicit `Pin<Box<dyn Future + Send>>` so that the recursive call inside
+/// `JoinSet::spawn` resolves to a concrete `Send` type, breaking the circularity that prevents
+/// the compiler from proving `Send` for recursive `async fn` futures.
+fn sign_directory(
+    path: std::path::PathBuf,
+    signed_inodes: Arc<Mutex<HashSet<u64>>>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+    Box::pin(async move {
+        let Ok(mut read_dir) = tokio::fs::read_dir(&path).await else {
+            return;
         };
-        // file_type() does NOT follow symlinks — symlinks are neither recursed nor signed.
-        if ft.is_dir() {
-            subdirs.push(entry.path());
-        } else if ft.is_file() {
-            files.push(entry.path());
-        }
-    }
 
-    // Step 1: Recurse into subdirectories first (inside-out order).
-    // Sequential at this level so the Mutex sees a consistent inode set;
-    // parallelism happens within each directory's file signing.
-    for dir in subdirs {
-        Box::pin(sign_directory(&dir, signed_inodes)).await;
-    }
+        let mut subdirs = Vec::new();
+        let mut files = Vec::new();
 
-    // Step 2: Sign Mach-O files in this directory (parallel, with inode dedup).
-    let mut tasks = tokio::task::JoinSet::new();
-    for file in files {
-        if !is_macho(&file).await {
-            continue;
+        while let Ok(Some(entry)) = read_dir.next_entry().await {
+            let Ok(ft) = entry.file_type().await else {
+                continue;
+            };
+            // file_type() does NOT follow symlinks — symlinks are neither recursed nor signed.
+            if ft.is_dir() {
+                subdirs.push(entry.path());
+            } else if ft.is_file() {
+                files.push(entry.path());
+            }
         }
-        if let Some(inode) = file_inode(&file).await
-            && !signed_inodes.lock().unwrap().insert(inode)
-        {
-            continue; // Already signed via hardlink
-        }
-        tasks.spawn(async move { sign_binary(&file).await });
-    }
-    while let Some(result) = tasks.join_next().await {
-        if let Err(e) = result {
-            log::warn!("Code signing task panicked: {}", e);
-        }
-    }
 
-    // Step 3: Sign the bundle after all its contents are signed.
-    if is_bundle(path) {
-        sign_bundle(path).await;
-    }
-}
+        // Recurse into subdirectories in parallel. Each call returns a Send future (explicit
+        // return type above), so JoinSet::spawn accepts it without Box::pin.
+        let mut subdir_tasks = tokio::task::JoinSet::new();
+        for dir in subdirs {
+            let inodes = Arc::clone(&signed_inodes);
+            subdir_tasks.spawn(sign_directory(dir, inodes));
+        }
+        while let Some(result) = subdir_tasks.join_next().await {
+            if let Err(e) = result {
+                log::warn!("Directory signing task panicked: {}", e);
+            }
+        }
 
-/// Returns true for directories that are macOS bundles (`.app` or `.framework`).
-fn is_bundle(path: &Path) -> bool {
-    path.extension().is_some_and(|ext| ext == "app" || ext == "framework")
+        let mut file_tasks = tokio::task::JoinSet::new();
+        for file in files {
+            if !is_macho(&file).await {
+                continue;
+            }
+            if let Some(inode) = file_inode(&file).await
+                && !signed_inodes.lock().unwrap().insert(inode)
+            {
+                continue; // Already signed via hardlink
+            }
+            file_tasks.spawn(async move { sign_binary(&file).await });
+        }
+        while let Some(result) = file_tasks.join_next().await {
+            if let Err(e) = result {
+                log::warn!("Code signing task panicked: {}", e);
+            }
+        }
+    })
 }
 
 /// Returns the inode number of a regular file, used for hardlink deduplication.
@@ -182,10 +194,20 @@ async fn remove_quarantine(content_path: &Path) {
     }
 }
 
-/// Signs a Mach-O binary with ad-hoc signature, retrying with an inode workaround on failure.
+/// Signs a Mach-O binary with an ad-hoc signature, retrying with an inode workaround on failure.
 ///
-/// Uses `--preserve-metadata=entitlements,requirements,flags,runtime` to retain any existing
-/// entitlements and hardened-runtime settings from the original signature.
+/// Preserved metadata from the original signature:
+/// - `entitlements`: app-declared capabilities (JIT, network extensions, sandbox) — must be
+///   retained so the binary runs correctly under its intended privilege model.
+/// - `flags`: code signing flags (`CS_HARD`, `CS_KILL`, `CS_RESTRICT`, etc.) — preserve the
+///   binary's intended hardening posture.
+/// - `runtime`: hardened runtime flag — required for binaries that depend on restricted JIT or
+///   library validation.
+///
+/// Intentionally NOT preserved:
+/// - `requirements`: the original Designated Requirement encodes the issuing certificate's Team ID.
+///   An ad-hoc signature cannot satisfy a third-party Team ID constraint, which would cause
+///   "different Team IDs" dyld errors when loading Qt frameworks and similar third-party bundles.
 ///
 /// If the first attempt fails (known Apple `codesign` bug with certain inodes), the file is
 /// copied to a temp path (new inode), signed there, and moved back.
@@ -196,7 +218,7 @@ async fn sign_binary(path: &Path) {
         "--sign",
         "-",
         "--force",
-        "--preserve-metadata=entitlements,requirements,flags,runtime",
+        "--preserve-metadata=entitlements,flags,runtime",
     ];
 
     if try_codesign(args, path).await {
@@ -208,14 +230,6 @@ async fn sign_binary(path: &Path) {
     if let Err(e) = retry_sign_with_copy(args, path).await {
         log::warn!("Failed to sign {} (even after retry): {}", path.display(), e);
     }
-}
-
-/// Signs a bundle (`.app` or `.framework`) without `--deep`.
-///
-/// Expects all nested content to already be signed (called after recursive descent).
-async fn sign_bundle(path: &Path) {
-    log::debug!("Signing bundle: {}", path.display());
-    try_codesign(&["--sign", "-", "--force"], path).await;
 }
 
 /// Runs `codesign` with the given arguments. Returns `true` on success.
@@ -250,8 +264,16 @@ async fn try_codesign(args: &[&str], path: &Path) -> bool {
 ///
 /// Works around a known Apple `codesign` bug where signing fails on certain inodes.
 /// Homebrew uses the same technique in `codesign_patched_binary`.
+///
+/// The temp file is placed alongside the original with `.codesign_tmp` appended to the
+/// full filename (not replacing the extension) to avoid collisions between files that share
+/// a stem but differ only in extension (e.g. `foo.bar` and `foo.baz`).
 async fn retry_sign_with_copy(args: &[&str], path: &Path) -> std::io::Result<()> {
-    let tmp = path.with_extension("codesign_tmp");
+    let tmp_name = format!(
+        "{}.codesign_tmp",
+        path.file_name().unwrap_or_default().to_string_lossy()
+    );
+    let tmp = path.with_file_name(tmp_name);
     tokio::fs::copy(path, &tmp).await?;
 
     if try_codesign(args, &tmp).await {
@@ -375,33 +397,10 @@ mod tests {
         assert!(!super::is_macho(&path).await);
     }
 
-    // -- is_bundle ----------------------------------------------------------------
-
-    #[test]
-    fn is_bundle_detects_app() {
-        assert!(super::is_bundle(std::path::Path::new("/tmp/Foo.app")));
-    }
-
-    #[test]
-    fn is_bundle_detects_framework() {
-        assert!(super::is_bundle(std::path::Path::new("/tmp/QtCore.framework")));
-    }
-
-    #[test]
-    fn is_bundle_rejects_plain_directory() {
-        assert!(!super::is_bundle(std::path::Path::new("/tmp/bin")));
-    }
-
-    #[test]
-    fn is_bundle_rejects_file_extension() {
-        assert!(!super::is_bundle(std::path::Path::new("/tmp/file.txt")));
-    }
-
     // -- sign_directory -----------------------------------------------------------
 
     #[tokio::test]
     async fn sign_directory_finds_standalone_binaries() {
-        // Verifies that sign_directory visits Mach-O files by checking the inode set.
         let dir = TempDir::new().unwrap();
         let bin_dir = dir.path().join("bin");
         std::fs::create_dir_all(&bin_dir).unwrap();
@@ -410,83 +409,18 @@ mod tests {
         create_file_with_magic(&bin_dir, "tool_b", &0xFEED_FACEu32.to_be_bytes());
         create_file_with_magic(&bin_dir, "script.sh", b"#!/b");
 
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(dir.path(), &signed_inodes).await;
+        let signed_inodes = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+        super::sign_directory(dir.path().to_path_buf(), signed_inodes.clone()).await;
 
-        // Two Mach-O files should have their inodes recorded (script.sh is not Mach-O).
+        // Two Mach-O files; script.sh is not Mach-O.
         assert_eq!(signed_inodes.lock().unwrap().len(), 2);
-    }
-
-    #[tokio::test]
-    async fn sign_directory_finds_binaries_inside_app_bundle() {
-        // With the new approach, binaries inside .app bundles ARE signed individually.
-        let dir = TempDir::new().unwrap();
-        let app_macos = dir.path().join("MyApp.app").join("Contents").join("MacOS");
-        std::fs::create_dir_all(&app_macos).unwrap();
-
-        create_file_with_magic(&app_macos, "MyApp", &0xFEED_FACFu32.to_be_bytes());
-
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(dir.path(), &signed_inodes).await;
-
-        assert_eq!(signed_inodes.lock().unwrap().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn sign_directory_finds_all_binaries_in_app() {
-        let dir = TempDir::new().unwrap();
-        let app_macos = dir.path().join("Foo.app").join("Contents").join("MacOS");
-        std::fs::create_dir_all(&app_macos).unwrap();
-        create_file_with_magic(&app_macos, "Foo", &0xFEED_FACFu32.to_be_bytes());
-        create_file_with_magic(&app_macos, "helper", &0xFEED_FACFu32.to_be_bytes());
-
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(dir.path(), &signed_inodes).await;
-
-        assert_eq!(
-            signed_inodes.lock().unwrap().len(),
-            2,
-            "should sign both Mach-O binaries inside .app"
-        );
-    }
-
-    #[tokio::test]
-    async fn sign_directory_mixed_content() {
-        let dir = TempDir::new().unwrap();
-        let content = dir.path().join("content");
-        std::fs::create_dir_all(&content).unwrap();
-
-        // Standalone Mach-O
-        let bin_dir = content.join("bin");
-        std::fs::create_dir_all(&bin_dir).unwrap();
-        create_file_with_magic(&bin_dir, "tool", &0xFEED_FACFu32.to_be_bytes());
-
-        // Shell script (not Mach-O)
-        create_file_with_magic(&bin_dir, "wrapper.sh", b"#!/b");
-
-        // .app bundle with Mach-O inside
-        let app_macos = content.join("MyApp.app").join("Contents").join("MacOS");
-        std::fs::create_dir_all(&app_macos).unwrap();
-        create_file_with_magic(&app_macos, "MyApp", &0xFEED_FACFu32.to_be_bytes());
-
-        // ELF binary (should be ignored)
-        create_file_with_magic(&bin_dir, "linux_bin", &[0x7F, b'E', b'L', b'F']);
-
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(&content, &signed_inodes).await;
-
-        assert_eq!(
-            signed_inodes.lock().unwrap().len(),
-            2,
-            "should sign standalone Mach-O + Mach-O inside .app"
-        );
     }
 
     #[tokio::test]
     async fn sign_directory_empty_directory() {
         let dir = TempDir::new().unwrap();
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(dir.path(), &signed_inodes).await;
+        let signed_inodes = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+        super::sign_directory(dir.path().to_path_buf(), signed_inodes.clone()).await;
         assert!(signed_inodes.lock().unwrap().is_empty());
     }
 
@@ -497,8 +431,8 @@ mod tests {
         create_file_with_magic(dir.path(), "data.json", b"{\"ke");
         create_file_with_magic(dir.path(), "image.png", &[0x89, b'P', b'N', b'G']);
 
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(dir.path(), &signed_inodes).await;
+        let signed_inodes = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+        super::sign_directory(dir.path().to_path_buf(), signed_inodes.clone()).await;
         assert!(signed_inodes.lock().unwrap().is_empty());
     }
 
@@ -513,8 +447,8 @@ mod tests {
         #[cfg(unix)]
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(dir.path(), &signed_inodes).await;
+        let signed_inodes = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+        super::sign_directory(dir.path().to_path_buf(), signed_inodes.clone()).await;
 
         // Only the real file should be signed, not the symlink.
         assert_eq!(signed_inodes.lock().unwrap().len(), 1);
@@ -530,8 +464,8 @@ mod tests {
         let hardlink = bin_dir.join("hardlink");
         std::fs::hard_link(&original, &hardlink).unwrap();
 
-        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
-        super::sign_directory(dir.path(), &signed_inodes).await;
+        let signed_inodes = std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashSet::new()));
+        super::sign_directory(dir.path().to_path_buf(), signed_inodes.clone()).await;
 
         // Same inode — should only be signed once.
         assert_eq!(signed_inodes.lock().unwrap().len(), 1);
@@ -638,34 +572,6 @@ mod tests {
         assert!(
             verify_signature(&binary).await,
             "binary should be signed after sign_extracted_content"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[tokio::test]
-    async fn sign_extracted_content_signs_app_bundle_inside_out() {
-        let env = crate::test::env::lock();
-        env.remove("OCX_DISABLE_CODESIGN");
-
-        let dir = TempDir::new().unwrap();
-        let content = dir.path().join("content");
-        let app_dir = content.join("Test.app");
-        let macos_dir = app_dir.join("Contents").join("MacOS");
-        std::fs::create_dir_all(&macos_dir).unwrap();
-
-        let binary = build_unsigned_binary(&macos_dir, "Test");
-        assert!(
-            !verify_signature(&binary).await,
-            "binary should be unsigned before signing"
-        );
-
-        let result = super::sign_extracted_content(&content).await;
-        assert!(result.is_ok(), "sign_extracted_content should succeed");
-
-        assert!(verify_signature(&binary).await, "binary inside .app should be signed");
-        assert!(
-            verify_signature(&app_dir).await,
-            ".app bundle should be signed after its contents"
         );
     }
 }

--- a/crates/ocx_lib/src/codesign.rs
+++ b/crates/ocx_lib/src/codesign.rs
@@ -134,8 +134,7 @@ async fn sign_directory(path: &Path, signed_inodes: &Mutex<HashSet<u64>>) {
 
 /// Returns true for directories that are macOS bundles (`.app` or `.framework`).
 fn is_bundle(path: &Path) -> bool {
-    path.extension()
-        .is_some_and(|ext| ext == "app" || ext == "framework")
+    path.extension().is_some_and(|ext| ext == "app" || ext == "framework")
 }
 
 /// Returns the inode number of a regular file, used for hardlink deduplication.
@@ -444,7 +443,11 @@ mod tests {
         let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
         super::sign_directory(dir.path(), &signed_inodes).await;
 
-        assert_eq!(signed_inodes.lock().unwrap().len(), 2, "should sign both Mach-O binaries inside .app");
+        assert_eq!(
+            signed_inodes.lock().unwrap().len(),
+            2,
+            "should sign both Mach-O binaries inside .app"
+        );
     }
 
     #[tokio::test]
@@ -651,12 +654,18 @@ mod tests {
         std::fs::create_dir_all(&macos_dir).unwrap();
 
         let binary = build_unsigned_binary(&macos_dir, "Test");
-        assert!(!verify_signature(&binary).await, "binary should be unsigned before signing");
+        assert!(
+            !verify_signature(&binary).await,
+            "binary should be unsigned before signing"
+        );
 
         let result = super::sign_extracted_content(&content).await;
         assert!(result.is_ok(), "sign_extracted_content should succeed");
 
         assert!(verify_signature(&binary).await, "binary inside .app should be signed");
-        assert!(verify_signature(&app_dir).await, ".app bundle should be signed after its contents");
+        assert!(
+            verify_signature(&app_dir).await,
+            ".app bundle should be signed after its contents"
+        );
     }
 }

--- a/crates/ocx_lib/src/codesign.rs
+++ b/crates/ocx_lib/src/codesign.rs
@@ -1,12 +1,18 @@
-use std::path::{Path, PathBuf};
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Mutex;
 
 use crate::{Result, log};
 
-/// Applies ad-hoc code signatures to Mach-O binaries and `.app` bundles after extraction.
+/// Applies ad-hoc code signatures to Mach-O binaries after extraction.
 ///
 /// On macOS, unsigned Mach-O binaries are killed on Apple Silicon (`Killed: 9`) and blocked
-/// by Gatekeeper on Intel. This function walks the extracted content directory, detects Mach-O
-/// files by their magic bytes, and applies ad-hoc signatures via `codesign --sign -`.
+/// by Gatekeeper on Intel. This function recursively walks the extracted content directory,
+/// detects Mach-O files by their magic bytes, and applies ad-hoc signatures via `codesign --sign -`.
+///
+/// Signing is performed inside-out: subdirectories are processed before the current directory,
+/// so nested bundles (`.framework`, `.app`) are sealed after their contents are signed.
+/// Hardlinked files (same inode) are signed only once. Symlinks are not followed.
 ///
 /// On non-macOS platforms this is a no-op.
 ///
@@ -29,13 +35,13 @@ pub async fn sign_extracted_content(content_path: &Path) -> Result<()> {
 
     remove_quarantine(content_path).await;
 
-    let targets = collect_sign_targets(content_path).await;
-    sign_targets(targets).await;
+    let signed_inodes = Mutex::new(HashSet::new());
+    sign_directory(content_path, &signed_inodes).await;
 
     Ok(())
 }
 
-// -- Discovery (async) --------------------------------------------------------
+// -- Mach-O detection ---------------------------------------------------------
 
 /// Mach-O magic bytes (native and byte-swapped variants).
 const MACHO_MAGIC: &[u32] = &[
@@ -46,80 +52,6 @@ const MACHO_MAGIC: &[u32] = &[
     0xCFFA_EDFE, // MH_CIGAM_64 (64-bit, swapped)
     0xBEBA_FECA, // FAT_CIGAM (Universal, swapped)
 ];
-
-#[cfg_attr(test, derive(Debug))]
-enum SignTarget {
-    AppBundle(PathBuf),
-    Binary(PathBuf),
-}
-
-/// Walk the content directory asynchronously to collect signing targets.
-///
-/// `.app` bundles are collected first. Individual Mach-O binaries that live
-/// outside any `.app` bundle are collected separately — files inside `.app`
-/// bundles are skipped because `codesign --deep` already covers them.
-async fn collect_sign_targets(content_path: &Path) -> Vec<SignTarget> {
-    let entries = match walkdir(content_path).await {
-        Ok(e) => e,
-        Err(e) => {
-            log::warn!("Failed to walk content directory for code signing: {}", e);
-            return Vec::new();
-        }
-    };
-
-    let mut targets = Vec::new();
-    let mut app_bundle_prefixes: Vec<PathBuf> = Vec::new();
-
-    // First: collect .app bundles.
-    for entry in &entries {
-        if entry.path.is_dir() && entry.path.extension().is_some_and(|ext| ext == "app") {
-            app_bundle_prefixes.push(entry.path.clone());
-            targets.push(SignTarget::AppBundle(entry.path.clone()));
-        }
-    }
-
-    // Second: collect standalone Mach-O binaries outside .app bundles.
-    for entry in &entries {
-        if !entry.is_file {
-            continue;
-        }
-        if app_bundle_prefixes.iter().any(|prefix| entry.path.starts_with(prefix)) {
-            continue;
-        }
-        if is_macho(&entry.path).await {
-            targets.push(SignTarget::Binary(entry.path.clone()));
-        }
-    }
-
-    targets
-}
-
-struct DirEntry {
-    path: PathBuf,
-    is_file: bool,
-}
-
-async fn walkdir(path: &Path) -> std::io::Result<Vec<DirEntry>> {
-    let mut entries = Vec::new();
-    walk_recursive(path, &mut entries).await?;
-    Ok(entries)
-}
-
-async fn walk_recursive(path: &Path, entries: &mut Vec<DirEntry>) -> std::io::Result<()> {
-    let mut read_dir = tokio::fs::read_dir(path).await?;
-    while let Some(entry) = read_dir.next_entry().await? {
-        let file_type = entry.file_type().await?;
-        let path = entry.path();
-        entries.push(DirEntry {
-            path: path.clone(),
-            is_file: file_type.is_file(),
-        });
-        if file_type.is_dir() {
-            Box::pin(walk_recursive(&path, entries)).await?;
-        }
-    }
-    Ok(())
-}
 
 async fn is_macho(path: &Path) -> bool {
     let Ok(mut file) = tokio::fs::File::open(path).await else {
@@ -138,28 +70,87 @@ async fn is_macho(path: &Path) -> bool {
     MACHO_MAGIC.contains(&value)
 }
 
-// -- Signing (async, parallel) ------------------------------------------------
+// -- Recursive inside-out signing ---------------------------------------------
 
-async fn sign_targets(targets: Vec<SignTarget>) {
-    let mut tasks = tokio::task::JoinSet::new();
+/// Recursively signs all Mach-O binaries and bundles in inside-out order.
+///
+/// 1. Recurse into real subdirectories (symlinks are not followed)
+/// 2. Sign Mach-O files in this directory in parallel (deduplicated by inode)
+/// 3. If this directory is a bundle (`.app` / `.framework`), sign the bundle itself
+///
+/// Inode tracking via `signed_inodes` prevents signing the same physical file
+/// twice when hardlinks exist across directories.
+async fn sign_directory(path: &Path, signed_inodes: &Mutex<HashSet<u64>>) {
+    let Ok(mut read_dir) = tokio::fs::read_dir(path).await else {
+        return;
+    };
 
-    for target in targets {
-        match target {
-            SignTarget::AppBundle(path) => {
-                tasks.spawn(async move { sign_app_bundle(&path).await });
-            }
-            SignTarget::Binary(path) => {
-                tasks.spawn(async move { sign_binary(&path).await });
-            }
+    let mut subdirs = Vec::new();
+    let mut files = Vec::new();
+
+    while let Ok(Some(entry)) = read_dir.next_entry().await {
+        let Ok(ft) = entry.file_type().await else {
+            continue;
+        };
+        // file_type() does NOT follow symlinks — symlinks are neither recursed nor signed.
+        if ft.is_dir() {
+            subdirs.push(entry.path());
+        } else if ft.is_file() {
+            files.push(entry.path());
         }
     }
 
+    // Step 1: Recurse into subdirectories first (inside-out order).
+    // Sequential at this level so the Mutex sees a consistent inode set;
+    // parallelism happens within each directory's file signing.
+    for dir in subdirs {
+        Box::pin(sign_directory(&dir, signed_inodes)).await;
+    }
+
+    // Step 2: Sign Mach-O files in this directory (parallel, with inode dedup).
+    let mut tasks = tokio::task::JoinSet::new();
+    for file in files {
+        if !is_macho(&file).await {
+            continue;
+        }
+        if let Some(inode) = file_inode(&file).await
+            && !signed_inodes.lock().unwrap().insert(inode)
+        {
+            continue; // Already signed via hardlink
+        }
+        tasks.spawn(async move { sign_binary(&file).await });
+    }
     while let Some(result) = tasks.join_next().await {
         if let Err(e) = result {
             log::warn!("Code signing task panicked: {}", e);
         }
     }
+
+    // Step 3: Sign the bundle after all its contents are signed.
+    if is_bundle(path) {
+        sign_bundle(path).await;
+    }
 }
+
+/// Returns true for directories that are macOS bundles (`.app` or `.framework`).
+fn is_bundle(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext == "app" || ext == "framework")
+}
+
+/// Returns the inode number of a regular file, used for hardlink deduplication.
+#[cfg(unix)]
+async fn file_inode(path: &Path) -> Option<u64> {
+    use std::os::unix::fs::MetadataExt;
+    tokio::fs::metadata(path).await.ok().map(|m| m.ino())
+}
+
+#[cfg(not(unix))]
+async fn file_inode(_path: &Path) -> Option<u64> {
+    None
+}
+
+// -- Signing ------------------------------------------------------------------
 
 fn codesign_available() -> bool {
     which::which("codesign").is_ok()
@@ -192,8 +183,44 @@ async fn remove_quarantine(content_path: &Path) {
     }
 }
 
-/// Run a codesign command, capture all output, and log the result.
-async fn run_codesign(args: &[&str], path: &Path, label: &str) {
+/// Signs a Mach-O binary with ad-hoc signature, retrying with an inode workaround on failure.
+///
+/// Uses `--preserve-metadata=entitlements,requirements,flags,runtime` to retain any existing
+/// entitlements and hardened-runtime settings from the original signature.
+///
+/// If the first attempt fails (known Apple `codesign` bug with certain inodes), the file is
+/// copied to a temp path (new inode), signed there, and moved back.
+async fn sign_binary(path: &Path) {
+    log::debug!("Signing Mach-O binary: {}", path.display());
+
+    let args = &[
+        "--sign",
+        "-",
+        "--force",
+        "--preserve-metadata=entitlements,requirements,flags,runtime",
+    ];
+
+    if try_codesign(args, path).await {
+        return;
+    }
+
+    // Retry: copy to new inode, sign, move back (Apple codesign bug workaround).
+    log::debug!("Retrying with inode workaround: {}", path.display());
+    if let Err(e) = retry_sign_with_copy(args, path).await {
+        log::warn!("Failed to sign {} (even after retry): {}", path.display(), e);
+    }
+}
+
+/// Signs a bundle (`.app` or `.framework`) without `--deep`.
+///
+/// Expects all nested content to already be signed (called after recursive descent).
+async fn sign_bundle(path: &Path) {
+    log::debug!("Signing bundle: {}", path.display());
+    try_codesign(&["--sign", "-", "--force"], path).await;
+}
+
+/// Runs `codesign` with the given arguments. Returns `true` on success.
+async fn try_codesign(args: &[&str], path: &Path) -> bool {
     let result = tokio::process::Command::new("codesign")
         .args(args)
         .arg(path)
@@ -205,15 +232,37 @@ async fn run_codesign(args: &[&str], path: &Path, label: &str) {
 
     match result {
         Ok(output) if output.status.success() => {
-            log::debug!("Signed {}: {}", label, path.display());
+            log::debug!("Signed: {}", path.display());
+            true
         }
         Ok(output) => {
-            let combined = format_process_output(&output.stdout, &output.stderr);
-            log::warn!("Failed to sign {} {}: {}", label, path.display(), combined);
+            let msg = format_process_output(&output.stdout, &output.stderr);
+            log::warn!("codesign failed for {}: {}", path.display(), msg);
+            false
         }
         Err(e) => {
-            log::warn!("Failed to run codesign on {} {}: {}", label, path.display(), e);
+            log::warn!("Failed to run codesign on {}: {}", path.display(), e);
+            false
         }
+    }
+}
+
+/// Copies the file to a temp path (new inode), signs it, and moves it back.
+///
+/// Works around a known Apple `codesign` bug where signing fails on certain inodes.
+/// Homebrew uses the same technique in `codesign_patched_binary`.
+async fn retry_sign_with_copy(args: &[&str], path: &Path) -> std::io::Result<()> {
+    let tmp = path.with_extension("codesign_tmp");
+    tokio::fs::copy(path, &tmp).await?;
+
+    if try_codesign(args, &tmp).await {
+        tokio::fs::rename(&tmp, path).await?;
+        Ok(())
+    } else {
+        if let Err(error) = tokio::fs::remove_file(&tmp).await {
+            log::debug!("Failed to remove temp file {}: {}", tmp.display(), error);
+        }
+        Err(std::io::Error::other("codesign failed after inode workaround"))
     }
 }
 
@@ -230,26 +279,6 @@ fn format_process_output(stdout: &[u8], stderr: &[u8]) -> String {
     }
 }
 
-async fn sign_app_bundle(path: &Path) {
-    log::debug!("Signing .app bundle: {}", path.display());
-    run_codesign(&["--sign", "-", "--force", "--deep"], path, ".app bundle").await;
-}
-
-async fn sign_binary(path: &Path) {
-    log::debug!("Signing Mach-O binary: {}", path.display());
-    run_codesign(
-        &[
-            "--sign",
-            "-",
-            "--force",
-            "--preserve-metadata=entitlements,requirements,flags,runtime",
-        ],
-        path,
-        "Mach-O binary",
-    )
-    .await;
-}
-
 // -- Tests --------------------------------------------------------------------
 
 #[cfg(test)]
@@ -259,7 +288,7 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use super::{MACHO_MAGIC, SignTarget};
+    use super::MACHO_MAGIC;
 
     fn create_file_with_magic(dir: &std::path::Path, name: &str, magic: &[u8]) -> PathBuf {
         let path = dir.join(name);
@@ -347,10 +376,33 @@ mod tests {
         assert!(!super::is_macho(&path).await);
     }
 
-    // -- collect_sign_targets -----------------------------------------------------
+    // -- is_bundle ----------------------------------------------------------------
+
+    #[test]
+    fn is_bundle_detects_app() {
+        assert!(super::is_bundle(std::path::Path::new("/tmp/Foo.app")));
+    }
+
+    #[test]
+    fn is_bundle_detects_framework() {
+        assert!(super::is_bundle(std::path::Path::new("/tmp/QtCore.framework")));
+    }
+
+    #[test]
+    fn is_bundle_rejects_plain_directory() {
+        assert!(!super::is_bundle(std::path::Path::new("/tmp/bin")));
+    }
+
+    #[test]
+    fn is_bundle_rejects_file_extension() {
+        assert!(!super::is_bundle(std::path::Path::new("/tmp/file.txt")));
+    }
+
+    // -- sign_directory -----------------------------------------------------------
 
     #[tokio::test]
-    async fn collect_targets_finds_standalone_binaries() {
+    async fn sign_directory_finds_standalone_binaries() {
+        // Verifies that sign_directory visits Mach-O files by checking the inode set.
         let dir = TempDir::new().unwrap();
         let bin_dir = dir.path().join("bin");
         std::fs::create_dir_all(&bin_dir).unwrap();
@@ -359,41 +411,44 @@ mod tests {
         create_file_with_magic(&bin_dir, "tool_b", &0xFEED_FACEu32.to_be_bytes());
         create_file_with_magic(&bin_dir, "script.sh", b"#!/b");
 
-        let targets = super::collect_sign_targets(dir.path()).await;
-        let bin_count = targets.iter().filter(|t| matches!(t, SignTarget::Binary(_))).count();
-        assert_eq!(bin_count, 2);
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(dir.path(), &signed_inodes).await;
+
+        // Two Mach-O files should have their inodes recorded (script.sh is not Mach-O).
+        assert_eq!(signed_inodes.lock().unwrap().len(), 2);
     }
 
     #[tokio::test]
-    async fn collect_targets_finds_app_bundles() {
+    async fn sign_directory_finds_binaries_inside_app_bundle() {
+        // With the new approach, binaries inside .app bundles ARE signed individually.
         let dir = TempDir::new().unwrap();
         let app_macos = dir.path().join("MyApp.app").join("Contents").join("MacOS");
         std::fs::create_dir_all(&app_macos).unwrap();
+
         create_file_with_magic(&app_macos, "MyApp", &0xFEED_FACFu32.to_be_bytes());
 
-        let targets = super::collect_sign_targets(dir.path()).await;
-        let app_count = targets.iter().filter(|t| matches!(t, SignTarget::AppBundle(_))).count();
-        assert_eq!(app_count, 1);
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(dir.path(), &signed_inodes).await;
+
+        assert_eq!(signed_inodes.lock().unwrap().len(), 1);
     }
 
     #[tokio::test]
-    async fn collect_targets_skips_binaries_inside_app_bundle() {
+    async fn sign_directory_finds_all_binaries_in_app() {
         let dir = TempDir::new().unwrap();
         let app_macos = dir.path().join("Foo.app").join("Contents").join("MacOS");
         std::fs::create_dir_all(&app_macos).unwrap();
         create_file_with_magic(&app_macos, "Foo", &0xFEED_FACFu32.to_be_bytes());
         create_file_with_magic(&app_macos, "helper", &0xFEED_FACFu32.to_be_bytes());
 
-        let targets = super::collect_sign_targets(dir.path()).await;
-        let app_count = targets.iter().filter(|t| matches!(t, SignTarget::AppBundle(_))).count();
-        let bin_count = targets.iter().filter(|t| matches!(t, SignTarget::Binary(_))).count();
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(dir.path(), &signed_inodes).await;
 
-        assert_eq!(app_count, 1, "should find the .app bundle");
-        assert_eq!(bin_count, 0, "should not list binaries inside .app separately");
+        assert_eq!(signed_inodes.lock().unwrap().len(), 2, "should sign both Mach-O binaries inside .app");
     }
 
     #[tokio::test]
-    async fn collect_targets_mixed_content() {
+    async fn sign_directory_mixed_content() {
         let dir = TempDir::new().unwrap();
         let content = dir.path().join("content");
         std::fs::create_dir_all(&content).unwrap();
@@ -414,30 +469,69 @@ mod tests {
         // ELF binary (should be ignored)
         create_file_with_magic(&bin_dir, "linux_bin", &[0x7F, b'E', b'L', b'F']);
 
-        let targets = super::collect_sign_targets(&content).await;
-        let app_count = targets.iter().filter(|t| matches!(t, SignTarget::AppBundle(_))).count();
-        let bin_count = targets.iter().filter(|t| matches!(t, SignTarget::Binary(_))).count();
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(&content, &signed_inodes).await;
 
-        assert_eq!(app_count, 1, "should find exactly one .app bundle");
-        assert_eq!(bin_count, 1, "should find exactly one standalone Mach-O");
+        assert_eq!(
+            signed_inodes.lock().unwrap().len(),
+            2,
+            "should sign standalone Mach-O + Mach-O inside .app"
+        );
     }
 
     #[tokio::test]
-    async fn collect_targets_empty_directory() {
+    async fn sign_directory_empty_directory() {
         let dir = TempDir::new().unwrap();
-        let targets = super::collect_sign_targets(dir.path()).await;
-        assert!(targets.is_empty());
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(dir.path(), &signed_inodes).await;
+        assert!(signed_inodes.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
-    async fn collect_targets_ignores_non_macho_files() {
+    async fn sign_directory_ignores_non_macho_files() {
         let dir = TempDir::new().unwrap();
         create_file_with_magic(dir.path(), "readme.txt", b"Hell");
         create_file_with_magic(dir.path(), "data.json", b"{\"ke");
         create_file_with_magic(dir.path(), "image.png", &[0x89, b'P', b'N', b'G']);
 
-        let targets = super::collect_sign_targets(dir.path()).await;
-        assert!(targets.is_empty());
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(dir.path(), &signed_inodes).await;
+        assert!(signed_inodes.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sign_directory_skips_symlinks() {
+        let dir = TempDir::new().unwrap();
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        let real = create_file_with_magic(&bin_dir, "real_binary", &0xFEED_FACFu32.to_be_bytes());
+        let link = bin_dir.join("link_binary");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(dir.path(), &signed_inodes).await;
+
+        // Only the real file should be signed, not the symlink.
+        assert_eq!(signed_inodes.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn sign_directory_deduplicates_hardlinks() {
+        let dir = TempDir::new().unwrap();
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+
+        let original = create_file_with_magic(&bin_dir, "original", &0xFEED_FACFu32.to_be_bytes());
+        let hardlink = bin_dir.join("hardlink");
+        std::fs::hard_link(&original, &hardlink).unwrap();
+
+        let signed_inodes = std::sync::Mutex::new(std::collections::HashSet::new());
+        super::sign_directory(dir.path(), &signed_inodes).await;
+
+        // Same inode — should only be signed once.
+        assert_eq!(signed_inodes.lock().unwrap().len(), 1);
     }
 
     // -- sign_extracted_content (stubbed) -----------------------------------------
@@ -520,27 +614,6 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[tokio::test]
-    async fn sign_app_bundle_signs_app() {
-        let dir = TempDir::new().unwrap();
-        let app_dir = dir.path().join("Test.app");
-        let macos_dir = app_dir.join("Contents").join("MacOS");
-        std::fs::create_dir_all(&macos_dir).unwrap();
-        build_unsigned_binary(&macos_dir, "Test");
-        assert!(
-            !verify_signature(&app_dir).await,
-            ".app bundle should be unsigned before signing"
-        );
-
-        super::sign_app_bundle(&app_dir).await;
-
-        assert!(
-            verify_signature(&app_dir).await,
-            ".app bundle should have a valid ad-hoc signature after signing"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[tokio::test]
     async fn sign_extracted_content_signs_real_binaries() {
         let env = crate::test::env::lock();
         env.remove("OCX_DISABLE_CODESIGN");
@@ -563,5 +636,27 @@ mod tests {
             verify_signature(&binary).await,
             "binary should be signed after sign_extracted_content"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn sign_extracted_content_signs_app_bundle_inside_out() {
+        let env = crate::test::env::lock();
+        env.remove("OCX_DISABLE_CODESIGN");
+
+        let dir = TempDir::new().unwrap();
+        let content = dir.path().join("content");
+        let app_dir = content.join("Test.app");
+        let macos_dir = app_dir.join("Contents").join("MacOS");
+        std::fs::create_dir_all(&macos_dir).unwrap();
+
+        let binary = build_unsigned_binary(&macos_dir, "Test");
+        assert!(!verify_signature(&binary).await, "binary should be unsigned before signing");
+
+        let result = super::sign_extracted_content(&content).await;
+        assert!(result.is_ok(), "sign_extracted_content should succeed");
+
+        assert!(verify_signature(&binary).await, "binary inside .app should be signed");
+        assert!(verify_signature(&app_dir).await, ".app bundle should be signed after its contents");
     }
 }

--- a/website/src/docs/faq.md
+++ b/website/src/docs/faq.md
@@ -11,7 +11,7 @@ macOS requires all executable code to carry a valid <Tooltip term="code signatur
 
 When a publisher never signed their binaries before packaging, the extracted files will be unsigned and macOS will refuse to run them. Signatures that were present before packaging survive the tar round-trip — they are part of the binary content, not extended attributes.
 
-ocx handles this automatically: after extracting a package, it detects <Tooltip term="Mach-O binaries">The native executable format on macOS and iOS. ocx identifies them by reading the first four bytes of each file and checking for known magic numbers (`0xFEEDFACF` for 64-bit, `0xCAFEBABE` for universal, etc.).</Tooltip> and `.app` bundles in the content directory, applies ad-hoc signatures, and strips quarantine flags. No configuration required.
+ocx handles this automatically: after extracting a package, it recursively walks the content directory, detects <Tooltip term="Mach-O binaries">The native executable format on macOS and iOS. ocx identifies them by reading the first four bytes of each file and checking for known magic numbers (`0xFEEDFACF` for 64-bit, `0xCAFEBABE` for universal, etc.).</Tooltip>, signs each one individually, then seals any `.app` and `.framework` bundles — inside-out, so nested content is always signed before its parent. Quarantine flags are stripped. No configuration required.
 
 ::: info Same approach as Homebrew
 [Homebrew][homebrew] solves the identical problem with the same technique — see [`codesign_patched_binary`][homebrew-codesign] in their source. ocx applies the signatures after extraction rather than after patching, but the `codesign` invocation is equivalent.
@@ -19,23 +19,25 @@ ocx handles this automatically: after extracting a package, it detects <Tooltip 
 
 ::: details What ocx runs under the hood
 
-For individual Mach-O binaries:
+For each Mach-O binary found in the content directory (recursive, inside-out):
 
 ```sh
 codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime <binary>
 ```
 
-For `.app` bundles (signs nested frameworks, helpers, and plugins):
+For `.app` and `.framework` bundles (signed after their contents, without `--deep`):
 
 ```sh
-codesign --sign - --force --deep <bundle.app>
+codesign --sign - --force <bundle>
 ```
 
-Quarantine removal (applied to the entire content directory):
+Quarantine removal (applied to the entire content directory before signing):
 
 ```sh
 xattr -dr com.apple.quarantine <content_path>
 ```
+
+Hardlinked files (same inode) are signed only once. Symlinks are not followed.
 :::
 
 ::: tip For package publishers
@@ -59,14 +61,12 @@ If a binary still fails to launch after installation, sign it manually:
 codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime /path/to/binary
 ```
 
-```sh [.app bundle]
-codesign --sign - --force --deep /path/to/App.app
-```
-
 ```sh [Remove quarantine]
 xattr -dr com.apple.quarantine /path/to/content
 ```
 :::
+
+For `.app` bundles, sign each nested Mach-O binary individually (inside-out), then sign the bundle itself without `--deep`.
 
 ::: details Can I disable macOS code signing enforcement entirely?
 macOS enforces code signatures through <Tooltip term="AMFI">Apple Mobile File Integrity — a kernel-level module that validates code signatures independently of Gatekeeper. It cannot be disabled without booting into Recovery Mode, turning off SIP, and setting `amfi_get_out_of_my_way=1`.</Tooltip>, which runs independently of [Gatekeeper][gatekeeper]. Disabling it requires Recovery Mode, disabling [SIP][sip], and setting a boot argument — a configuration Apple does not support that significantly weakens system security.

--- a/website/src/docs/faq.md
+++ b/website/src/docs/faq.md
@@ -11,33 +11,30 @@ macOS requires all executable code to carry a valid <Tooltip term="code signatur
 
 When a publisher never signed their binaries before packaging, the extracted files will be unsigned and macOS will refuse to run them. Signatures that were present before packaging survive the tar round-trip — they are part of the binary content, not extended attributes.
 
-ocx handles this automatically: after extracting a package, it recursively walks the content directory, detects <Tooltip term="Mach-O binaries">The native executable format on macOS and iOS. ocx identifies them by reading the first four bytes of each file and checking for known magic numbers (`0xFEEDFACF` for 64-bit, `0xCAFEBABE` for universal, etc.).</Tooltip>, signs each one individually, then seals any `.app` and `.framework` bundles — inside-out, so nested content is always signed before its parent. Quarantine flags are stripped. No configuration required.
+ocx handles this automatically: after extracting a package, it recursively walks the content directory, detects <Tooltip term="Mach-O binaries">The native executable format on macOS and iOS. ocx identifies them by reading the first four bytes of each file and checking for known magic numbers (`0xFEEDFACF` for 64-bit, `0xCAFEBABE` for universal, etc.).</Tooltip>, and signs each one individually with an ad-hoc signature. Quarantine flags are stripped. No configuration required.
 
 ::: info Same approach as Homebrew
-[Homebrew][homebrew] solves the identical problem with the same technique — see [`codesign_patched_binary`][homebrew-codesign] in their source. ocx applies the signatures after extraction rather than after patching, but the `codesign` invocation is equivalent.
+[Homebrew][homebrew] solves the identical problem with the same technique — per-file ad-hoc signing without bundle sealing — see [`codesign_patched_binary`][homebrew-codesign] in their source. ocx applies signatures after extraction rather than after patching, but the `codesign` invocation is equivalent.
 :::
 
 ::: details What ocx runs under the hood
 
-For each Mach-O binary found in the content directory (recursive, inside-out):
-
-```sh
-codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime <binary>
-```
-
-For `.app` and `.framework` bundles (signed after their contents, without `--deep`):
-
-```sh
-codesign --sign - --force <bundle>
-```
-
-Quarantine removal (applied to the entire content directory before signing):
+Quarantine removal (applied to the entire content directory first):
 
 ```sh
 xattr -dr com.apple.quarantine <content_path>
 ```
 
-Hardlinked files (same inode) are signed only once. Symlinks are not followed.
+For each Mach-O binary found in the content directory (recursive walk, symlinks not followed):
+
+```sh
+codesign --sign - --force --preserve-metadata=entitlements,flags,runtime <binary>
+```
+
+`entitlements`, `flags`, and `runtime` are preserved from the original signature.
+`requirements` (the original certificate's Team ID constraint) is intentionally dropped —
+preserving it would cause dyld "different Team IDs" errors when loading third-party frameworks.
+Hardlinked files (same inode) are signed only once.
 :::
 
 ::: tip For package publishers
@@ -58,15 +55,13 @@ If a binary still fails to launch after installation, sign it manually:
 
 ::: code-group
 ```sh [Single binary]
-codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime /path/to/binary
+codesign --sign - --force --preserve-metadata=entitlements,flags,runtime /path/to/binary
 ```
 
 ```sh [Remove quarantine]
 xattr -dr com.apple.quarantine /path/to/content
 ```
 :::
-
-For `.app` bundles, sign each nested Mach-O binary individually (inside-out), then sign the bundle itself without `--deep`.
 
 ::: details Can I disable macOS code signing enforcement entirely?
 macOS enforces code signatures through <Tooltip term="AMFI">Apple Mobile File Integrity — a kernel-level module that validates code signatures independently of Gatekeeper. It cannot be disabled without booting into Recovery Mode, turning off SIP, and setting `amfi_get_out_of_my_way=1`.</Tooltip>, which runs independently of [Gatekeeper][gatekeeper]. Disabling it requires Recovery Mode, disabling [SIP][sip], and setting a boot argument — a configuration Apple does not support that significantly weakens system security.


### PR DESCRIPTION
## Summary

- Replace deprecated `codesign --deep` (deprecated since macOS 13.0) with recursive inside-out per-binary signing, matching Homebrew's approach
- Add inode-based hardlink deduplication — same physical file is only signed once
- Add retry-with-copy fallback for known Apple `codesign` inode bug (same workaround as Homebrew)
- Symlinks are correctly skipped (not followed, not signed)
- `.app` and `.framework` bundles are sealed after their contents, without `--deep`

## Motivation

`codesign --deep` has poorly-specified ordering guarantees for nested frameworks with symlink structures (e.g. Qt's `Versions/Current → 5` layout). Apple recommends signing each component individually in inside-out order. The new recursive `sign_directory` function enforces this naturally: subdirectories are fully processed before the current directory, so nested `.framework` bundles are sealed before their parent `.app`.

## Changes

**`crates/ocx_lib/src/codesign.rs`**
- Replaced flat `walkdir` + two-pass `collect_sign_targets` with recursive `sign_directory` that enforces inside-out order
- Removed `SignTarget` enum, `sign_app_bundle` (which used `--deep`), and `run_codesign` helper
- Added `is_bundle()` to detect `.app` and `.framework` directories
- Added `file_inode()` for hardlink deduplication via `HashSet<u64>`
- Added `try_codesign()` / `retry_sign_with_copy()` — retry on failure by copying to a new inode (Homebrew's workaround for a known Apple bug)
- Rewrote tests: new coverage for symlink skipping, hardlink dedup, inside-out bundle signing

**`website/src/docs/faq.md`**
- Removed all `--deep` references
- Documented inside-out signing approach and inode dedup