### PR TITLE
Multi-Layer Packages — structural dedup via overlap-free OCI layers

### DIFF
--- a/.claude/artifacts/adr_package_layers.md
+++ b/.claude/artifacts/adr_package_layers.md
@@ -1,0 +1,563 @@
+# ADR: Package Layers
+
+## Metadata
+
+**Status:** Proposed
+**Date:** 2026-03-28
+**Deciders:** mherwig, architect
+**Beads Issue:** ocx-sh/ocx#20
+**Related PRD:** N/A
+**Tech Strategy Alignment:**
+- [x] Decision follows Golden Path in `.claude/rules/tech-strategy.md`
+**Domain Tags:** data | api | infrastructure
+**Supersedes:** N/A
+**Superseded By:** N/A
+
+## Context
+
+OCX currently treats each package as a single OCI layer — one compressed archive containing all files. The OCI manifest's `layers` array always has exactly one entry (enforced at `client.rs:298`). This works well for simple packages but creates inefficiency when multiple packages share common content.
+
+### The problem: redundant storage for shared content
+
+Consider a cross-compilation toolchain like GCC. The headers, specs, and plugin files are identical across all target architectures — only the compiler binary differs per platform. Today, each platform variant stores a complete copy of everything:
+
+```
+gcc:13 (linux/amd64)  →  [headers + specs + plugins + gcc-amd64]   ~200 MB
+gcc:13 (linux/arm64)  →  [headers + specs + plugins + gcc-arm64]   ~200 MB
+gcc:13 (darwin/arm64)  →  [headers + specs + plugins + gcc-darwin]  ~200 MB
+                                                            Total:  ~600 MB
+```
+
+With layers, the shared content is stored once:
+
+```
+layer-gcc-common      →  [headers + specs + plugins]                ~150 MB (stored once)
+layer-gcc-amd64       →  [gcc-amd64]                                ~50 MB
+layer-gcc-arm64       →  [gcc-arm64]                                ~50 MB
+layer-gcc-darwin      →  [gcc-darwin]                                ~50 MB
+                                                            Total:  ~300 MB
+```
+
+This matters at three levels:
+1. **Registry storage** — shared layer digest stored once (OCI dedup is by blob digest)
+2. **Network transfer** — mirrors and consumers download shared layers once
+3. **Local disk** — content-addressed object store stores each layer digest once
+
+### The problem: self-contained applications with shared runtimes
+
+Applications requiring a runtime (Python scripts, Java JARs, .NET assemblies) face a similar issue. Today these must either: (a) bundle the entire runtime in the package (wasteful), (b) declare a dependency on the runtime (evelynn branch — loose coupling via env vars, no structural guarantee), or (c) use a separate packaging step.
+
+Layers offer option (d): the runtime is a shared layer, the application files are another layer, and the package manifest binds them as a single structural unit with integrity guarantees.
+
+### Layers vs. dependencies: structural integrity vs. environment composition
+
+This distinction is fundamental to understanding why both mechanisms are needed:
+
+| Dimension | Dependencies (evelynn) | Layers (this ADR) |
+|-----------|----------------------|-------------------|
+| **Coupling** | Loose — separate packages composed via env vars | Tight — parts of one package merged into one content tree |
+| **Identity** | Each dep has its own OCI identity (digest, tag) | Layers share one package identity (one manifest) |
+| **Filesystem** | Each package in its own `content/` directory | Layers merge into one `content/` directory |
+| **Who controls it** | Publisher declares which other packages are needed | Publisher decides how to partition their own files |
+| **`${installPath}`** | Each dependency resolves independently | Single `${installPath}` for the assembled package |
+| **Integrity** | No structural guarantee — deps may be independently updated | Manifest is the contract — all layers verified together |
+| **Use case** | "My app needs Java 21" | "GCC headers shared across architecture-specific builds" |
+
+Dependencies compose **independent** packages. Layers compose **a single** package from **structurally coupled** parts.
+
+### Layers vs. patches: publisher vs. operator control
+
+Infrastructure patches (sion branch) let operators overlay configuration onto packages. Layers let publishers partition their own package content. These are complementary:
+
+| Dimension | Patches (sion) | Layers (this ADR) |
+|-----------|---------------|-------------------|
+| **Who controls it** | Infrastructure operator | Package publisher |
+| **Registry** | Separate operator-controlled registry | Same registry as the package |
+| **Composition** | Env var overlay (last-writer-wins) | File tree merge (no overlap allowed) |
+| **Coupling** | Zero — operator doesn't modify the package | Total — layers are the package |
+| **Use case** | "All Java installs need our corporate CA certs" | "My package's runtime and app code are separable" |
+
+### Layers vs. variants: internal structure vs. build-time choices
+
+Variants (already on main) encode build-time characteristics in tags (`python:pgo-3.12` vs `python:debug-3.12`). Layers and variants are synergistic — variants that share common content can use shared layers:
+
+```
+python:pgo-3.12    = [layer-cpython-stdlib, layer-cpython-pgo]
+python:debug-3.12  = [layer-cpython-stdlib, layer-cpython-debug]
+```
+
+The stdlib layer (identical across optimization profiles) is stored once.
+
+### How the four composition mechanisms relate
+
+```
+Loose coupling                                              Tight coupling
+├── Patches (sion)      — infra operator overlays env vars onto packages
+├── Dependencies (evelynn) — publisher declares required external packages
+├── Variants (main)     — publisher offers alternative builds (tag selection)
+└── Layers (this ADR)   — publisher partitions internal package structure ──┘
+```
+
+All four are orthogonal and compose: a package can have variants, layers, dependencies, and be patched by an operator simultaneously.
+
+### Scope — what this ADR covers and what it does not
+
+| Concern | Status | Relationship to layers |
+|---------|--------|----------------------|
+| **Multi-layer pull/extract** | This ADR | Download, validate, extract, assemble |
+| **Multi-layer push/create** | This ADR | Partitioning, bundling, publishing |
+| **Layer-level GC** | This ADR | Reference tracking for shared layers |
+| **Dedup optimization tool** | Future work | Analyzes packages to suggest optimal layering |
+| **`zstd:chunked` lazy-pull** | Future work | Cross-layer file-level dedup at the registry |
+| **Dependencies** | Separate ADR (evelynn) | Orthogonal — external package references |
+| **Patches** | Separate ADR (sion) | Orthogonal — operator env overlays |
+| **Variants** | Implemented (main) | Synergistic — shared layers across variants |
+
+## Decision Drivers
+
+- **Storage efficiency**: Shared content across platform variants and package versions should be stored once at the registry, mirror, and local level.
+- **Structural integrity**: A multi-layer package must be self-describing and verifiable — the manifest is the contract for which layers compose the package.
+- **Parallel extraction**: Layers should be downloadable and extractable concurrently for performance.
+- **OCI compatibility**: Must use standard OCI manifest `layers` array with standard media types. Any conformant registry must be able to store and serve these images without modification.
+- **GC correctness**: Layer objects shared across packages must not be garbage collected while any package referencing them is still installed.
+- **Backward compatibility**: Existing single-layer packages must continue to work unchanged.
+- **Simplicity**: Prefer the simplest model that achieves the goals. Avoid OCI complexities (whiteouts, overlayfs) that don't serve binary package distribution.
+
+## Industry Context & Research
+
+**Research artifact:** [research_oci_layers_and_composition.md](./research_oci_layers_and_composition.md)
+
+### Cross-ecosystem survey
+
+| System | Layer model | Overlap handling | Dedup granularity |
+|--------|-----------|-----------------|-------------------|
+| **Docker/OCI** | Sequential changesets with whiteouts | Upper shadows lower (by design) | Whole layer blob |
+| **Nix** | No layers — isolated store paths per derivation | Impossible (unique hash paths) | Store path (package version) |
+| **Flatpak** | OSTree runtimes shared across apps | Separate addressable units | File content hash |
+| **Ollama** | Per-component layers with distinct `mediaType` | No overlap (distinct component types) | Whole layer blob |
+| **Bazel rules_oci** | One layer per build target | No overlap (build system prevents it) | Whole layer blob |
+| **dpkg** | File ownership database | Conflicts/Replaces declarations | N/A |
+| **overlayfs** | Multiple lower dirs, one upper dir | Upper always shadows lower | N/A |
+
+### Key insights
+
+1. **No production system enforces overlap-free layers at the filesystem level.** Enforcement is always at a higher level: build system (Bazel), package metadata (dpkg), or structural naming (Nix). OCX must enforce at the package manager level during extraction.
+
+2. **The Ollama pattern is the closest precedent** for binary package dedup on OCI. Separate layers with distinct `mediaType` annotations, raw content-addressed blobs, no tar wrapping overhead. Registry-level dedup by digest.
+
+3. **OCI whiteouts solve a problem OCX doesn't have.** Whiteouts enable incremental container image builds where each Dockerfile step adds a changeset. Binary packages are not built incrementally — the publisher knows the full content at publish time. Whiteouts add complexity with no benefit.
+
+4. **Tar format nondeterminism is a real concern** (Cyphar's OCIv2 analysis). Identical file content can produce different layer digests depending on `readdir` order. Publishers must use deterministic archiving tools to realize dedup benefits.
+
+5. **Layer-granularity dedup is coarse but sufficient** for the stated use cases (shared headers, shared runtimes). Cross-package file-level dedup (`zstd:chunked`) is a future optimization, not a prerequisite.
+
+**Trending:** `zstd:chunked` layers (containerd support maturing), Nydus/Dragonfly (CNCF incubating).
+**Established:** OCI tar-based layers, Nix store paths, overlayfs.
+**Declining:** eStargz (superseded by `zstd:chunked` and Nydus).
+
+## Considered Options
+
+The three options are as proposed in issue #20, plus a fourth "do nothing" option.
+
+### Option 0: Do Nothing — Single-Layer Only
+
+**Description:** Keep the current `layers.len() == 1` enforcement. Shared content is handled via dependencies (evelynn) or duplicated across packages.
+
+| Pros | Cons |
+|------|------|
+| Zero implementation cost | No storage dedup for shared content across platform variants |
+| No GC complexity increase | Publishers must duplicate headers/runtimes in every package |
+| No extraction complexity | No structural integrity for composite packages |
+| | Dependencies provide env composition but not file tree composition |
+
+### Option 1: Full OCI-Compliant Layers — Sequential Changesets with Whiteouts
+
+**Description:** Layers are applied sequentially, bottom-to-top. Upper layers can shadow files from lower layers using whiteout markers (`.wh.<name>`, `.wh..wh..opq`). This is the standard OCI container image model.
+
+| Pros | Cons |
+|------|------|
+| Full OCI compliance — existing container tooling works | Layers must be applied sequentially, preventing parallel extraction |
+| Images can be incrementally modified by adding layers | Upper layers can shadow lower layers, enabling "untransparent / chaotically crafted packages" |
+| Well-documented spec with extensive ecosystem support | Whiteout handling adds significant extraction complexity |
+| | overlayfs would enable lazy composition but is Linux-only and requires privileges |
+| | Nondeterministic tar ordering can defeat dedup even with identical content |
+| | Solving a container build problem OCX doesn't have |
+
+### Option 2: Overlap-Free Layers — File Structures Merged
+
+**Description:** Layers are independent file trees merged into one content directory. Files (other than directories) must not appear at the same path in two layers. Directories at the same path are merged (union). No whiteouts, no layer ordering dependency for extraction.
+
+```
+layer-gcc-common/            layer-gcc-amd64/
+└── usr/                     └── usr/
+    └── lib/                     └── bin/
+        └── gcc/                     ├── gcc
+            └── 13/                  ├── g++
+                ├── specs            └── cpp
+                └── plugin/
+```
+
+Both layers contribute to `usr/` (directory merge), but no non-directory file exists in both.
+
+| Pros | Cons |
+|------|------|
+| Parallel extraction — no ordering dependency, no whiteouts | Differs from standard OCI layer semantics (no shadowing) |
+| Overlap validation at extraction catches structural errors early | Standard OCI images with shadowing layers are incompatible |
+| Simple mental model for publishers — "partition your files" | Shared directories (e.g., `usr/bin/`) require careful partitioning |
+| Content-addressable dedup at layer granularity | Publishers must ensure non-overlap — tooling should help |
+| Works on all platforms — pure userspace, no overlayfs | More complex GC (layer objects need reference tracking) |
+| OCI-compatible wire format (standard media types, any registry) | |
+| Backward compatible — single-layer packages unchanged | |
+
+### Option 3: Completely Overlap-Free Layers — Disjoint Root Trees
+
+**Description:** Like Option 2 but stricter: layers must differ at the root directory level. No directory merging at all — each layer contributes a unique top-level directory.
+
+```
+layer-gcc-common/            layer-gcc-amd64/
+└── gcc-common/              └── gcc-amd64/
+    └── usr/                     └── usr/
+        └── lib/                     └── bin/
+            └── gcc/                     ├── gcc
+                └── 13/                  └── g++
+                    └── specs
+```
+
+| Pros | Cons |
+|------|------|
+| Layers never interact — each has a unique root | Forces unnatural directory structures |
+| Layers can be hardlinked/symlinked without extraction merging | `${installPath}/bin` can't work — paths depend on which layer a file is in |
+| Simplest validation — just check root dirs are disjoint | Package env vars need per-layer `${installPath}` or layer-specific path variables |
+| | Severely limits package design options |
+| | **Breaks the `${installPath}` contract** — no single content directory to point env vars at |
+| | Even less intuitive than Option 2 for OCI users |
+
+## Decision Outcome
+
+**Chosen Option:** Option 2 — Overlap-free layers with file structure merging
+
+**Rationale:** Option 2 strikes the right balance between dedup efficiency, implementation simplicity, and compatibility with OCX's existing architecture. The key arguments:
+
+1. **Parallel extraction** is a significant performance advantage. OCI's sequential changeset model exists for container build caching, which is irrelevant to binary packages. Removing the ordering dependency lets OCX download and extract all layers concurrently.
+
+2. **No whiteouts** eliminates a class of complexity that serves no purpose in binary distribution. Publishers know their full content at publish time — there's no "delete a file from a previous layer" use case.
+
+3. **Overlap validation** is a feature, not a limitation. It catches publisher mistakes at extraction time rather than producing silently wrong content. If two layers provide the same file, that's a structural error, not a valid composition.
+
+4. **The `${installPath}` contract is preserved.** Option 3 breaks this by requiring layer-specific root directories, which would cascade into env var resolution, `ocx exec`, `ocx env`, and all tooling that relies on a single content path per package. Option 2 maintains one assembled `content/` directory per package — the layer boundary is invisible to consumers.
+
+5. **Standard OCI wire format.** Layers use standard media types and sit in a standard `manifest.layers[]` array. Any OCI registry stores and serves them. The overlap-free constraint is enforced by OCX at extraction time, not encoded in the wire format.
+
+### Nuances: what each option uniquely enables or prevents
+
+| Capability | Option 1 (changesets) | Option 2 (overlap-free) | Option 3 (disjoint roots) |
+|---|---|---|---|
+| Incremental image modification (add a layer to patch) | Yes — add a shadowing layer | No — must republish with modified layer | No — must republish |
+| Parallel layer extraction | No — ordering matters | Yes — no dependencies between layers | Yes — fully independent |
+| Cross-platform portability | No — overlayfs is Linux-only; userspace apply is complex | Yes — pure userspace merge | Yes — pure symlink/hardlink |
+| Standard OCI image consumption | Yes — any OCI image works | Partial — only overlap-free images work | Partial — only disjoint-root images work |
+| Single `${installPath}` per package | Yes | Yes | **No** — breaks env resolution contract |
+| Structural integrity validation | No — shadowing is intentional, can't distinguish error from intent | Yes — overlap = error, caught at extraction | Yes — disjoint roots trivially validated |
+| Shims and tool execution | Works — standard content tree | Works — assembled content tree | **Complicated** — shims would need to know layer structure to find executables |
+| Layer reuse without extraction | No — must apply changesets sequentially | Partial — needs directory merge step | Yes — hardlink/symlink individual layer roots |
+
+### Impact on tool execution and shims
+
+The choice between options has significant implications for `ocx exec` and future shims:
+
+**Options 1 and 2** maintain the contract that `${installPath}` points to a single directory containing all package files. `ocx exec gcc:13 -- gcc -v` resolves `gcc` via `PATH=${installPath}/bin:...` and finds `${installPath}/bin/gcc` in the assembled content tree. Shims (future ADR) would generate launchers that invoke `ocx exec` — they don't need to know about layers because the assembled view is opaque.
+
+**Option 3** breaks this. With disjoint roots, `gcc` lives at `${installPath}/gcc-amd64/usr/bin/gcc` and headers at `${installPath}/gcc-common/usr/lib/gcc/13/specs`. The publisher must declare per-layer env vars or use a complex path template. Shims would need layer-awareness to construct correct `PATH` entries. This cascades into `ocx env`, `ocx shell env`, CI export, and profile management — every path-consuming feature becomes layer-aware.
+
+**Option 2's assembled view keeps layers as a storage optimization invisible to consumers.** This is the right abstraction boundary: publishers think about layers (how to partition files), consumers think about packages (one content dir with env vars).
+
+### Consequences
+
+**Positive:**
+- Registry, mirror, and local storage dedup for shared layers across platform variants and package versions.
+- Parallel download and extraction of layers — bounded only by bandwidth and I/O.
+- Structural integrity: overlap validation catches malformed packages at extraction time.
+- Backward compatible — existing single-layer packages work without changes.
+- Synergy with variants: shared layers across variant builds reduce total storage.
+- Standard OCI wire format: any registry, any mirror, standard tooling for push/pull.
+
+**Negative:**
+- GC becomes more complex — layer objects need reference tracking and cascading collection.
+- Standard OCI images with layer shadowing (whiteouts) are incompatible — OCX will reject them with a clear error. This is by design: OCX packages are a subset of OCI images, not a superset.
+- Publishers must partition files to avoid overlap — tooling should validate and help, but the constraint is non-obvious to someone expecting Docker-style layer behavior.
+- Extraction step now includes a merge/assembly phase, adding I/O overhead for hardlink/symlink creation.
+
+**Risks:**
+- **Deep layer stacks may slow extraction.** Mitigation: practical use cases have 2–5 layers; the overlap validation is O(total files) regardless of layer count.
+- **Hardlink-based assembly may fail on cross-filesystem setups.** Mitigation: fall back to symlinks; if symlinks also fail (unusual), fall back to copy.
+- **Deterministic tar archiving is a publisher responsibility.** Mitigation: document the requirement; `ocx package create` should produce deterministic archives by default.
+- **Shared layer eviction under disk pressure.** Mitigation: GC only collects objects with empty `refs/`; no LRU eviction. Users can `ocx clean` to reclaim unused layers.
+
+## Technical Details
+
+### Architecture
+
+#### Storage model
+
+```
+ObjectStore (content-addressed by digest)
+├── {registry}/{repo}/{layer1-digest}/
+│   ├── content/            ← extracted layer 1 files
+│   ├── metadata.json       ← layer metadata (optional, for standalone layers)
+│   └── refs/               ← back-references from packages using this layer
+│       ├── {hash1}  → ../{pkg-A-digest}/content   ← gcc:13 (linux/amd64) uses this layer
+│       └── {hash2}  → ../{pkg-B-digest}/content   ← gcc:13 (linux/arm64) uses this layer
+│
+├── {registry}/{repo}/{layer2-digest}/
+│   ├── content/            ← extracted layer 2 files (arch-specific)
+│   ├── metadata.json
+│   └── refs/
+│       └── {hash1}  → ../{pkg-A-digest}/content
+│
+├── {registry}/{repo}/{pkg-A-digest}/
+│   ├── content/            ← assembled view (hardlinks/symlinks to layer content)
+│   │   ├── usr/lib/gcc/13/specs    → ../../{layer1-digest}/content/usr/lib/gcc/13/specs
+│   │   └── usr/bin/gcc             → ../../{layer2-digest}/content/usr/bin/gcc
+│   ├── metadata.json       ← package metadata (env vars, dependencies, etc.)
+│   ├── manifest.json       ← OCI manifest (records layer digests and order)
+│   ├── layers/             ← NEW: forward-references to layer objects
+│   │   ├── {hash-of-layer1-content}  → ../../{layer1-digest}/content
+│   │   └── {hash-of-layer2-content}  → ../../{layer2-digest}/content
+│   └── refs/               ← back-references from install symlinks
+│       └── {hash}  → ../../../installs/.../candidates/13
+```
+
+Key design choices:
+- **Layer objects are first-class objects in the store**, stored by their own digest with their own `content/`, `refs/`, and optional `metadata.json`.
+- **Package objects assemble** a merged `content/` view using hardlinks (preferred, same filesystem) or symlinks (cross-filesystem fallback).
+- **`layers/` directory** in the package object holds forward-references to layer objects (analogous to `deps/` in the dependency model on evelynn). This enables GC to discover layer relationships via filesystem traversal.
+- **`refs/` in layer objects** hold back-references from package objects that use the layer. This prevents GC from collecting shared layers while any package uses them.
+- **Single-layer packages** continue to store content directly (no `layers/` directory, no assembly step).
+
+#### Pull and extraction flow
+
+```
+pull_package(manifest):
+    if manifest.layers.len() == 1:
+        # Existing single-layer fast path (unchanged)
+        pull_blob(layer[0].digest) → extract to content/
+
+    else:
+        # Multi-layer path
+        parallel for layer in manifest.layers:
+            if not in_object_store(layer.digest):
+                pull_blob(layer.digest) → extract to layer object content/
+
+        validate_no_overlap(layer_contents)   # fail-fast on file conflicts
+        assemble_merged_view(layer_contents, package_content)
+        create_layer_forward_refs(package → layers)
+        create_layer_back_refs(layers → package)
+```
+
+#### Overlap validation
+
+```
+validate_no_overlap(layers):
+    seen_paths: HashMap<RelativePath, LayerIndex>
+
+    for (i, layer) in layers:
+        for entry in walk_tree(layer.content):
+            if entry.is_directory():
+                continue  # directories merge naturally
+            if let Some(prev) = seen_paths.get(entry.relative_path):
+                error!("Overlap: '{}' exists in layer {} and layer {}", path, prev, i)
+            seen_paths.insert(entry.relative_path, i)
+```
+
+Validation is O(total files across all layers). Directories are allowed to overlap (they merge); non-directory entries (files, symlinks) must be unique.
+
+#### Assembly via hardlinks
+
+```
+assemble_merged_view(layers, target_content):
+    for layer in layers:
+        for entry in walk_tree(layer.content):
+            source = layer.content / entry.relative_path
+            target = target_content / entry.relative_path
+
+            if entry.is_directory():
+                create_dir_all(target)
+            else:
+                hard_link(source, target)  # fallback: symlink, then copy
+```
+
+Hardlinks are preferred because:
+- Zero additional disk space (same inode)
+- No broken-link risk if layer object is accessed directly
+- Atomic — visible immediately after creation
+- Work transparently with all tools (no symlink-aware special cases)
+
+Symlinks are the fallback for cross-filesystem or platform limitations.
+
+### Garbage collection
+
+#### The challenge
+
+With shared layers, GC becomes a graph problem — not just "delete objects with empty `refs/`". A layer object may be referenced by multiple packages. Deleting a package must decrement the layer's ref count, and only collect the layer when no packages reference it.
+
+This is structurally analogous to the dependency GC problem solved on the evelynn branch (Kahn's algorithm on the reverse dependency graph). The same pattern extends naturally to layers.
+
+#### GC model: layers as GC-tracked objects
+
+The GC model uses the same `refs/` + forward-reference pattern as dependencies:
+
+| Ref type | Location | Points to | Created when |
+|----------|----------|-----------|-------------|
+| **Install → Package** | Package's `refs/{hash}` | Install symlink path | `ocx install` |
+| **Package → Layer** (forward) | Package's `layers/{hash}` | Layer's `content/` | Pull/extraction |
+| **Layer → Package** (back-ref) | Layer's `refs/{hash}` | Package's `content/` | Pull/extraction |
+| **Package → Dependency** (forward) | Package's `deps/{hash}` | Dependency's `content/` | Dependency pull (evelynn) |
+| **Dependency → Package** (back-ref) | Dependency's `refs/{hash}` | Package's `content/` | Dependency pull (evelynn) |
+
+GC phase 1 (scan) counts `refs/` entries for each object. GC phase 2 (Kahn's algorithm) processes:
+1. Objects with `ref_count == 0` are enqueued.
+2. For each dequeued object:
+   - Decrement ref counts of its layers (via `layers/` forward-refs).
+   - Decrement ref counts of its dependencies (via `deps/` forward-refs).
+   - If any layer/dependency drops to 0, enqueue it.
+3. All dequeued objects are collected.
+
+This is O(N + E) where N = objects and E = total forward-references (layers + deps).
+
+#### GC edge cases
+
+**Shared layer across packages:** Layer L is used by packages A and B. Uninstalling A removes A's back-ref from L's `refs/`. L still has B's back-ref → not collected. Uninstalling B removes B's back-ref → L's `refs/` is empty → L is collected.
+
+**Shared layer across packages with dependencies:** Package A uses layer L and depends on package D. D also uses layer L (same shared runtime). Uninstalling A removes A's refs from L and D. D still has its own install ref → D stays. L still has D's ref → L stays. When D is eventually uninstalled or its last referrer is removed, the cascade collects both D and L.
+
+**Single-layer packages:** No `layers/` directory → GC treats them as before (only `refs/` and `deps/` matter). Fully backward compatible.
+
+**Package with both layers and dependencies:** The `layers/` and `deps/` forward-reference directories are independent. GC processes both edge types in the same Kahn's pass.
+
+#### Concurrency considerations
+
+Same constraint as dependency GC: `clean` is not safe to run concurrently with `install`. A concurrent install that creates layer back-refs between phase 1 (scan) and phase 2 (delete) could race. The existing best-effort guard (re-check `refs/` before deleting) applies equally to layer objects.
+
+### Package creation flow
+
+```
+ocx package create --layer common/ --layer arch/ -o gcc-13.tar.gz
+```
+
+Each `--layer` argument specifies a directory to archive as a separate layer. The resulting manifest has one entry per layer in `manifest.layers[]`. The config blob stores metadata (env vars, etc.) that applies to the assembled package.
+
+Alternatively, a layer manifest file:
+
+```json
+{
+  "layers": [
+    { "path": "common/", "media_type": "application/vnd.oci.image.layer.v1.tar+zstd" },
+    { "path": "arch/",   "media_type": "application/vnd.oci.image.layer.v1.tar+zstd" }
+  ]
+}
+```
+
+The `media_type` field is optional — OCX infers it from compression. Custom media types are allowed for publishers who want to tag layer roles (e.g., `application/vnd.ocx.layer.runtime.v1.tar+zstd`).
+
+### Manifest structure
+
+Standard OCI image manifest with multiple layers:
+
+```json
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.ocx.package.config.v1+json",
+    "digest": "sha256:abc...",
+    "size": 1234
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
+      "digest": "sha256:layer1...",
+      "size": 150000000,
+      "annotations": {
+        "org.opencontainers.image.title": "gcc-common"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+zstd",
+      "digest": "sha256:layer2...",
+      "size": 50000000,
+      "annotations": {
+        "org.opencontainers.image.title": "gcc-amd64"
+      }
+    }
+  ]
+}
+```
+
+The `annotations.org.opencontainers.image.title` is advisory — it helps publishers identify layers in registry UIs. It has no semantic meaning to OCX.
+
+### Error types
+
+New error variants in `PackageErrorKind`:
+
+```rust
+/// Two layers provide the same non-directory file path.
+LayerOverlap {
+    path: PathBuf,
+    layer_a: oci::Digest,
+    layer_b: oci::Digest,
+},
+
+/// Failed to assemble the merged content view from layers.
+LayerAssemblyFailed {
+    digest: oci::Digest,
+    source: std::io::Error,
+},
+```
+
+### API impact
+
+- `ocx install` — no change in output. Layer download progress shows per-layer bars.
+- `ocx find` — no change. Returns assembled `content/` path.
+- `ocx exec` / `ocx env` — no change. `${installPath}` resolves to assembled `content/`.
+- `ocx clean --dry-run` — shows layer objects that would be collected, with annotation "(shared layer)".
+- `ocx index list` — no change. Layer count is an internal detail.
+- `ocx package create` — new `--layer` flag for multi-layer bundling.
+- `ocx package push` — handles multi-layer manifests, pushes shared layers only once.
+
+## Implementation Plan
+
+1. [ ] **Multi-layer pull** — Relax `layers.len() == 1` validation. Download all layer blobs. Extract each to its own object store entry.
+2. [ ] **Overlap validation** — Walk extracted layer trees, detect non-directory path conflicts.
+3. [ ] **Assembly** — Create merged `content/` view in package object via hardlinks (symlink fallback).
+4. [ ] **Layer reference management** — Add `layers/` forward-refs and layer `refs/` back-refs to `ReferenceManager`.
+5. [ ] **GC extension** — Extend Kahn's algorithm to traverse `layers/` edges alongside `deps/` edges.
+6. [ ] **Multi-layer `package create`** — `--layer` flag for specifying layer directories.
+7. [ ] **Multi-layer `package push`** — Construct multi-layer manifest, push layers, skip already-present digests.
+8. [ ] **Acceptance tests** — Multi-layer install, shared layer dedup, GC correctness, overlap rejection.
+
+## Validation
+
+- [ ] Single-layer packages work unchanged (backward compatibility)
+- [ ] Multi-layer packages extract correctly with assembled content view
+- [ ] Overlap detection rejects conflicting layers
+- [ ] Shared layers stored once in object store
+- [ ] GC correctly cascades: package deletion → layer ref decrement → layer collection when unreferenced
+- [ ] `ocx exec` / `ocx env` work transparently with multi-layer packages
+- [ ] `task verify` passes (fmt, clippy, build, unit tests, acceptance tests)
+
+## Links
+
+- [ocx-sh/ocx#20 — Supporting Layers](https://github.com/ocx-sh/ocx/issues/20)
+- [OCI Image Layer Specification](https://github.com/opencontainers/image-spec/blob/main/layer.md)
+- [OCI Image Manifest Specification](https://github.com/opencontainers/image-spec/blob/main/manifest.md)
+- [Research: OCI Layers and Composition](./research_oci_layers_and_composition.md)
+- [ADR: Package Dependencies](./adr_package_dependencies.md) (evelynn — orthogonal)
+- [ADR: Package Variants](./adr_variants.md) (main — synergistic)
+
+---
+
+## Changelog
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-03-28 | architect | Initial draft |

--- a/.claude/artifacts/research_oci_layers_and_composition.md
+++ b/.claude/artifacts/research_oci_layers_and_composition.md
@@ -1,0 +1,222 @@
+# Research: OCI Layer Spec, Multi-Layer Composition, and Overlap-Free Merging
+
+**Date:** 2026-03-28
+**Context:** Research for ocx-sh/ocx#20 (Supporting Layers)
+
+---
+
+## 1. OCI Layer Specification — Technical Detail
+
+### Two digests per layer
+
+- `manifest.layers[i].digest` = SHA-256 of the **compressed** blob (used for registry fetch and storage dedup)
+- `config.rootfs.diff_ids[i]` = SHA-256 of the **uncompressed** tar = the "DiffID" (canonical content identity, independent of compression)
+
+### Changeset semantics (three entry types)
+
+| Entry | Meaning |
+|-------|---------|
+| Regular tar entry | Add or replace file at that path. Upper layer shadows lower. |
+| `.wh.<name>` (whiteout) | Delete `<name>` from lower layers. Must be an empty file. |
+| `.wh..wh..opq` (opaque whiteout) | Delete all children of the containing directory from lower layers. Applied *before* sibling entries regardless of tar archive ordering. |
+
+Whiteouts MUST only apply to lower/parent layers; they cannot delete files introduced in the same layer.
+
+### Sequential application
+
+Layers applied bottom-up (index 0 first). Later layers shadow earlier layers on path conflicts.
+
+### ChainID — position-sensitive cryptographic identity
+
+```
+ChainID(L0)        = DiffID(L0)
+ChainID(L0|L1)     = SHA256(ChainID(L0) + " " + DiffID(L1))
+ChainID(L0|...|Ln) = SHA256(ChainID(L0|...|Ln-1) + " " + DiffID(Ln))
+```
+
+Binds each layer to its position in the stack. If the runtime has a cached snapshot for ChainID(L0|L1), it can use it regardless of how many images share those bottom layers.
+
+### Deduplication limits
+
+- Dedup granularity = whole layer blob. One changed byte = new layer digest = full re-download.
+- No cross-layer file-level dedup. Identical files in two different layers stored twice.
+- Compression defeats file-level equality: same file content in two different tar archives produces different bytes (different dictionary context).
+
+### Tar format legacy problems (Cyphar's OCIv2 analysis)
+
+Tar entry ordering is nondeterministic (filesystem `readdir` order varies by OS and filesystem), so identical builds on different machines produce different layer digests even with identical file content. OCI inherited AUFS's on-disk tar format from Docker.
+
+---
+
+## 2. Package Manager Composition and Deduplication
+
+### Nix (gold standard for isolation)
+
+- Every package at `/nix/store/<hash>-<name>-<version>/`. Hash covers all build inputs.
+- **Structural non-overlap**: two packages can never share a path — each under unique hash directory. Overlap physically impossible.
+- **Profile composability**: "installed environment" is a symlink tree pointing into the store. No files copied for installation. Composition = additive symlink merging.
+- Runtime dep tracking: scan binaries for embedded store path strings (RPATHs).
+
+### Bazel
+
+- Build actions declare exact inputs; action sandbox contains only declared inputs.
+- Actions cached in CAS keyed by hash of (command + inputs + environment).
+- `rules_oci` maps each Bazel target to one OCI layer. Targets cannot produce same output path — overlap prevented at action graph level.
+
+### npm/pnpm
+
+- npm hoisting: compatible packages promoted to root `node_modules`; conflicting versions nested.
+- pnpm: global content-addressed store at `~/.pnpm-store`; `node_modules` populated with **hard links**. Identical files across all packages stored once at the inode level.
+
+### Cargo
+
+- Source compilation model; feature unification within a single build.
+- `cargo-binstall`: installs pre-built binaries as flat files to `~/.cargo/bin`. No dedup, no overlay.
+
+### apk (Alpine)
+
+- Constraints in `/etc/apk/world`. SAT solver on every transaction. Refuses to commit inconsistent states.
+- File conflict = hard error unless `Replaces:` declared. No content-addressed store.
+
+### dpkg (Debian)
+
+- File ownership database per package (`/var/lib/dpkg/info/*.list`). Every file owned by exactly one package.
+- `Conflicts:` — two packages owning the same path refuse to coexist.
+- `Replaces:` — package A takes ownership of files from package B.
+- `dpkg-divert` — redirect a file to a different path to resolve conflicts without full Replaces.
+
+---
+
+## 3. OCI Artifacts Beyond Containers
+
+### ORAS (OCI Registry as Storage)
+
+- Same structure as OCI images: config descriptor + arbitrary layers array.
+- Layer count arbitrary; `mediaType` (not ordering) communicates what each layer is.
+- OCI v1.1 (Feb 2024): `artifactType` field on manifests; `subject` field for Referrers API.
+- Registry-level dedup: identical blob digests stored once across all artifacts.
+
+### Helm charts
+
+- One layer: entire chart as `application/vnd.cncf.helm.chart.content.v1.tar+gzip`.
+- Optional second layer: provenance file (`.prov`).
+- No inter-chart dedup — chart dependencies bundled inside the single tarball.
+
+### Ollama (LLM model distribution — most relevant binary dedup example)
+
+- Multi-layer manifest: config layer (metadata), weight layer(s) (raw GGUF files), template layer, parameters layer.
+- Blobs stored at `~/.ollama/models/blobs/sha256-<digest>` — raw files, not tar archives.
+- **Cross-model deduplication**: if `llama3:8b` and `llama3:8b-instruct` share a base weight blob, they reference the same digest — stored once.
+- No filesystem overlay — layers accessed directly as files, not extracted into merged directory.
+
+### WASM modules
+
+Typically single layer (raw `.wasm` binary). No established multi-layer composition pattern.
+
+---
+
+## 4. Overlap-Free Layer Merging
+
+### overlayfs kernel semantics
+
+```
+mount -t overlay overlay -o lowerdir=/l3:/l2:/l1,upperdir=/upper,workdir=/work /merged
+```
+
+- Leftmost lower = highest priority. Upper always takes precedence over all lower.
+- File in both upper and lower: upper is visible; lower hidden entirely.
+- Directory in both: merged view; upper entry wins on name conflict.
+- **No enforcement of non-overlap** — overlap is the core mechanism.
+
+### Who enforces overlap-free trees
+
+| System | Mechanism | Level |
+|--------|-----------|-------|
+| Nix | Hash-addressed unique path per derivation | Structural — physically impossible |
+| Bazel + rules_oci | Targets cannot share output paths | Build system |
+| dpkg | File ownership DB + `Conflicts:` + `Replaces:` | Package metadata + install-time check |
+| apk | SAT solver rejects unsatisfiable constraints | Install-time solver |
+| OCI spec | None — later layers shadow earlier | No enforcement |
+| overlayfs | None — upper always shadows lower | No enforcement |
+
+**Conclusion**: no production filesystem-level system rejects layer overlap. Enforcement is always at a higher level.
+
+---
+
+## 5. Technology Landscape
+
+### Trending
+
+| Tool/Pattern | Signal | OCX Relevance |
+|-------------|--------|---------------|
+| `zstd:chunked` layers | containerd support; growing CI adoption | Relevant if OCX packages grow large |
+| Nydus (Dragonfly) | CNCF incubating; production at Alibaba | Future lazy-pull model |
+| ORAS v1.1 + Referrers API | OCI spec ratified Feb 2024; ECR/GHCR support | Already relevant to OCX artifact publishing |
+| pnpm hard-link store | 38k+ GitHub stars | Comparable to OCX content-addressed object store |
+
+### Established
+
+| Tool/Pattern | Status |
+|-------------|--------|
+| OCI tar-based layers | Mature/Standard |
+| Nix isolated store paths | Gold standard for binary isolation |
+| overlayfs | Linux kernel standard |
+| dpkg Conflicts/Replaces | De facto for OS-level package conflict resolution |
+
+### Emerging
+
+| Tool/Pattern | Worth Watching |
+|-------------|----------------|
+| OCIv2 (new image format) | Could replace tar with content-tree format |
+| Ollama-pattern multi-layer binary distribution | Most practical model for multi-component binary dedup on OCI |
+
+### Declining
+
+| Tool/Pattern | Avoid |
+|-------------|-------|
+| eStargz | Superseded by Nydus and `zstd:chunked` |
+
+---
+
+## 6. Design Patterns Worth Considering
+
+- **Per-component `mediaType` layers (Ollama pattern)** — separate layers with distinct `mediaType` annotations enable component-level dedup at the registry without tar overhead.
+- **Profile symlink trees (Nix pattern)** — OCX's `installs/` tree already follows this. Composition = additive symlink union.
+- **Hard-link global content store (pnpm pattern)** — if cross-package file-level dedup becomes priority, hard links from file-hash-keyed global store is the model.
+- **Opaque whiteout for destructive layer transitions** — relevant if OCX ever produces multi-layer artifacts representing upgrades/patches.
+
+---
+
+## Recommendation for OCX
+
+OCX's content-addressed `objects/` store + `installs/` symlink tree is structurally equivalent to the Nix model — the right architecture for binary package management.
+
+**Do not use OCI layers for cross-package file deduplication.** Layer-granularity dedup is too coarse. The right dedup unit is the whole package version (one digest = one object directory), which OCX already implements.
+
+**If per-component layers are needed** (binary + large data asset + shared runtime), adopt the Ollama pattern: separate layers with `mediaType` annotations, raw content-addressed blobs, no tar wrapping.
+
+**For overlap detection**, implement at the OCX metadata layer — a file-ownership database similar to dpkg. Do not rely on overlayfs or OCI layer semantics.
+
+**Watch `zstd:chunked`** — first path to cross-package file-level dedup at the registry level.
+
+---
+
+## Sources
+
+| Source | Type | Date |
+|--------|------|------|
+| [OCI Layer Spec](https://specs.opencontainers.org/image-spec/layer/) | Spec | Maintained |
+| [OCI Image Config](https://github.com/opencontainers/image-spec/blob/main/config.md) | Spec | Maintained |
+| [The Road to OCIv2 — Cyphar](https://www.cyphar.com/blog/post/20190121-ociv2-images-i-tar) | Blog | Jan 2019 |
+| [OCIv2 Brainstorm — HackMD](https://hackmd.io/@cyphar/ociv2-brainstorm) | Design | 2019+ |
+| [ORAS Concepts: Artifact](https://oras.land/docs/concepts/artifact/) | Docs | 2024 |
+| [Helm OCI MediaTypes](https://helm.sh/blog/helm-oci-mediatypes/) | Blog | 2021 |
+| [Ollama Model Registry — DeepWiki](https://deepwiki.com/ollama/ollama/4.2-model-registry-and-layers) | Analysis | 2024 |
+| [Linux Kernel overlayfs](https://docs.kernel.org/filesystems/overlayfs.html) | Docs | Maintained |
+| [Nix Store Path Spec](https://nix.dev/manual/nix/2.22/protocols/store-path) | Spec | Maintained |
+| [Debian Policy: Relationships](https://www.debian.org/doc/debian-policy/ch-relationships.html) | Spec | Maintained |
+| [npm dedupe docs](https://docs.npmjs.com/cli/v11/commands/npm-dedupe/) | Docs | 2024 |
+| [What Package Registries Could Borrow from OCI](https://nesbitt.io/2026/02/18/what-package-registries-could-borrow-from-oci.html) | Blog | Feb 2026 |
+| [Building Container Layers from Scratch — Depot](https://depot.dev/blog/building-container-layers-from-scratch) | Blog | 2023 |
+| [Nydus/Dragonfly — CNCF](https://www.cncf.io/blog/2020/10/20/introducing-nydus-dragonfly-container-image-service/) | Blog | 2020 |
+| [Bazel rules_oci](https://github.com/bazel-contrib/rules_oci) | Repo | 2024 |


### PR DESCRIPTION
## Problem

OCX currently enforces exactly one layer per package manifest. When multiple platform variants share common content (headers, specs, plugins, runtimes), that content is duplicated in every variant's archive — redundant at the registry, mirror, and local store level.

**Example: cross-compilation toolchain**

```
gcc:13 (linux/amd64)  →  [headers + specs + plugins + gcc-amd64]   ~200 MB
gcc:13 (linux/arm64)  →  [headers + specs + plugins + gcc-arm64]   ~200 MB
gcc:13 (darwin/arm64)  →  [headers + specs + plugins + gcc-darwin]  ~200 MB
                                                            Total:  ~600 MB
```

With shared layers, the common content is stored once:

```
layer-gcc-common      →  [headers + specs + plugins]                ~150 MB (stored once)
layer-gcc-amd64       →  [gcc-amd64]                                ~50 MB
layer-gcc-arm64       →  [gcc-arm64]                                ~50 MB
layer-gcc-darwin      →  [gcc-darwin]                                ~50 MB
                                                            Total:  ~300 MB
```

## Proposed Solution

**Overlap-free layers** — layers are independent file trees merged into one content directory. Non-directory files must not appear at the same path in two layers. Directories at the same path merge naturally. No whiteouts, no sequential ordering dependency.

**Key design decisions:**

- **Not full OCI changeset semantics** — whiteouts and layer shadowing solve container build caching problems that don't exist for binary packages. Removing them enables parallel extraction and catches structural errors early.
- **Overlap validation at extraction** — if two layers provide the same file, that's a publisher error, not a valid composition. Fail-fast with a clear error message.
- **Assembled content view via hardlinks** — the package's `content/` directory contains hardlinks to layer object files. `${installPath}` resolves to this assembled directory — layers are invisible to consumers (`ocx exec`, `ocx env`, shims all work unchanged).
- **Layers are first-class objects** in the content-addressed store, with their own `refs/` back-references. Shared layers are stored once; GC uses Kahn's algorithm (same pattern as dependency GC) to cascade-collect unreferenced layers.
- **Standard OCI wire format** — layers sit in `manifest.layers[]` with standard media types. Any conformant registry stores and serves them without modification.
- **Backward compatible** — single-layer packages work exactly as before.

## How this relates to other features

| Feature | What it composes | Coupling | Relationship |
|---------|-----------------|----------|-------------|
| **Dependencies** (#20, evelynn) | Independent packages via env vars | Loose | Orthogonal — a package can have layers AND dependencies |
| **Variants** (main) | Alternative builds via tag selection | None | Synergistic — shared layers across variant builds |
| **Patches** (#21, sion) | Infra config via operator-controlled registry | Loose | Orthogonal — patches overlay env vars onto assembled packages |
| **Layers** (this PR) | Internal package structure via file tree merge | Tight | Publisher partitions files for storage efficiency |

## Example

```sh
# Publisher creates a multi-layer package
ocx package create --layer common/ --layer arch-amd64/ -o gcc-13-amd64.tar.gz

# Consumer installs — layers downloaded in parallel, assembled transparently
ocx install gcc:13
ocx exec gcc:13 -- gcc -v   # works — ${installPath}/bin/gcc in assembled content
```

## What's in this PR

Design artifacts only (no implementation code):

- `.claude/artifacts/adr_package_layers.md` — full ADR with options analysis, GC model, storage layout, and implementation plan
- `.claude/artifacts/research_oci_layers_and_composition.md` — research into OCI layer spec, Nix/Docker/Bazel/Ollama composition models, and overlap-free merging patterns

Ref: ocx-sh/ocx#20