### PR TITLE
feat(package)!: multi-layer package push and pull

### DIFF
--- a/.claude/artifacts/plan_multi_layer_packages.md
+++ b/.claude/artifacts/plan_multi_layer_packages.md
@@ -1,0 +1,630 @@
+# Plan: Multi-Layer Packages (Issue #20)
+
+<!--
+Implementation Plan
+Filename: artifacts/plan_multi_layer_packages.md
+Owner: Builder (/builder)
+Handoff to: Builder (/builder), QA Engineer (/qa-engineer)
+Related Skills: builder, qa-engineer, architect
+-->
+
+## Overview
+
+**Status:** Implemented (with post-review revision: positional `Vec<LayerRef>`, no `--layer` flag, no backward compat for `content`, user guide documentation added)
+**Author:** Claude (swarm-plan)
+**Date:** 2026-04-12
+**Scope:** Medium (1-2 weeks) | One-Way Door (Medium)
+**GitHub Issue:** ocx-sh/ocx#20 (Supporting Layers)
+**Related PR:** ocx-sh/ocx#22 (Multi-Layer Packages design)
+**Related ADR:** [adr_three_tier_cas_storage.md](./adr_three_tier_cas_storage.md)
+**Depends on:** [plan_multi_layer_assembly.md](./plan_multi_layer_assembly.md) (completed)
+
+## Objective
+
+Complete multi-layer package support across the full lifecycle: push (create + publish multi-layer packages to registries) and pull (install packages with multiple layers). The core assembly walker is already implemented; this plan covers the remaining pipeline-level integration, CLI refactoring, and mirror adaptation.
+
+## Scope
+
+### In Scope
+
+- **Pull-side**: Remove the `manifest.layers.len() > 1` guard in `pull.rs` and switch to multi-layer assembly
+- **`LayerRef` type**: New enum representing a layer as either a file path (upload) or an OCI digest (reuse existing), living in the `publisher` module
+- **Publisher refactoring**: `push_package` (and its internal `push_image_manifest` helper) refactored to accept `&[LayerRef]`, uploads new layers, verifies digest-referenced layers exist
+- **CLI `package push`**: Accept multiple layers via `--layer` flag(s), each parsed as `LayerRef`
+- **Mirror adaptation**: Update mirror pipeline to use the new Publisher API (single-layer backward compat)
+- **Acceptance tests**: Multi-layer push + pull round-trip, layer reuse via digest, overlap detection
+
+### Out of Scope
+
+- **Mirror multi-layer config**: Defining multiple layers in mirror YAML specs (future enhancement)
+- **Layer optimization tool**: Automated dedup analysis across package variants (mentioned in issue #20 "further notes")
+- **Layer shadowing / whiteouts**: Only overlap-free layers; OCI changeset semantics remain unsupported
+- **`package create` changes**: `package create` continues to bundle a single directory into one archive; multi-layer assembly happens at push time
+- **Dependency cross-layer ordering**: Layer ordering within a package is manifest-order; cross-package dependencies are orthogonal
+
+## Research
+
+**Research artifact:** [research_oci_layers_and_composition.md](./research_oci_layers_and_composition.md) (from PR #22), [research_content_addressed_storage.md](./research_content_addressed_storage.md) (from ADR)
+
+**Key findings from prior research:**
+- Per-file symlinks break `@loader_path`/`$ORIGIN` resolution; hardlinks are safe and established (pnpm, uv pattern)
+- Non-overlapping subtree constraint balances dedup power with assembly correctness
+- OCI wire format natively supports multi-layer manifests; no registry changes needed
+- Existing `assemble_from_layers` walker is fully tested (41 tests, 10 categories)
+
+**Push-side design insight:** ZIP/tar creation is non-deterministic (timestamps, compression entropy). If a user re-bundles the same content, they get a different digest. By allowing `LayerRef::Digest`, users can reference an already-uploaded layer by its stable OCI digest, avoiding re-upload and preserving dedup. This is the key enabler for the layer reuse workflow described in issue #20.
+
+**OCI blob media types:** OCI distribution does not store media types per blob — the `Content-Type` on a blob HEAD is always `application/octet-stream`. Media types are manifest-descriptor metadata only. For `LayerRef::Digest`, we cannot derive the original media type from the blob. OCX's archive extraction already detects format from magic bytes, so the manifest media type is informational, not functional. We will use a standard fallback for digest-referenced layers.
+
+## Technical Approach
+
+### Architecture Changes
+
+```
+BEFORE (single-layer only):
+
+  CLI: ocx package push ID FILE -p platform
+    → Publisher::push(info, &Path)
+      → client.push_image_manifest(info, file)  [one layer descriptor]
+        → client.update_image_index(...)
+
+  Pull: setup_impl()
+    → extract_layers()     [N=1 enforced by guard]
+    → assemble_from_layer(single_layer, dest)
+
+AFTER (multi-layer):
+
+  CLI: ocx package push ID --layer REF1 --layer REF2 -p platform
+    → Publisher::push(info, &[LayerRef])
+      → client.push_multi_layer_manifest(info, &[LayerRef])
+        → for each LayerRef::File: upload blob, create descriptor
+        → for each LayerRef::Digest: HEAD to verify + get size, create descriptor
+        → build manifest with N layer descriptors
+        → client.update_image_index(...)
+
+  Pull: setup_impl()
+    → extract_layers()     [N≥1, parallel, already implemented]
+    → assemble_from_layers(&[all_layer_contents], dest)  [already implemented]
+```
+
+### Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `LayerRef` enum with `File`/`Digest` variants | The user specified layers should be "either a path to file or a digest like the OCI digest." This maps directly to the existing `oci::Digest` type. Digest-referenced layers avoid re-upload and enable layer reuse. |
+| `--layer` repeatable flag (not positional) | Clap makes repeatable flags ergonomic (`Vec<LayerRef>`). Keeps the identifier as the only positional arg. Clear intent: `--layer sha256:abc --layer ./file.tar.xz`. |
+| Backward-compatible `content` positional as sugar | Keep `content` positional as optional — if provided without `--layer`, treated as `LayerRef::File(content)`. Existing scripts keep working. Mutex: `content` and `--layer` cannot both be specified. |
+| HEAD for digest verification before manifest creation | Before creating the manifest, HEAD each `LayerRef::Digest` blob to verify it exists in the registry and retrieve its `Content-Length`. Fail fast with a clear error if a referenced layer is missing. |
+| Standard media type fallback for digest layers | Use `application/vnd.oci.image.layer.v1.tar+gzip` for digest-referenced layers. OCX's pull-side extracts by magic bytes, not media type. This is informational only. |
+| Two workstreams (pull + push) in parallel | Pull-side is a 3-line change plus tests. Push-side is a larger refactoring. They are independent and can be developed and tested in parallel. |
+| Mirror gets single-layer wrapper, not multi-layer config | Mirror adaptation wraps the existing single bundle path in `vec![LayerRef::File(path)]`. Multi-layer mirror config is a separate future enhancement. |
+
+## Component Contracts
+
+### `LayerRef` (`crates/ocx_lib/src/publisher/layer_ref.rs`)
+
+```rust
+/// A reference to a layer in a multi-layer package.
+///
+/// Layers are ordered: index 0 is the base layer, index N is the top layer.
+/// With overlap-free semantics, order doesn't affect the assembled result,
+/// but it determines error messages and manifest descriptor order.
+#[derive(Debug, Clone)]
+pub enum LayerRef {
+    /// An archive file to upload as a new layer.
+    File(PathBuf),
+    /// An existing layer already present in the registry, referenced by digest.
+    /// The layer blob must exist in the target registry — verified before
+    /// manifest creation via a HEAD request.
+    Digest(oci::Digest),
+}
+```
+
+**Parsing from CLI string (`FromStr` / `TryFrom<&str>`):**
+- Calls `oci::Digest::try_from(s)`. If it returns `Ok(digest)`, produce `LayerRef::Digest(digest)`.
+- If `Digest::try_from` returns `Err(DigestError::Invalid(_))` — regardless of whether the prefix looked like an algorithm — treat the entire string as a file path → `LayerRef::File(PathBuf::from(s))`.
+- This means `"sha256:tooshort"` (valid algorithm prefix but invalid hex length) becomes `LayerRef::File("sha256:tooshort")`, not an error. File existence is validated at execution time, not parse time.
+
+**Display:** `LayerRef::File(p)` displays as the path; `LayerRef::Digest(d)` displays as the digest string.
+
+### `Publisher::push` (refactored)
+
+```rust
+/// Push a package with one or more layers to the registry.
+///
+/// Each `LayerRef::File` is uploaded as a new blob. Each `LayerRef::Digest`
+/// is verified to exist via HEAD. The manifest contains one descriptor per
+/// layer in the order provided.
+pub async fn push(&self, info: Info, layers: &[LayerRef]) -> Result<()>
+
+/// Push a package with cascade tag management.
+pub async fn push_cascade(&self, info: Info, layers: &[LayerRef], existing_versions: BTreeSet<Version>) -> Result<()>
+```
+
+**Error cases:**
+- Empty `layers` slice → error (package must have at least one layer)
+- `LayerRef::File` path doesn't exist → IO error
+- `LayerRef::File` unsupported archive format → `ClientError::InvalidManifest`
+- `LayerRef::Digest` blob not found in registry → `ClientError::BlobNotFound` (new variant)
+- Registry push failure → existing `ClientError` variants
+
+### `Client::push_multi_layer_manifest` (new internal method)
+
+```rust
+/// Pushes config blob + N layer blobs + image manifest.
+///
+/// For `LayerRef::File` layers: reads file, computes digest, uploads blob.
+/// For `LayerRef::Digest` layers: HEADs blob to verify existence and get size.
+/// Returns the manifest, its serialized bytes, and its SHA-256 digest string.
+pub(crate) async fn push_multi_layer_manifest(
+    &self,
+    package_info: &Info,
+    layers: &[LayerRef],
+) -> std::result::Result<(oci::ImageManifest, Vec<u8>, String), ClientError>
+```
+
+**Layer descriptor construction:**
+- `LayerRef::File(path)`: `media_type` from `media_type_from_path(path)`, `digest` from SHA-256 of file content, `size` from file length (as `u64`)
+- `LayerRef::Digest(d)`: `media_type` = `MEDIA_TYPE_LAYER_TAR_GZIP` (standard fallback — see deferred finding D1 below), `digest` = `d.to_string()`, `size` from HEAD `Content-Length` (as `u64`)
+
+### `Client::head_blob` (new method)
+
+```rust
+/// HEAD a blob by digest to verify existence and retrieve size.
+///
+/// Returns `(content_length, content_type)` if the blob exists.
+/// Returns `Err(ClientError::BlobNotFound)` if the blob does not exist.
+pub(crate) async fn head_blob(
+    &self,
+    identifier: &oci::Identifier,
+    digest: &oci::Digest,
+) -> std::result::Result<BlobHead, ClientError>
+
+pub(crate) struct BlobHead {
+    pub size: u64,
+}
+```
+
+### CLI `PackagePush` (refactored)
+
+```rust
+#[derive(Parser)]
+#[clap(group = clap::ArgGroup::new("layer_input").required(true))]
+pub struct PackagePush {
+    #[clap(long = "cascade", short = 'c')]
+    cascade: bool,
+
+    #[clap(long = "new", short = 'n')]
+    new: bool,
+
+    #[clap(short, long)]
+    metadata: Option<std::path::PathBuf>,
+
+    #[clap(short, long, required = true)]
+    platform: oci::Platform,
+
+    identifier: options::Identifier,
+
+    /// Archive file to push as a single layer (backward-compatible shorthand).
+    /// Mutually exclusive with --layer.
+    #[clap(group = "layer_input")]
+    content: Option<std::path::PathBuf>,
+
+    /// Layer reference: file path or OCI digest (sha256:...).
+    /// Can be repeated for multi-layer packages. Order is preserved.
+    /// Mutually exclusive with positional content argument.
+    #[clap(long = "layer", group = "layer_input")]
+    layers: Vec<String>,
+}
+```
+
+**Behavior:**
+- If `content` is provided: `vec![LayerRef::File(content)]`
+- If `layers` is provided: parse each string → `Vec<LayerRef>`
+- Neither provided: clap `ArgGroup("layer_input").required(true)` rejects with clear error message
+- Both provided: clap `ArgGroup` enforces mutual exclusion
+
+### Pull pipeline changes (`pull.rs`)
+
+```rust
+// REMOVE: lines 272-277 (multi-layer guard)
+
+// REPLACE: lines 318-326 (single-layer assembly)
+// FROM:
+let layer_content = fs.layers.content(pinned.registry(), &layer_digests[0]);
+crate::utility::fs::assemble_from_layer(&layer_content, &pkg.content()).await...
+
+// TO:
+let layer_contents: Vec<PathBuf> = layer_digests.iter()
+    .map(|d| fs.layers.content(pinned.registry(), d))
+    .collect();
+let sources: Vec<&Path> = layer_contents.iter().map(AsRef::as_ref).collect();
+crate::utility::fs::assemble_from_layers(&sources, &pkg.content()).await...
+```
+
+### Mirror pipeline changes
+
+```rust
+// push.rs: push_and_cascade — change Publisher::push signature
+// Before: publisher.push(info, bundle_path).await?;
+// After:  publisher.push(info, &[LayerRef::File(bundle_path.to_path_buf())]).await?;
+
+// Same for push_cascade:
+// Before: publisher.push_cascade(info, bundle_path, versions).await?;
+// After:  publisher.push_cascade(info, &[LayerRef::File(bundle_path.to_path_buf())], versions).await?;
+```
+
+### Cascade module changes
+
+```rust
+// cascade.rs: push_with_cascade — pass through layers
+// Before: pub async fn push_with_cascade(client, info, file, versions, version)
+// After:  pub async fn push_with_cascade(client, info, layers: &[LayerRef], versions, version)
+```
+
+## Implementation Steps
+
+> **Contract-First TDD**: Stub -> Verify -> Specify -> Implement -> Review.
+
+## Execution Model
+
+Follows the **Swarm Workflow** from [workflow-feature.md](../../.claude/rules/workflow-feature.md) with contract-first TDD. Worker assignments per [workflow-swarm.md](../../.claude/rules/workflow-swarm.md). The Review-Fix Loop (Phase C) is the self-introspective loop where reviewer subagents find issues, builder subagents fix them on the fly, and the loop iterates until clean — bounded to 3 rounds max.
+
+The plan has two parallel workstreams that converge in a shared acceptance test phase.
+
+### Workstream A: Pull-Side Multi-Layer Support
+
+**Minimal change — the assembly walker, layer extraction, and refs/layers bookkeeping already handle N layers. The only single-layer assumption left is the guard and the assembly call site.**
+
+#### Phase A1: Implement (no stubs needed)
+
+**Worker:** `worker-builder` (focus: `implementation`)
+
+- [ ] **Step A1.1:** Remove multi-layer guard in `pull.rs`
+  - File: `crates/ocx_lib/src/package_manager/tasks/pull.rs`
+  - Remove the guard block at ~line 272 (`if manifest.layers.len() > 1 { ... }`) and its preceding comment (~lines 265-271)
+  - Note: `extract_layers()` (~line 520) already handles N layers in parallel; `link_layers_in_temp()` (~line 733) already iterates the full `layer_digests` slice. No changes needed in those functions.
+
+- [ ] **Step A1.2:** Switch to multi-layer assembly in `pull.rs`
+  - File: `crates/ocx_lib/src/package_manager/tasks/pull.rs`
+  - Replace the single-layer assembly block (~lines 318-326: the comment and `assemble_from_layer(&layer_digests[0])` call) with multi-layer assembly:
+    ```rust
+    let layer_contents: Vec<PathBuf> = layer_digests.iter()
+        .map(|d| fs.layers.content(pinned.registry(), d))
+        .collect();
+    let sources: Vec<&Path> = layer_contents.iter().map(AsRef::as_ref).collect();
+    crate::utility::fs::assemble_from_layers(&sources, &pkg.content())
+        .await
+        .map_err(PackageErrorKind::Internal)?;
+    ```
+
+**Gate:** `cargo check` passes. Existing tests pass (`task rust:verify`).
+
+#### Phase A2: Specify (acceptance tests for multi-layer pull)
+
+**Worker:** `worker-tester` (focus: `specification`)
+
+Tests in `test/tests/test_install.py` (or new `test_multi_layer.py`).
+
+| Test | Invariant |
+|------|-----------|
+| `test_install_multi_layer_package` | Push a 2-layer package to local registry, install it, verify both layers' files present in content dir |
+| `test_install_multi_layer_shared_directory` | Push a 2-layer package where layers share a directory (e.g., `bin/`), install, verify merged content |
+| `test_install_multi_layer_overlap_fails` | Push a 2-layer package with overlapping files, install fails with clear error |
+| `test_install_single_layer_still_works` | Existing single-layer install is unaffected (regression) |
+| `test_exec_multi_layer_package` | Push 2-layer package, exec a binary from layer B that loads a library from layer A |
+
+**Note:** These tests require the push-side to be implemented first (Workstream B), OR they can use a pre-built multi-layer OCI artifact pushed directly via `oras` or the OCI client. The simpler approach is to make these tests depend on Workstream B completion and test the full round-trip.
+
+**Gate:** Tests compile and are skipped/marked pending until push-side is ready.
+
+### Workstream B: Push-Side Multi-Layer Support
+
+#### Phase B1: Stub
+
+**Worker:** `worker-builder` (focus: `stubbing`)
+
+- [ ] **Step B1.1:** Create `LayerRef` type
+  - File: `crates/ocx_lib/src/publisher/layer_ref.rs`
+  - Public API: `LayerRef` enum (File/Digest), `Display`, `FromStr` (for CLI parsing)
+  - Refactor `publisher.rs` into `publisher/mod.rs` + `publisher/layer_ref.rs` (if currently a single file), or add `layer_ref.rs` as a submodule
+  - Re-export `LayerRef` from the `publisher` module
+  - **Rationale:** `LayerRef` is a push-side concept consumed by `Publisher` and `Client`. It has no relationship to the `package` module (metadata, cascade, version). Placing it in `publisher` respects SRP and the existing module boundaries.
+
+- [ ] **Step B1.2:** Add `BlobHead` struct and `head_blob` stub to Client
+  - File: `crates/ocx_lib/src/oci/client.rs`
+  - Public API: `pub(crate) struct BlobHead { pub size: u64 }`, `pub(crate) async fn head_blob(&self, identifier: &oci::Identifier, digest: &oci::Digest) -> Result<BlobHead, ClientError>`
+  - Body: `unimplemented!()`
+
+- [ ] **Step B1.3:** Add `BlobNotFound` variant to `ClientError`
+  - File: `crates/ocx_lib/src/oci/client/error.rs`
+  - Add: `BlobNotFound { registry: String, digest: String }` with appropriate Display
+
+- [ ] **Step B1.4:** Stub `push_multi_layer_manifest` on Client
+  - File: `crates/ocx_lib/src/oci/client.rs`
+  - Public API: `pub(crate) async fn push_multi_layer_manifest(&self, package_info: &Info, layers: &[LayerRef]) -> Result<(oci::ImageManifest, Vec<u8>, String), ClientError>`
+  - Body: `unimplemented!()`
+
+- [ ] **Step B1.5:** Update `Publisher` signatures
+  - File: `crates/ocx_lib/src/publisher.rs`
+  - Change: `push(info, file: &Path)` → `push(info, layers: &[LayerRef])`
+  - Change: `push_cascade(info, file: &Path, versions)` → `push_cascade(info, layers: &[LayerRef], versions)`
+  - Bodies: `unimplemented!()` (temporarily breaks existing callers — fix in B1.6)
+
+- [ ] **Step B1.6:** Update cascade module signature
+  - File: `crates/ocx_lib/src/package/cascade.rs`
+  - Change: `push_with_cascade(client, info, file, versions, version)` → `push_with_cascade(client, info, layers: &[LayerRef], versions, version)`
+  - Body: `unimplemented!()`
+
+- [ ] **Step B1.7:** Update CLI `PackagePush` args
+  - File: `crates/ocx_cli/src/command/package_push.rs`
+  - Change `content: PathBuf` to `content: Option<PathBuf>`, add `layers: Vec<String>` with `conflicts_with`
+  - Stub the layer resolution logic in `execute()`
+
+- [ ] **Step B1.8:** Update Mirror push call sites
+  - File: `crates/ocx_mirror/src/pipeline/push.rs`
+  - Change `publisher.push(info, bundle_path)` → `publisher.push(info, &[LayerRef::File(bundle_path.to_path_buf())])`
+  - Same for `push_cascade` calls
+
+**Gate:** `cargo check` passes (all call sites updated, stubs compile).
+
+#### Phase B2: Architecture Review
+
+**Worker:** `worker-reviewer` (focus: `spec-compliance`, phase: `post-stub`)
+
+Review stubs against this design record. Verify:
+- `LayerRef` enum matches documented contract (File/Digest variants, Display, FromStr)
+- `Publisher` signature changes are backward-compatible (single-layer callers can wrap in slice)
+- `ClientError::BlobNotFound` covers the "digest layer doesn't exist" failure mode
+- CLI args handle mutual exclusion between `content` and `--layer`
+- Mirror call sites correctly wrap bundle path in `LayerRef::File`
+- Cascade module passes layers through without unwrapping
+
+**Gate:** Architecture review passes.
+
+#### Phase B3: Specify
+
+**Worker:** `worker-tester` (focus: `specification`)
+
+##### Unit tests (`crates/ocx_lib/src/publisher/layer_ref.rs`)
+
+| Test | Invariant |
+|------|-----------|
+| `parse_file_path` | `"./archive.tar.xz"` → `LayerRef::File(PathBuf)` |
+| `parse_digest_sha256` | `"sha256:abc..."` (64 hex chars) → `LayerRef::Digest(Digest::Sha256(...))` |
+| `parse_digest_sha512` | `"sha512:def..."` (128 hex chars) → `LayerRef::Digest(Digest::Sha512(...))` |
+| `parse_absolute_path` | `"/tmp/layer.tar.gz"` → `LayerRef::File` |
+| `parse_windows_path` | `#[cfg(windows)]` — `"C:\\layers\\layer.tar.gz"` → `LayerRef::File` |
+| `display_file` | `LayerRef::File` displays as path string |
+| `display_digest` | `LayerRef::Digest` displays as `sha256:abc...` |
+| `parse_invalid_digest_falls_back_to_file` | `"sha256:tooshort"` → `LayerRef::File("sha256:tooshort")` — `Digest::try_from` fails, entire string becomes a path |
+
+##### Unit tests (`crates/ocx_lib/src/oci/client.rs` — push tests)
+
+| Test | Invariant |
+|------|-----------|
+| `push_single_file_layer` | `push_multi_layer_manifest` with `[LayerRef::File]` uploads one blob, creates manifest with one layer descriptor |
+| `push_two_file_layers` | `[File, File]` → two blob uploads, manifest with two layer descriptors in order |
+| `push_digest_layer_verified` | `[Digest]` → HEAD request verifies blob, manifest uses provided digest |
+| `push_mixed_file_and_digest` | `[File, Digest, File]` → upload 2, HEAD 1, manifest has 3 descriptors in order |
+| `push_digest_not_found_fails` | `[Digest]` where HEAD returns 404 → `BlobNotFound` error |
+| `push_empty_layers_fails` | `&[]` → error |
+
+##### Acceptance tests (`test/tests/test_multi_layer.py`)
+
+| Test | Invariant |
+|------|-----------|
+| `test_push_multi_layer_files` | Push 2-layer package from files, verify manifest has 2 layer descriptors |
+| `test_push_single_layer_backward_compat` | Push single file via positional `content` arg — existing syntax works |
+| `test_push_layer_flag_single` | `--layer file.tar.xz` works for single layer |
+| `test_push_digest_layer_reuse` | Push layer A as part of pkg v1, then push pkg v2 with `--layer sha256:{A}` + `--layer file_B.tar.xz` |
+| `test_push_digest_layer_not_found` | `--layer sha256:nonexistent` fails with clear error |
+| `test_push_content_and_layer_conflict` | `ocx package push ... content.tar.xz --layer x.tar.xz` fails (mutual exclusion) |
+| `test_push_no_layer_fails` | `ocx package push ID -p linux/amd64` (no content, no --layer) fails with "one of 'content' or '--layer' required" |
+| `test_round_trip_multi_layer` | Push 2-layer package, install it, verify all files from both layers present |
+| `test_round_trip_shared_directory` | Push 2-layer package with shared `bin/`, install, verify merged content |
+| `test_round_trip_layer_overlap_fails` | Push 2-layer package with overlapping files, install fails with overlap error |
+| `test_cascade_multi_layer` | Push 2-layer package with `--cascade`, verify rolling tags exist |
+| `test_layer_dedup_across_packages` | Push pkg A with layers [X, Y], push pkg B with layers [X, Z] (X by digest). Verify local store has one copy of layer X |
+
+**Gate:** Tests compile/parse and fail against stubs.
+
+#### Phase B4: OCI Transport — `head_blob` support
+
+**Prerequisite for B5 (implement).** `push_multi_layer_manifest` calls `head_blob` for digest-referenced layers, so the transport layer must be in place first.
+
+The `OciTransport` trait (`crates/ocx_lib/src/oci/client/transport.rs`) may need a new `head_blob` method. If the trait doesn't already support HEAD requests:
+
+- [ ] **Step B4.1:** Add `head_blob` to `OciTransport` trait
+  - File: `crates/ocx_lib/src/oci/client/transport.rs`
+  - Add: `async fn head_blob(&self, image: &Reference, digest: &str) -> Result<BlobHead, ClientError>`
+
+- [ ] **Step B4.2:** Implement in `NativeTransport`
+  - File: `crates/ocx_lib/src/oci/client/native_transport.rs`
+  - Use `oci_client` HEAD blob API or raw HTTP HEAD
+
+- [ ] **Step B4.3:** Implement in `TestTransport`
+  - File: `crates/ocx_lib/src/oci/client/test_transport.rs`
+  - Mock HEAD responses for unit testing
+
+**Gate:** `cargo check` passes.
+
+#### Phase B5: Implement
+
+**Worker:** `worker-builder` (focus: `implementation`)
+
+- [ ] **Step B5.1:** Implement `LayerRef` with `FromStr` and `Display`
+  - File: `crates/ocx_lib/src/publisher/layer_ref.rs`
+  - Parse logic: try `oci::Digest::try_from(s)` first; on any `DigestError::Invalid`, treat as file path
+
+- [ ] **Step B5.2:** Implement `head_blob` on Client
+  - File: `crates/ocx_lib/src/oci/client.rs`
+  - Delegate to transport layer: HEAD request on `/v2/{repo}/blobs/{digest}`
+  - Parse `Content-Length` header for size (as `u64`)
+  - Map 404 → `BlobNotFound`, other errors → existing error variants
+
+- [ ] **Step B5.3:** Implement `push_multi_layer_manifest` and refactor `push_package`
+  - File: `crates/ocx_lib/src/oci/client.rs`
+  - Refactor: `push_package(info: Info, file: impl AsRef<Path>)` → `push_package(info: Info, layers: &[LayerRef])`
+  - The internal `push_image_manifest` helper is replaced by `push_multi_layer_manifest`:
+    - For each `LayerRef::File`: read file, compute SHA-256, upload blob with progress, build descriptor
+    - For each `LayerRef::Digest`: call `head_blob`, build descriptor with size from HEAD and fallback media type
+    - Build manifest with all layer descriptors in order
+    - Push config blob + manifest (same pattern as current `push_image_manifest`)
+  - `push_package` then calls `push_multi_layer_manifest` + `update_image_index` (same flow as before)
+  - Progress reporting: each `LayerRef::File` gets its own progress span (loop over file layers)
+  - **Note:** Add a code comment at the media type fallback site documenting the assumption that OCX extracts by magic bytes, not media type. If OCX ever adds media-type-based routing, this becomes a latent bug.
+
+- [ ] **Step B5.4:** Implement updated `Publisher` methods
+  - File: `crates/ocx_lib/src/publisher.rs`
+  - `push(info, layers)` → delegates to `client.push_package(info, layers)` (refactored to accept `&[LayerRef]`), which internally calls `push_multi_layer_manifest` then `update_image_index`
+  - `push_cascade(info, layers, versions)` → same pattern as before but passing layers through
+
+- [ ] **Step B5.5:** Implement cascade passthrough
+  - File: `crates/ocx_lib/src/package/cascade.rs`
+  - `push_with_cascade` passes `layers` to `client.push_multi_layer_manifest` instead of single file
+
+- [ ] **Step B5.6:** Implement CLI layer resolution
+  - File: `crates/ocx_cli/src/command/package_push.rs`
+  - Resolve `content` / `layers` into `Vec<LayerRef>` per `ArgGroup` contract:
+    - If `content` present: `vec![LayerRef::File(content)]`
+    - If `layers` present: parse each string via `LayerRef::from_str`
+    - Neither: clap rejects (ArgGroup required)
+  - Validate file-type layers exist on disk before calling publisher
+
+- [ ] **Step B5.7:** Update mirror push call sites (already done in B1.8, verify they compile)
+  - File: `crates/ocx_mirror/src/pipeline/push.rs`
+
+**Gate:** All unit tests and acceptance tests pass. `task verify` succeeds.
+
+### Phase C: Convergence (Review-Fix Loop)
+
+Per [workflow-feature.md](../../.claude/rules/workflow-feature.md) steps 9-11 and [workflow-swarm.md](../../.claude/rules/workflow-swarm.md) review protocol.
+
+**Diff-scoped, bounded iterative review (max 3 rounds).** During the loop, run `task rust:verify` (subsystem gate for Rust changes) — NOT full `task verify`. Full `task verify` is the final gate before commit.
+
+**Round 1 — all perspectives (parallel):**
+- `worker-reviewer` (focus: `spec-compliance`, phase: `post-implementation`) — design record <-> tests <-> implementation traceability
+- `worker-reviewer` (focus: `quality`) — code review checklist per [quality-core.md](../../.claude/rules/quality-core.md) and [quality-rust.md](../../.claude/rules/quality-rust.md)
+- `worker-reviewer` (focus: `security`) — blob verification, digest validation, no path traversal in LayerRef
+
+Each reviewer classifies findings as:
+- **Actionable** — `worker-builder` fixes automatically, then re-runs affected perspectives in Round 2
+- **Deferred** — needs human judgment, surfaced in commit summary
+
+**Round 2+ (selective):** Re-run only perspectives that had actionable findings. Loop exits when no actionable findings remain or after 3 rounds total.
+
+**Cross-model adversarial pass** (per workflow-feature.md step 10): After the loop converges, run a single Codex adversarial review against the full diff. Actionable findings fold into one final `worker-builder` pass. Deferred findings go to the completion summary. One-shot — no looping. Skipped gracefully if Codex is unavailable. Flag: `--no-cross-model` on `/swarm-execute` to opt out.
+
+**Commit** (per workflow-feature.md step 11): All changes committed on feature branch with conventional commit message. Deferred findings from review-fix loop and adversarial pass printed as summary. Human decides when to push.
+
+**Gate:** No actionable findings remain. `task verify` passes on final state. Deferred findings documented.
+
+## Files to Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `crates/ocx_lib/src/publisher/layer_ref.rs` | Create | `LayerRef` enum with `FromStr`, `Display` |
+| `crates/ocx_lib/src/publisher.rs` → `publisher/mod.rs` | Modify | Refactor to module dir, add `pub mod layer_ref;`, re-export `LayerRef` |
+| `crates/ocx_lib/src/oci/client.rs` | Modify | Add `push_multi_layer_manifest`, `head_blob`; retire `push_image_manifest` |
+| `crates/ocx_lib/src/oci/client/error.rs` | Modify | Add `BlobNotFound` variant |
+| `crates/ocx_lib/src/oci/client/transport.rs` | Modify | Add `head_blob` to trait (if not present) |
+| `crates/ocx_lib/src/oci/client/native_transport.rs` | Modify | Implement `head_blob` |
+| `crates/ocx_lib/src/oci/client/test_transport.rs` | Modify | Mock `head_blob` |
+| `crates/ocx_lib/src/publisher.rs` | Modify | Change `push`/`push_cascade` to accept `&[LayerRef]` |
+| `crates/ocx_lib/src/package/cascade.rs` | Modify | Pass layers through `push_with_cascade` |
+| `crates/ocx_lib/src/package_manager/tasks/pull.rs` | Modify | Remove guard, switch to multi-layer assembly |
+| `crates/ocx_cli/src/command/package_push.rs` | Modify | Add `--layer` flag, resolve to `Vec<LayerRef>` |
+| `crates/ocx_mirror/src/pipeline/push.rs` | Modify | Wrap bundle path in `LayerRef::File` |
+| `test/tests/test_multi_layer.py` | Create | Acceptance tests for multi-layer push/pull |
+
+## Dependencies
+
+### Code Dependencies
+
+No new crate dependencies. Uses existing:
+- `oci::Digest` — for `LayerRef::Digest` variant
+- `clap` — `conflicts_with` for mutual exclusion
+- `oci_client` (patched) — may need HEAD blob support in transport
+
+### Transport Layer Dependency
+
+Check whether `oci_client`'s transport already supports HEAD blob requests. If not, this requires a patch to `external/rust-oci-client`. This is the only potential blocker.
+
+## Testing Strategy
+
+> Tests are the executable specification, written from this design record.
+
+### Unit Tests (from component contracts)
+
+| Component | Count | Focus |
+|-----------|-------|-------|
+| `LayerRef` parsing/display | 8 | FromStr, Display, edge cases |
+| `push_multi_layer_manifest` | 6 | File/digest/mixed layers, error paths |
+| `head_blob` | 3 | Found, not found, network error |
+| **Total** | **17** | |
+
+### Acceptance Tests (from user experience)
+
+| Scenario | Count | Focus |
+|----------|-------|-------|
+| Push (file, digest, mixed, backward compat, error) | 7 | CLI layer arg handling |
+| Pull (multi-layer install, shared dirs, overlap) | 3 | Assembly integration |
+| Round-trip (push + pull end-to-end) | 3 | Full lifecycle |
+| Dedup (layer reuse, cascade) | 2 | Storage efficiency |
+| **Total** | **15** | |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `oci_client` doesn't support HEAD blob | Check first; if missing, add to patched fork (small change) |
+| Media type mismatch for digest layers | OCX extracts by magic bytes, not media type. Use standard fallback. Document the convention. |
+| Backward compatibility for `package push` | Keep positional `content` arg as optional, mutual exclusion with `--layer` via clap |
+| Multi-layer overlap errors confuse users | Error message includes layer indices, conflicting path, and guidance to fix |
+| Mirror breaks on Publisher signature change | Mirror adaptation is part of this plan (step B1.8); tested by existing mirror tests |
+| Large multi-layer packages hit progress reporting issues | Each file layer gets its own progress bar (existing pattern); digest layers are instant (HEAD only) |
+
+## Verification
+
+```sh
+cargo nextest run -p ocx_lib layer_ref           # LayerRef unit tests
+cargo nextest run -p ocx_lib push_multi           # Push unit tests
+cargo nextest run -p ocx_lib assemble             # Assembly tests (existing)
+cd test && uv run pytest tests/test_multi_layer.py -v  # Acceptance tests
+task verify                                        # Full quality gate
+```
+
+---
+
+## Dependency Graph
+
+```
+Workstream A (Pull):                    Workstream B (Push):
+  A1: Remove guard + multi-layer          B1: Stubs (LayerRef, Publisher, CLI, Mirror)
+          ↓                                       ↓
+          │                               B2: Architecture review
+          │                                       ↓
+          │                               B3: Specify (unit + acceptance tests)
+          │                                       ↓
+          │                               B4: Transport head_blob (prerequisite for B5)
+          │                                       ↓
+  A2: Pull acceptance tests ←───────── B5: Implement (all components)
+      (depends on push being done)                ↓
+                              ────────── Convergence (Phase C) ──────────
+                                          Review-Fix Loop
+                                          Adversarial Pass
+                                          Commit
+```
+
+**Critical path:** B1 → B2 → B3 → B4 → B5 → C. Workstream A1 is a quick win that can land independently (no push-side dependency). A2 acceptance tests require B5 completion for the full push+pull round-trip.
+
+**GC safety note:** When two packages share a layer via digest reuse, each package creates its own `refs/layers/` forward-ref symlink to the shared layer. Uninstalling one package removes only its forward-ref; GC sweeps the layer only when no forward-refs remain. This is the existing GC mechanism — no changes needed.
+
+## Deferred Findings (require human judgment)
+
+| # | Finding | Why human judgment is needed |
+|---|---------|---------------------------|
+| D1 | **Media type fallback for digest layers** — Using `MEDIA_TYPE_LAYER_TAR_GZIP` for digest-referenced layers is correct given magic-byte extraction. However, third-party OCI tools (cosign, Syft, Harbor GC) may misinterpret layers with incorrect media types. | Policy decision: accept the interop risk or probe blob content. Mitigated by documenting the convention in code comments. |
+| D2 | **SHA-384/512 parsing tests** — Unit tests include non-SHA-256 variants. In practice OCI registries almost universally use SHA-256. | Low-risk either way. Include for completeness or drop to reduce test noise. |
+| D3 | **Progress reporting for multi-layer push** — Each file layer should get its own progress span, but the current single-file code uses one span. Implementation must create per-layer spans. | Noted in step B5.3; implementation detail, not a design decision. |

--- a/.claude/rules/arch-principles.md
+++ b/.claude/rules/arch-principles.md
@@ -139,6 +139,7 @@ These `crates/ocx_lib/src/` modules have no dedicated subsystem rule — they se
 | Parallel directory tree walk with pruning decisions | `utility::fs::{DirWalker, WalkDecision}` | `utility/fs/dir_walker.rs` |
 | Lexical path normalize / containment check (no FS I/O) | `utility::fs::path::{lexical_normalize, escapes_root, validate_symlinks_in_dir}` | `utility/fs/path.rs` |
 | Move a directory (same-filesystem rename, overwrite-safe) | `utility::fs::move_dir` | `utility/fs.rs` |
+| Probe whether a path exists, swallow I/O errors as `false` with debug log | `utility::fs::path_exists_lossy` | `utility/fs.rs` |
 | Hardlink file (dedup layer into package) | `hardlink::create` / `update` | `crates/ocx_lib/src/hardlink.rs` |
 | Create / update / probe a symlink (cross-platform, junction-aware) | `symlink::create` / `update` / `remove` / `is_link` | `crates/ocx_lib/src/symlink.rs` |
 | Assemble a layer's content tree into a package (hardlinks + symlinks) | `utility::fs::assemble_from_layer(s)` | `utility/fs/assemble.rs` |

--- a/.claude/rules/arch-principles.md
+++ b/.claude/rules/arch-principles.md
@@ -93,6 +93,7 @@ Project-wide conventions enforced by the reviewer:
 |------------|------|-----------------|
 | **Type names** | Full descriptive names (`OperatingSystem`, `Architecture`), not abbreviations (`Os`, `Arch`) | Abbreviated type names |
 | **Module structure** | One concept per file, deep nested modules (`platform/operating_system.rs`) — no `mod.rs`, use named module files | Monolithic files, `mod.rs` files |
+| **Internal enum exhaustiveness** | Omit `#[non_exhaustive]` on internal non-error enums so matches stay total across the workspace. The binary is our only consumer — we do not ship a stable library API. Error enums are exempt: they grow routinely and `#[non_exhaustive]` still aids safe expansion. | `#[non_exhaustive]` on a closed internal enum |
 
 ## Where Features Land
 

--- a/.claude/rules/workflow-github.md
+++ b/.claude/rules/workflow-github.md
@@ -7,24 +7,107 @@ paths:
 
 **Never create issues or PRs without user approval.** Pushing triggers CI, which has real cost.
 
-**Tool preference**: Prefer MCP tools `mcp__github__*` for structured, typed access. Fallback: `gh` CLI — still valid when MCP lacks parity (custom JSON projections, label management edge cases) or when a parallel session already uses `gh`.
+## Tooling: MCP first
+
+Prefer `mcp__github__*` MCP tools for structured, typed access. `gh` CLI is a fallback when MCP lacks parity (label admin, org issue-type admin, ad-hoc JSON projections) or when a parallel session already uses `gh`. When `GITHUB_TOKEN` is set in the environment, `gh` uses it and ignores stored credentials — prefix with `env -u GITHUB_TOKEN gh ...` if you need the stored credential's scopes (e.g., `admin:org`).
 
 | Action | MCP tool | `gh` fallback |
 |--------|----------|---------------|
-| Create issue | `mcp__github__issue_write` | `gh issue create` |
+| Create/update issue | `mcp__github__issue_write` (supports `type:`) | `gh issue create/edit` |
 | Read issue | `mcp__github__issue_read` | `gh issue view` |
 | List issues | `mcp__github__list_issues` | `gh issue list` |
+| List org issue types | `mcp__github__list_issue_types` | `gh api /orgs/{org}/issue-types` |
 | Create PR | `mcp__github__create_pull_request` | `gh pr create` |
 | Read PR | `mcp__github__pull_request_read` | `gh pr view` |
 | List PRs | `mcp__github__list_pull_requests` | `gh pr list` |
 | PR review | `mcp__github__pull_request_review_write` | `gh pr review` |
 | Comment | `mcp__github__add_issue_comment` | `gh issue/pr comment` |
+| Threaded PR reply | `mcp__github__add_reply_to_pull_request_comment` | `gh api` |
 
 ---
 
-## Issues
+## Issue Types (org-level, `ocx-sh`)
 
-### Proposal-First Protocol
+Every issue MUST have a type. Types replace the old `bug` / `enhancement` / `chore` labels entirely. Types do NOT apply to PRs — use labels on PRs for cross-cutting concerns.
+
+| Type | When to use |
+|------|-------------|
+| **Bug** | Broken behavior, unexpected output, crash, spec deviation |
+| **Feature** | New user-facing capability, command, or behavior |
+| **Task** | Internal work with no user-visible capability — refactor, CI, tooling, chore, AI-config maintenance |
+| **Documentation** | Docs-only: website, user guide, `--help`, ADRs, man pages |
+| **Performance** | Measurable throughput / latency / memory / RSS change |
+| **Security** | Vulnerability, hardening, auth, credentials, secret handling |
+
+**When ambiguous**: a perf-motivated refactor is **Performance**, not Task. A bug fix that adds a new flag is still **Bug**. A new doc site feature (beyond docs content) is **Feature**.
+
+Discover types programmatically via `mcp__github__list_issue_types` (or `env -u GITHUB_TOKEN gh api /orgs/ocx-sh/issue-types`).
+
+**Setting the type on an issue.** Prefer `mcp__github__issue_write` (supports `type:` natively). If you must fall back to `gh`, note that `gh issue create/edit` has no `--type` flag — use the GraphQL `updateIssue` mutation with the type's node id. Fetch ids once, then update:
+
+```sh
+# 1. fetch org type ids (one-shot)
+gh api graphql -f query='query { organization(login:"ocx-sh") { issueTypes(first:20) { nodes { id name } } } }'
+
+# 2. fetch issue node id
+gh issue view <N> --json id
+
+# 3. assign type (replace ids)
+gh api graphql -f query='mutation($i:ID!,$t:ID!){ updateIssue(input:{id:$i,issueTypeId:$t}){ issue { number } } }' \
+  -f i=<issue-node-id> -f t=<type-node-id>
+```
+
+To clear a type, pass `issueTypeId: null` via `-F i=<id> -F t=`.
+
+---
+
+## Labels — Curated Taxonomy
+
+**Do not invent labels.** If a concept isn't covered below, propose an addition to this file first, get approval, then create it. The taxonomy has three axes: subsystem routing (`area/*`), priority (`priority/*`), and cross-cutting concerns.
+
+### Area labels — subsystem routing (mirrors `CLAUDE.md` subsystem table)
+
+| Label | Scope |
+|-------|-------|
+| `area/oci` | OCI registry, index, push/pull |
+| `area/package` | Package metadata, schema |
+| `area/package-manager` | Install, resolve, lock |
+| `area/file-structure` | Storage, CAS, symlinks |
+| `area/cli` | CLI commands, API surface |
+| `area/mirror` | Mirror tool, bundling |
+| `area/tests` | Acceptance test infrastructure |
+| `area/website` | VitePress docs site |
+| `area/ci` | GitHub Actions, release pipeline |
+
+### Priority labels — only the ends of the spectrum
+
+| Label | Meaning |
+|-------|---------|
+| `priority/critical` | Blocks a release or causes data loss |
+| `priority/high` | Should land in the next release |
+| `priority/low` | Backlog, nice-to-have |
+
+Default (untagged) = normal priority. No `priority/medium` — it becomes a dumping ground.
+
+### Cross-cutting labels — apply on both issues AND PRs
+
+| Label | Use |
+|-------|-----|
+| `performance` | PR tag for perf-impacting changes (types don't apply to PRs) |
+| `security` | PR tag for security-sensitive changes |
+| `breaking-change` | API or behavior change requiring a version bump; surfaces in changelog |
+| `regression` | Worked before, broken by a recent change; elevates triage |
+| `flaky-test` | CI reliability, distinct from product bugs |
+| `dependencies` | Dependabot and manual dep bumps (auto-applied) |
+
+### Domain / triage labels
+
+- `ai-config` — `.claude/` maintenance (agents, skills, rules, hooks)
+- GitHub defaults (`good first issue`, `help wanted`, `duplicate`, `wontfix`) — use as documented by GitHub
+
+---
+
+## Issues — Proposal-First Protocol
 
 When the user describes future work, a feature idea, or technical debt to track:
 
@@ -34,33 +117,13 @@ When the user describes future work, a feature idea, or technical debt to track:
 
 ### Proposal Format
 
-Present all proposed issues in a single overview before creating any:
+Present all proposed issues in a single overview table, then one body section per issue using the template below, then ask "Shall I create these? Any changes?":
 
 ```
-## Proposed Issues
-
-| # | Title | Type | Depends On |
-|---|-------|------|------------|
-| 1 | feat: short user-facing title | Feature | — |
-| 2 | fix: another title | Bug | #1 |
-
-### Issue 1: feat: short user-facing title
-
-**Value:** What the user/developer gains from this.
-**Context:** Why this matters now, what triggered it.
-
-**Scope:**
-- Bullet list of what's in scope
-- And what's explicitly out
-
-**Acceptance Criteria:**
-- [ ] Testable condition 1
-- [ ] Testable condition 2
-
-**Depends on:** None / #other-issue
-
----
-Shall I create these issues? Any changes?
+| # | Title | Type | Labels | Depends On |
+|---|-------|------|--------|------------|
+| 1 | short imperative title | Feature | area/cli, priority/high | — |
+| 2 | another title | Bug | area/oci, regression | #1 |
 ```
 
 ### Issue Body Template
@@ -86,16 +149,7 @@ Mermaid diagrams where they clarify relationships or flows. Skip for simple issu
 - #issue — one-line description of why this blocks
 ```
 
-### Issue Types vs Labels
-
-Prefer **GitHub issue types** (`Bug`, `Feature`) over labels that duplicate type information.
-
-| Issue type | When to use | CLI flag |
-|------------|-------------|----------|
-| Bug | Something broken | `--label bug` (until `gh` supports `--type`) |
-| Feature | New feature or capability | `--label enhancement` (until `gh` supports `--type`) |
-
-Additional labels — use sparingly, only labels that exist on the repo: `docs`, `good first issue`.
+**Titles**: do not prefix with `feat:` / `fix:` / `chore:` — the issue type already classifies the work. Titles describe the outcome in plain imperative form.
 
 ---
 
@@ -122,7 +176,8 @@ Closes #<issue>
 
 ### PR Conventions
 
-- **Title**: Conventional Commit format matching the primary commit (e.g., `feat: three-tier CAS`)
+- **Title**: Conventional Commit format matching the primary commit (e.g., `feat: three-tier CAS`). PR titles keep the `type:` prefix; issue titles do not.
+- **Labels**: apply `area/*` for routing; add `performance`, `security`, `breaking-change`, or `regression` when relevant. (Issue types do not apply to PRs — labels are the only signal.)
 - **One concern per PR**: matches the one-concern-per-issue rule
 - **Link issues**: use `Closes #N` in the body to auto-close on merge
 - **Draft PRs**: use `--draft` for work-in-progress that needs early CI feedback
@@ -132,10 +187,8 @@ Closes #<issue>
 
 ## Shared Conventions
 
-- **Title format**: `type: short imperative description` — titles describe the outcome, not the approach
 - **User-first framing**: Value section answers "why should anyone care?" before "how does it work?"
 - **Cross-reference**: Use `#N` to link related issues/PRs. Add a "Depends on" section when order matters.
 - **One concern per item**: Don't combine unrelated work
 - **Mermaid where applicable**: Architecture, data flow, state machines. Not for simple lists.
 - **No implementation details in titles**
-- **Do not invent labels** — use only labels that exist on the repository

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -113,11 +113,12 @@ Otherwise, `AskUserQuestion`:
 
 - Stage files **by name**, never `git add -A` / `.`. This prevents both accidentally-committed secrets **and** the bug where pre-staged files from a previous session get swept into a commit whose message doesn't describe them.
 - Warn before staging anything matching `.env*`, `*credentials*`, `*.pem`, `*.key`, or `token` patterns; require explicit confirmation.
+- **`--amend` must fold the dirty tree into HEAD.** When `/commit --amend` is invoked and the working tree has uncommitted changes, those changes **must** be staged and included in the amend — an `--amend` with nothing staged silently becomes a message-only amend that drops the user's active work. Always `git add <files>` before `git commit --amend`, even when the user only asked to "amend". After the amend, run `git show --stat HEAD` and confirm the expected files appear in the diff stat before reporting success.
 - Pre-commit hook (`pre_commit_verification.py`) blocks commits without fresh `task verify`. When it blocks, run `task verify` (not `--no-verify`), then mark state in a separate `Bash` call (combining with the commit in one `&&` chain does not satisfy the hook):
   ```sh
   echo $(date +%s) > .claude/hooks/.state/commit-verified
   ```
-  Then retry.
+  Then retry. **On retry, re-run `git add` too** — a blocked Bash invocation ran nothing, not even the part before `&&`, so staging is gone if it was chained.
 - Commit with a HEREDOC:
 
   ```sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Multi-layer package push and pull. `ocx package push` now accepts multiple layer arguments, each either a file path or a `sha256:<hex>.tar.gz` digest reference. *(package)*
+
 ### Changed
 
 - **Breaking:** `--remote` / `OCX_REMOTE` semantics narrowed — tag and catalog lookups now bypass the local tag store and query the registry directly, but digest-addressed blob reads still use the local cache with write-through to `$OCX_HOME/blobs/`. Previously, `--remote` routed all operations to the registry. Only `$OCX_HOME/tags/` is no longer updated under `--remote`. *(oci)*
@@ -15,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `ocx --offline install <pkg>` after a bare `ocx index update <pkg>` now fails with a clear `OfflineManifestMissing` error naming the missing digest instead of a silent failure. Recovery: run `ocx install <pkg>` online to populate the blob cache. *(oci)*
+
+### Security
+
+- Pulled layer blobs are verified against the claimed digest before extraction; mismatched blobs are deleted and fail the pull with a clear error. *(oci)*
 
 ## [0.2.1] - 2026-03-24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 resolver = "3"
 members = ["crates/ocx_cli", "crates/ocx_lib", "crates/ocx_mirror", "crates/ocx_schema"]
+# The submodule is pulled in via [patch.crates-io] below; excluding it here
+# lets `cargo` commands run directly inside `external/rust-oci-client/` (for
+# the fork's own test suite) without the outer workspace claiming ownership.
+exclude = ["external/rust-oci-client"]
 
 [workspace.package]
 version = "0.2.1"

--- a/crates/ocx_cli/src/command/deps.rs
+++ b/crates/ocx_cli/src/command/deps.rs
@@ -16,6 +16,7 @@ use ocx_lib::{
         resolved_package::ResolvedPackage,
     },
     prelude::SerdeExt,
+    utility,
 };
 
 use crate::{api, conventions::platforms_or_default, options};
@@ -220,7 +221,7 @@ async fn resolve_dep_via_metadata(
     // Primary: direct digest lookup (single-platform manifests where
     // the declared digest matches the stored content digest).
     let content = fs.packages.content(id);
-    if tokio::fs::try_exists(&content).await.unwrap_or(false) {
+    if utility::fs::path_exists_lossy(&content).await {
         return load_install_info(id.clone(), content).await;
     }
 

--- a/crates/ocx_cli/src/command/package_push.rs
+++ b/crates/ocx_cli/src/command/package_push.rs
@@ -25,10 +25,11 @@ pub struct PackagePush {
 
     /// Path to the package metadata JSON file. Defaults to a sibling of the
     /// first file layer (e.g. `pkg.tar.gz` → `pkg-metadata.json`). Required
-    /// when all layers are digest references.
+    /// when no file layers are provided.
     #[clap(short, long)]
     metadata: Option<std::path::PathBuf>,
 
+    /// Target platform (e.g. `linux/amd64`). Required.
     #[clap(short, long, required = true)]
     platform: oci::Platform,
 
@@ -46,13 +47,13 @@ pub struct PackagePush {
     ///     guess.
     ///
     /// Digest references enable layer reuse: a base layer pushed once can be
-    /// referenced by digest from many packages without re-uploading. At least
-    /// one layer is required.
+    /// referenced by digest from many packages without re-uploading. Zero
+    /// layers is valid (produces a config-only OCI artifact) when
+    /// `--metadata` is supplied.
     ///
     /// Examples:
-    ///   ocx package push repo:2.0.0 sha256:abc....tar.gz ./new.tar.gz
-    ///   ocx package push repo:2.0.0 sha256:abc....tar.xz
-    #[clap(required = true)]
+    ///   ocx package push repo:2.0.0 sha256:<hex>.tar.gz ./new.tar.gz
+    ///   ocx package push repo:2.0.0 sha256:<hex>.tar.xz
     layers: Vec<LayerRef>,
 }
 
@@ -69,7 +70,7 @@ impl PackagePush {
                     LayerRef::Digest { .. } => None,
                 });
                 let file_path = first_file
-                    .ok_or_else(|| anyhow::anyhow!("--metadata is required when all layers are digest references"))?;
+                    .ok_or_else(|| anyhow::anyhow!("--metadata is required when no file layers are provided"))?;
                 crate::conventions::infer_metadata_file(file_path)?
             }
         };

--- a/crates/ocx_cli/src/command/package_push.rs
+++ b/crates/ocx_cli/src/command/package_push.rs
@@ -4,7 +4,11 @@
 use std::process::ExitCode;
 
 use clap::Parser;
-use ocx_lib::{log, oci, package, prelude::*, publisher::Publisher};
+use ocx_lib::{
+    log, oci, package,
+    prelude::*,
+    publisher::{LayerRef, Publisher},
+};
 
 use crate::options;
 
@@ -19,6 +23,9 @@ pub struct PackagePush {
     #[clap(long = "new", short = 'n')]
     new: bool,
 
+    /// Path to the package metadata JSON file. Defaults to a sibling of the
+    /// first file layer (e.g. `pkg.tar.gz` → `pkg-metadata.json`). Required
+    /// when all layers are digest references.
     #[clap(short, long)]
     metadata: Option<std::path::PathBuf>,
 
@@ -26,20 +33,50 @@ pub struct PackagePush {
     platform: oci::Platform,
 
     identifier: options::Identifier,
-    content: std::path::PathBuf,
+
+    /// Layers to push, in order (base layer first, top layer last).
+    ///
+    /// Each layer is either:
+    ///   - a path to a pre-built archive file (`.tar.gz`, `.tar.xz`), or
+    ///   - a digest reference to a layer already present in the target
+    ///     registry, written as `sha256:<hex>.<ext>` where `<ext>` declares
+    ///     the original archive format — one of `tar.gz`, `tgz`, `tar.xz`,
+    ///     `txz`. The OCI distribution spec does not expose a layer's media
+    ///     type via blob HEAD, so the suffix is required: OCX refuses to
+    ///     guess.
+    ///
+    /// Digest references enable layer reuse: a base layer pushed once can be
+    /// referenced by digest from many packages without re-uploading. At least
+    /// one layer is required.
+    ///
+    /// Examples:
+    ///   ocx package push repo:2.0.0 sha256:abc....tar.gz ./new.tar.gz
+    ///   ocx package push repo:2.0.0 sha256:abc....tar.xz
+    #[clap(required = true)]
+    layers: Vec<LayerRef>,
 }
 
 impl PackagePush {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
         let identifier = self.identifier.with_domain(context.default_registry())?;
+
+        // Infer metadata from the first file layer, or require --metadata for digest-only pushes.
         let metadata_path = match &self.metadata {
             Some(path) => path.clone(),
-            None => crate::conventions::infer_metadata_file(&self.content)?,
+            None => {
+                let first_file = self.layers.iter().find_map(|l| match l {
+                    LayerRef::File(p) => Some(p.as_path()),
+                    LayerRef::Digest { .. } => None,
+                });
+                let file_path = first_file
+                    .ok_or_else(|| anyhow::anyhow!("--metadata is required when all layers are digest references"))?;
+                crate::conventions::infer_metadata_file(file_path)?
+            }
         };
 
         log::info!(
-            "Deploying package from {} with metadata {}",
-            self.content.display(),
+            "Deploying package with {} layer(s) and metadata {}",
+            self.layers.len(),
             metadata_path.display()
         );
         let metadata = package::metadata::Metadata::read_json(&metadata_path).await?;
@@ -69,9 +106,9 @@ impl PackagePush {
             };
 
             let existing_versions = Publisher::parse_versions(&existing_tags);
-            publisher.push_cascade(info, &self.content, existing_versions).await?;
+            publisher.push_cascade(info, &self.layers, existing_versions).await?;
         } else {
-            publisher.push(info, &self.content).await?;
+            publisher.push(info, &self.layers).await?;
         }
 
         Ok(ExitCode::SUCCESS)

--- a/crates/ocx_lib/src/file_structure/cas_path.rs
+++ b/crates/ocx_lib/src/file_structure/cas_path.rs
@@ -3,7 +3,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::oci::Digest;
+use crate::oci::{Algorithm, Digest};
 
 /// Number of hex characters used as the shard prefix directory name.
 const CAS_SHARD_PREFIX_LEN: usize = 2;
@@ -88,7 +88,7 @@ pub async fn read_digest_file(path: &Path) -> crate::Result<Digest> {
 pub fn cas_ref_name(digest: &Digest) -> String {
     let hex = digest.hex();
     let total = CAS_SHARD_TOTAL_LEN.min(hex.len());
-    format!("{}_{}", digest.algorithm(), &hex[..total])
+    format!("{}_{}", digest.algorithm().prefix(), &hex[..total])
 }
 
 pub fn is_valid_cas_path(dir: &Path) -> bool {
@@ -107,7 +107,7 @@ pub fn is_valid_cas_path(dir: &Path) -> bool {
     let prefix = tail[1];
     let remaining = tail[0];
 
-    Digest::ALGORITHMS.contains(&algorithm)
+    Algorithm::ALL.iter().any(|a| a.prefix() == algorithm)
         && prefix.len() == CAS_SHARD_PREFIX_LEN
         && prefix.bytes().all(|b| b.is_ascii_hexdigit())
         && remaining.len() == CAS_SHARD_SUFFIX_LEN

--- a/crates/ocx_lib/src/file_structure/tag_store.rs
+++ b/crates/ocx_lib/src/file_structure/tag_store.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::utility::fs::{DirWalker, WalkDecision};
+use crate::utility::fs::{self, DirWalker, WalkDecision};
 use crate::{Result, oci};
 
 /// Manages the local tag store on the filesystem.
@@ -54,7 +54,7 @@ impl TagStore {
     /// and collects `.json` file stems as repository name fragments.
     pub async fn list_repositories(&self, registry: &str) -> Result<Vec<String>> {
         let registry_dir = self.root.join(super::slugify(registry));
-        if !tokio::fs::try_exists(&registry_dir).await.unwrap_or(false) {
+        if !fs::path_exists_lossy(&registry_dir).await {
             return Ok(Vec::new());
         }
 

--- a/crates/ocx_lib/src/oci.rs
+++ b/crates/ocx_lib/src/oci.rs
@@ -60,6 +60,7 @@ pub use platform::OperatingSystem;
 pub use platform::Platform;
 
 pub mod digest;
+pub use digest::Algorithm;
 pub use digest::Digest;
 
 pub mod pinned_identifier;

--- a/crates/ocx_lib/src/oci/client.rs
+++ b/crates/ocx_lib/src/oci/client.rs
@@ -5,16 +5,15 @@ use crate::{
     ACCEPTED_MANIFEST_MEDIA_TYPES, MEDIA_TYPE_DESCRIPTION_V1, MEDIA_TYPE_MARKDOWN, MEDIA_TYPE_OCI_EMPTY_CONFIG,
     MEDIA_TYPE_OCI_IMAGE_INDEX, MEDIA_TYPE_OCI_IMAGE_MANIFEST, MEDIA_TYPE_PACKAGE_METADATA_V1, MEDIA_TYPE_PACKAGE_V1,
     MEDIA_TYPE_PNG, MEDIA_TYPE_SVG, Result, archive, compression, log, media_type_file_ext, media_type_from_path,
-    media_type_select, media_type_select_some, oci,
+    media_type_select, oci,
     package::{self, info::Info, metadata, tag::InternalTag},
-    prelude::SerdeExt,
     utility,
 };
 
 use futures::stream::{self, StreamExt, TryStreamExt};
 use tracing::Instrument;
 
-use super::{Digest, Identifier, native};
+use super::{Algorithm, Digest, Identifier, native};
 
 /// Maximum number of layer push/verify operations to run concurrently.
 ///
@@ -37,11 +36,12 @@ use error::ClientError;
 
 /// Verifies that a blob on disk hashes to its claimed digest.
 ///
-/// Streams the file through SHA-256 and compares against `expected`
-/// (an OCI digest string like `sha256:<hex>`). On mismatch, removes
-/// the blob and returns [`ClientError::DigestMismatch`]. This defends
-/// against a compromised or misbehaving registry serving different
-/// bytes for the same digest (CWE-345).
+/// Streams the file through the algorithm named by `expected` (SHA-256,
+/// SHA-384, or SHA-512 — whichever variant the manifest descriptor
+/// declares) and compares against it. On mismatch, removes the blob
+/// and returns [`ClientError::DigestMismatch`]. This defends against
+/// a compromised or misbehaving registry serving different bytes for
+/// the same digest (CWE-345).
 ///
 /// This is the **second line of defense** against bad registry
 /// responses. The first line is the archive walker in
@@ -52,12 +52,16 @@ use error::ClientError;
 /// case of a registry serving different bytes for the same digest —
 /// i.e. a digest/bytes mismatch that the walker cannot see because
 /// it operates after extraction.
-async fn verify_blob_digest(blob_path: &std::path::Path, expected: &str) -> std::result::Result<(), ClientError> {
-    let actual = Digest::sha256_file(blob_path).await.map_err(|e| ClientError::Io {
-        path: blob_path.to_path_buf(),
-        source: e,
-    })?;
-    if actual.to_string() == expected {
+async fn verify_blob_digest(blob_path: &std::path::Path, expected: &Digest) -> std::result::Result<(), ClientError> {
+    let actual = expected
+        .algorithm()
+        .hash_file(blob_path)
+        .await
+        .map_err(|e| ClientError::Io {
+            path: blob_path.to_path_buf(),
+            source: e,
+        })?;
+    if &actual == expected {
         return Ok(());
     }
     // Best-effort cleanup of the tampered blob so a subsequent pull
@@ -199,10 +203,16 @@ impl Client {
                 let existing: oci::Manifest = serde_json::from_slice(&blob).map_err(ClientError::Serialization)?;
                 match existing {
                     oci::Manifest::Image(_) => {
+                        let blob_size = i64::try_from(blob.len()).map_err(|_| {
+                            ClientError::InvalidManifest(format!(
+                                "existing manifest blob size {} exceeds i64::MAX",
+                                blob.len()
+                            ))
+                        })?;
                         let entry = oci::ImageIndexEntry {
                             media_type: MEDIA_TYPE_OCI_IMAGE_MANIFEST.to_string(),
                             digest: digest_str,
-                            size: blob.len() as i64,
+                            size: blob_size,
                             platform: None,
                             annotations: None,
                         };
@@ -240,7 +250,7 @@ impl Client {
         });
 
         let index_data = serde_json::to_vec(&index).map_err(ClientError::Serialization)?;
-        let index_digest = Digest::sha256(&index_data);
+        let index_digest = Algorithm::Sha256.hash(&index_data);
         self.transport
             .push_manifest_raw(&ref_, index_data, MEDIA_TYPE_OCI_IMAGE_INDEX)
             .await?;
@@ -251,14 +261,14 @@ impl Client {
 
     // ── Package pull ─────────────────────────────────────────────────
     //
-    // Three composable methods for fetching a package from a registry:
+    // Composable methods for fetching a package from a registry:
     //
     //   pull_manifest  → ImageManifest   (validate digest, media types, layers)
     //   pull_metadata  → Metadata        (fetch config blob — deps, env, etc.)
-    //   pull_content   → TempAcquireResult (download content blob, extract, codesign)
+    //   pull_layer     → extracted dir   (download one layer blob, extract, codesign)
     //
-    // Both `pull_metadata` and `pull_content` accept an optional manifest.
-    // If `None`, they call `pull_manifest` internally.
+    // `pull_metadata` accepts an optional manifest; if `None`, it calls
+    // `pull_manifest` internally.
 
     /// Fetches and validates the OCI manifest for a pinned package.
     ///
@@ -311,91 +321,11 @@ impl Client {
         let image = native::Reference::from(&**identifier);
         self.transport.ensure_auth(&image, oci::RegistryOperation::Pull).await?;
 
-        let bytes = self.transport.pull_blob(&image, &manifest.config.digest).await?;
+        let config_digest = Digest::try_from(manifest.config.digest.as_str()).map_err(|e| {
+            ClientError::InvalidManifest(format!("config digest '{}' is malformed: {e}", manifest.config.digest))
+        })?;
+        let bytes = self.transport.pull_blob(&image, &config_digest).await?;
         serde_json::from_slice(&bytes).map_err(ClientError::Serialization)
-    }
-
-    /// Downloads the content blob and extracts it into a temp directory.
-    ///
-    /// Takes ownership of `temp` — on error, the temp directory is cleaned up
-    /// automatically. On success, returns the [`TempAcquireResult`] back.
-    ///
-    /// The temp directory will contain after success:
-    /// - `metadata.json` (serialized metadata)
-    /// - `content/` (extracted archive)
-    /// - `manifest.json` (OCI manifest for audit)
-    ///
-    /// If `manifest` is `None`, fetches it via [`pull_manifest`](Self::pull_manifest).
-    pub async fn pull_content(
-        &self,
-        identifier: &oci::PinnedIdentifier,
-        manifest: Option<&oci::ImageManifest>,
-        metadata: &metadata::Metadata,
-        output_dir: &std::path::Path,
-    ) -> std::result::Result<(), ClientError> {
-        let owned;
-        let manifest = match manifest {
-            Some(m) => m,
-            None => {
-                owned = self.pull_manifest(identifier).await?;
-                &owned
-            }
-        };
-
-        media_type_select_some(&manifest.artifact_type, &[MEDIA_TYPE_PACKAGE_V1])
-            .map_err(|e| ClientError::InvalidManifest(e.to_string()))?;
-        if manifest.layers.is_empty() {
-            return Err(ClientError::InvalidManifest("manifest has no layers".to_string()));
-        }
-
-        let mut temp_guard = utility::fs::DropFile::new(output_dir.to_path_buf());
-        let image = native::Reference::from(&**identifier);
-
-        // Write metadata.json to temp so it's available for the final move.
-        metadata
-            .write_json(output_dir.join("metadata.json"))
-            .await
-            .map_err(ClientError::internal)?;
-
-        let blob_layer = &manifest.layers[0];
-        let blob_compression =
-            compression::CompressionAlgorithm::from_media_type(&blob_layer.media_type).ok_or_else(|| {
-                ClientError::InvalidManifest(format!("unsupported layer media type: {}", blob_layer.media_type))
-            })?;
-        let blob_file_ext = media_type_file_ext(&blob_layer.media_type).unwrap_or("blob");
-        let content_path = output_dir.join("content");
-        let blob_path = content_path.with_added_extension(blob_file_ext);
-        let blob_total_size = u64::try_from(blob_layer.size).unwrap_or(0);
-
-        log::info!("Downloading package {} to temp {}", identifier, output_dir.display());
-
-        let bar = crate::cli::progress::ProgressBar::bytes(
-            tracing::info_span!("Downloading", package = %identifier),
-            blob_total_size,
-            identifier,
-        );
-        let on_progress = bar.callback();
-
-        {
-            let _guard = bar.enter();
-            self.transport
-                .pull_blob_to_file(&image, &blob_layer.digest, &blob_path, blob_total_size, on_progress)
-                .await?;
-        }
-
-        verify_blob_digest(&blob_path, &blob_layer.digest).await?;
-
-        self.extract_to_temp(identifier, metadata, blob_compression, blob_file_ext, output_dir)
-            .await?;
-
-        // Write manifest.json for audit.
-        manifest
-            .write_json(output_dir.join("manifest.json"))
-            .await
-            .map_err(ClientError::internal)?;
-
-        temp_guard.retain();
-        Ok(())
     }
 
     /// Downloads and extracts a single OCI layer to the specified directory.
@@ -424,9 +354,12 @@ impl Client {
 
         let image = native::Reference::from(&**identifier);
 
+        let layer_digest = Digest::try_from(layer.digest.as_str())
+            .map_err(|e| ClientError::InvalidManifest(format!("layer digest '{}' is malformed: {e}", layer.digest)))?;
+
         log::info!(
             "Downloading layer {} to {}",
-            &layer.digest[..std::cmp::min(19, layer.digest.len())],
+            layer_digest.to_short_string(),
             output_dir.display()
         );
 
@@ -440,11 +373,11 @@ impl Client {
         {
             let _guard = bar.enter();
             self.transport
-                .pull_blob_to_file(&image, &layer.digest, &blob_path, blob_total_size, on_progress)
+                .pull_blob_to_file(&image, &layer_digest, &blob_path, blob_total_size, on_progress)
                 .await?;
         }
 
-        verify_blob_digest(&blob_path, &layer.digest).await?;
+        verify_blob_digest(&blob_path, &layer_digest).await?;
 
         // Extract archive + codesign.
         self.extract_to_temp(identifier, metadata, blob_compression, blob_file_ext, output_dir)
@@ -507,6 +440,26 @@ impl Client {
         package_info: Info,
         layers: &[crate::publisher::LayerRef],
     ) -> Result<(Digest, oci::Manifest)> {
+        let (index_digest, index) = self.push_manifest_and_merge_tags(&package_info, layers, &[]).await?;
+        Ok((index_digest, oci::Manifest::ImageIndex(index)))
+    }
+
+    /// Pushes the package manifest and merges the resulting platform entry
+    /// into the primary tag's image index plus each tag in `extra_tags`.
+    ///
+    /// The manifest is pushed once and its digest reused across every
+    /// `merge_platform_into_index` call, so a cascade or multi-tag push
+    /// never re-serializes or re-uploads the manifest. `extra_tags` is
+    /// the rolling/cascade tag set (e.g. `["3.28", "3", "latest"]`);
+    /// pass `&[]` for a plain single-tag push.
+    ///
+    /// Returns the digest + data of the primary tag's image index.
+    pub(crate) async fn push_manifest_and_merge_tags(
+        &self,
+        package_info: &Info,
+        layers: &[crate::publisher::LayerRef],
+        extra_tags: &[String],
+    ) -> Result<(Digest, oci::ImageIndex)> {
         log::debug!(
             "Pushing package {} with {} layer(s)",
             package_info.identifier,
@@ -516,14 +469,35 @@ impl Client {
         let image = native::Reference::from(&package_info.identifier);
         self.transport.ensure_auth(&image, oci::RegistryOperation::Push).await?;
 
-        let (manifest, manifest_data, manifest_sha256) = self.push_multi_layer_manifest(&package_info, layers).await?;
+        let (_manifest, manifest_data, manifest_sha256) = self.push_multi_layer_manifest(package_info, layers).await?;
+        let manifest_size = i64::try_from(manifest_data.len()).map_err(|_| {
+            ClientError::InvalidManifest(format!("manifest size {} exceeds i64::MAX", manifest_data.len()))
+        })?;
 
+        let primary_tag = package_info.identifier.tag_or_latest().to_string();
         let (index_digest, index) = self
-            .update_image_index(&package_info, &manifest_data, &manifest_sha256)
+            .merge_platform_into_index(
+                &package_info.identifier,
+                &primary_tag,
+                &package_info.platform,
+                &manifest_sha256,
+                manifest_size,
+            )
             .await?;
 
-        drop(manifest);
-        Ok((index_digest, oci::Manifest::ImageIndex(index)))
+        for tag in extra_tags {
+            log::debug!("Cascading to {tag}");
+            self.merge_platform_into_index(
+                &package_info.identifier,
+                tag.clone(),
+                &package_info.platform,
+                &manifest_sha256,
+                manifest_size,
+            )
+            .await?;
+        }
+
+        Ok((index_digest, index))
     }
 
     /// Pushes config blob + N layer blobs + image manifest.
@@ -542,92 +516,106 @@ impl Client {
     ) -> std::result::Result<(oci::ImageManifest, Vec<u8>, String), ClientError> {
         use crate::publisher::LayerRef;
 
-        if layers.is_empty() {
-            return Err(ClientError::InvalidManifest(
-                "package must have at least one layer".to_string(),
-            ));
-        }
-
         let image = native::Reference::from(&package_info.identifier);
 
+        let total_layers = layers.len();
         // Upload file layers and verify digest layers concurrently, preserving
         // input order so manifest descriptors match the caller-supplied order.
         // Bounded by `LAYER_PUSH_CONCURRENCY` to cap in-memory archive buffers.
-        let layer_descriptors: Vec<oci::Descriptor> = stream::iter(layers.iter())
-            .map(|layer| async {
-                match layer {
-                    LayerRef::File(path) => {
-                        let package_media_type =
-                            media_type_from_path(path).map(|mt| mt.to_string()).ok_or_else(|| {
-                                ClientError::InvalidManifest(format!("unsupported archive: {}", path.display()))
+        let layer_descriptors: Vec<oci::Descriptor> = stream::iter(layers.iter().enumerate())
+            .map(|(index, layer)| {
+                // `async move` owns its captures, so each concurrent future needs
+                // its own copy of the image reference; clones are cheap
+                // (a few short strings) and are outweighed by avoiding a
+                // lifetime gymnastics around the stream combinator.
+                let image = image.clone();
+                let identifier = package_info.identifier.clone();
+                async move {
+                    let progress_label = format!("{}/{}", index + 1, total_layers);
+                    match layer {
+                        LayerRef::File(path) => {
+                            let package_media_type =
+                                media_type_from_path(path).map(|mt| mt.to_string()).ok_or_else(|| {
+                                    ClientError::InvalidManifest(format!("unsupported archive: {}", path.display()))
+                                })?;
+
+                            // BOUNDED: LAYER_PUSH_CONCURRENCY caps simultaneous
+                            // in-memory archives at 4 × (layer size). Do not raise
+                            // the constant without either switching to a streaming
+                            // push path or auditing the RSS budget for the largest
+                            // layers callers ship.
+                            //
+                            // Single disk pass: read and hash are interleaved in
+                            // 64 KiB chunks, so the SHA-256 finalization happens
+                            // without a second traversal of the buffer.
+                            let (package_data, digest) =
+                                Algorithm::Sha256
+                                    .hash_file_read(path)
+                                    .await
+                                    .map_err(|e| ClientError::Io {
+                                        path: path.to_path_buf(),
+                                        source: e,
+                                    })?;
+                            let package_data_len = package_data.len();
+
+                            log::trace!(
+                                "Layer {progress_label} {}: digest={}, size={}",
+                                path.display(),
+                                digest,
+                                package_data_len
+                            );
+
+                            let bar = crate::cli::progress::ProgressBar::bytes(
+                                tracing::info_span!(
+                                    "Uploading",
+                                    layer = %format!("{progress_label} {}", path.display())
+                                ),
+                                package_data_len as u64,
+                                &identifier,
+                            );
+                            let on_progress = bar.callback();
+                            let span = bar.into_span();
+                            self.transport
+                                .push_blob(&image, package_data, &digest, on_progress)
+                                .instrument(span)
+                                .await?;
+
+                            let size = i64::try_from(package_data_len).map_err(|_| {
+                                ClientError::InvalidManifest(format!("blob size {package_data_len} exceeds i64::MAX"))
                             })?;
+                            Ok::<oci::Descriptor, ClientError>(oci::Descriptor {
+                                media_type: package_media_type,
+                                digest: digest.to_string(),
+                                size,
+                                urls: None,
+                                annotations: None,
+                            })
+                        }
+                        LayerRef::Digest { digest, media_type } => {
+                            // The caller supplies `media_type` because the OCI
+                            // distribution spec does not expose a layer's media
+                            // type via blob HEAD — only the blob bytes and
+                            // Content-Length. See `LayerRef::FromStr` for the
+                            // `sha256:<hex>.<ext>` CLI syntax that carries this
+                            // information from the user to here.
+                            log::info!("Reusing layer {progress_label} {digest} ({media_type})");
+                            let size = self.transport.head_blob(&image, digest).await?;
 
-                        // BOUNDED: LAYER_PUSH_CONCURRENCY caps simultaneous
-                        // in-memory archives at 4 × (layer size). Do not raise
-                        // the constant without either switching to a streaming
-                        // push path or auditing the RSS budget for the largest
-                        // layers callers ship.
-                        let package_data = tokio::fs::read(path).await.map_err(|e| ClientError::Io {
-                            path: path.to_path_buf(),
-                            source: e,
-                        })?;
-                        let package_data_len = package_data.len();
-                        // Hash on a blocking thread: Digest::sha256 is
-                        // CPU-bound over potentially hundreds of MB and
-                        // would otherwise stall the Tokio executor mid-
-                        // `buffered()` stream.
-                        let (package_data, package_digest) = tokio::task::spawn_blocking(move || {
-                            let digest = Digest::sha256(&package_data).to_string();
-                            (package_data, digest)
-                        })
-                        .await
-                        .map_err(|e| ClientError::Internal(Box::new(e)))?;
+                            log::trace!(
+                                "Layer {progress_label} {digest}: verified, media_type={media_type}, size={size}"
+                            );
 
-                        log::trace!(
-                            "Layer {}: digest={}, size={}",
-                            path.display(),
-                            package_digest,
-                            package_data_len
-                        );
-
-                        let bar = crate::cli::progress::ProgressBar::bytes(
-                            tracing::info_span!("Uploading", layer = %path.display()),
-                            package_data_len as u64,
-                            &package_info.identifier,
-                        );
-                        let on_progress = bar.callback();
-                        let span = bar.into_span();
-                        self.transport
-                            .push_blob(&image, package_data, &package_digest, on_progress)
-                            .instrument(span)
-                            .await?;
-
-                        Ok::<oci::Descriptor, ClientError>(oci::Descriptor {
-                            media_type: package_media_type,
-                            digest: package_digest,
-                            size: package_data_len as i64,
-                            urls: None,
-                            annotations: None,
-                        })
-                    }
-                    LayerRef::Digest { digest, media_type } => {
-                        // The caller supplies `media_type` because the OCI
-                        // distribution spec does not expose a layer's media
-                        // type via blob HEAD — only the blob bytes and
-                        // Content-Length. See `LayerRef::FromStr` for the
-                        // `sha256:<hex>.<ext>` CLI syntax that carries this
-                        // information from the user to here.
-                        let size = self.transport.head_blob(&image, &digest.to_string()).await?;
-
-                        log::trace!("Layer {}: verified, media_type={}, size={}", digest, media_type, size);
-
-                        Ok(oci::Descriptor {
-                            media_type: media_type.as_media_type().to_string(),
-                            digest: digest.to_string(),
-                            size: size as i64,
-                            urls: None,
-                            annotations: None,
-                        })
+                            let size = i64::try_from(size).map_err(|_| {
+                                ClientError::InvalidManifest(format!("blob size {size} exceeds i64::MAX"))
+                            })?;
+                            Ok(oci::Descriptor {
+                                media_type: media_type.as_media_type().to_string(),
+                                digest: digest.to_string(),
+                                size,
+                                urls: None,
+                                annotations: None,
+                            })
+                        }
                     }
                 }
             })
@@ -638,19 +626,22 @@ impl Client {
         // Config blob — tiny, no progress needed.
         let config_data = serde_json::to_vec(&package_info.metadata).map_err(ClientError::Serialization)?;
         let config_data_len = config_data.len();
-        let config_sha256 = Digest::sha256(&config_data).to_string();
-        log::trace!("Config digest: {}", config_sha256);
+        let config_digest = Algorithm::Sha256.hash(&config_data);
+        log::trace!("Config digest: {}", config_digest);
         self.transport
-            .push_blob(&image, config_data, &config_sha256, transport::no_progress())
+            .push_blob(&image, config_data, &config_digest, transport::no_progress())
             .await?;
 
+        let config_size = i64::try_from(config_data_len).map_err(|_| {
+            ClientError::InvalidManifest(format!("config blob size {config_data_len} exceeds i64::MAX"))
+        })?;
         let manifest = oci::ImageManifest {
             media_type: Some(MEDIA_TYPE_OCI_IMAGE_MANIFEST.to_string()),
             artifact_type: Some(MEDIA_TYPE_PACKAGE_V1.to_string()),
             config: oci::Descriptor {
                 media_type: MEDIA_TYPE_PACKAGE_METADATA_V1.to_string(),
-                digest: config_sha256,
-                size: config_data_len as i64,
+                digest: config_digest.to_string(),
+                size: config_size,
                 urls: None,
                 annotations: None,
             },
@@ -660,7 +651,7 @@ impl Client {
         };
 
         let manifest_data = serde_json::to_vec(&manifest).map_err(ClientError::Serialization)?;
-        let manifest_sha256 = Digest::sha256(&manifest_data).to_string();
+        let manifest_sha256 = Algorithm::Sha256.hash(&manifest_data).to_string();
         let canonical_image = image.clone_with_digest(manifest_sha256.clone());
 
         let pushed_digest = self
@@ -670,33 +661,6 @@ impl Client {
         log::debug!("Pushed manifest with digest '{}'", pushed_digest);
 
         Ok((manifest, manifest_data, manifest_sha256))
-    }
-
-    /// Fetches (or creates) the image index, adds the new manifest entry for the
-    /// package platform, and pushes the updated index.
-    ///
-    /// Delegates to [`merge_platform_into_index`](Self::merge_platform_into_index).
-    async fn update_image_index(
-        &self,
-        package_info: &Info,
-        manifest_data: &[u8],
-        manifest_sha256: &str,
-    ) -> std::result::Result<(Digest, oci::ImageIndex), ClientError> {
-        let tag = package_info.identifier.tag_or_latest().to_string();
-        let manifest_size = manifest_data.len() as i64;
-
-        let (digest, index) = self
-            .merge_platform_into_index(
-                &package_info.identifier,
-                &tag,
-                &package_info.platform,
-                manifest_sha256,
-                manifest_size,
-            )
-            .await
-            .map_err(ClientError::internal)?;
-
-        Ok((digest, index))
     }
 
     // ── Description operations ────────────────────────────────────────
@@ -716,29 +680,31 @@ impl Client {
         self.transport.ensure_auth(&image, oci::RegistryOperation::Push).await?;
 
         let config_data = b"{}".to_vec();
-        let config_digest = Digest::sha256(&config_data).to_string();
+        let config_digest = Algorithm::Sha256.hash(&config_data);
         self.transport
             .push_blob(&image, config_data, &config_digest, transport::no_progress())
             .await?;
 
         let readme_bytes = description.readme.as_bytes();
         let readme_len = readme_bytes.len();
-        let readme_digest = Digest::sha256(readme_bytes).to_string();
+        let readme_digest = Algorithm::Sha256.hash(readme_bytes);
         self.transport
             .push_blob(&image, readme_bytes.to_vec(), &readme_digest, transport::no_progress())
             .await?;
 
+        let readme_size = i64::try_from(readme_len)
+            .map_err(|_| ClientError::InvalidManifest(format!("readme blob size {readme_len} exceeds i64::MAX")))?;
         let mut layers = vec![oci::Descriptor {
             media_type: MEDIA_TYPE_MARKDOWN.to_string(),
-            digest: readme_digest,
-            size: readme_len as i64,
+            digest: readme_digest.to_string(),
+            size: readme_size,
             urls: None,
             annotations: Some([(oci::annotations::TITLE.to_string(), "README.md".to_string())].into()),
         }];
 
         if let Some(logo) = &description.logo {
             let logo_len = logo.data.len();
-            let logo_digest = Digest::sha256(&logo.data).to_string();
+            let logo_digest = Algorithm::Sha256.hash(&logo.data);
             self.transport
                 .push_blob(&image, logo.data.clone(), &logo_digest, transport::no_progress())
                 .await?;
@@ -748,10 +714,12 @@ impl Client {
                 MEDIA_TYPE_SVG => "svg",
                 _ => "bin",
             };
+            let logo_size = i64::try_from(logo_len)
+                .map_err(|_| ClientError::InvalidManifest(format!("logo blob size {logo_len} exceeds i64::MAX")))?;
             layers.push(oci::Descriptor {
                 media_type: logo.media_type.to_string(),
-                digest: logo_digest,
-                size: logo_len as i64,
+                digest: logo_digest.to_string(),
+                size: logo_size,
                 urls: None,
                 annotations: Some([(oci::annotations::TITLE.to_string(), format!("logo.{ext}"))].into()),
             });
@@ -768,7 +736,7 @@ impl Client {
             artifact_type: Some(MEDIA_TYPE_DESCRIPTION_V1.to_string()),
             config: oci::Descriptor {
                 media_type: MEDIA_TYPE_OCI_EMPTY_CONFIG.to_string(),
-                digest: config_digest,
+                digest: config_digest.to_string(),
                 size: 2,
                 urls: None,
                 annotations: None,
@@ -833,8 +801,11 @@ impl Client {
 
         for (i, layer) in image_manifest.layers.iter().enumerate() {
             let blob_path = temp_dir.join(format!("layer_{i}"));
+            let layer_digest = Digest::try_from(layer.digest.as_str()).map_err(|e| {
+                ClientError::InvalidManifest(format!("description layer digest '{}' is malformed: {e}", layer.digest))
+            })?;
             self.transport
-                .pull_blob_to_file(&image, &layer.digest, &blob_path, 0, transport::no_progress())
+                .pull_blob_to_file(&image, &layer_digest, &blob_path, 0, transport::no_progress())
                 .await?;
 
             match layer.media_type.as_str() {
@@ -953,20 +924,30 @@ mod tests {
     }
 
     /// Build a valid image manifest with the given config and layer digests.
+    /// Pads any short hex suffix up to 64 hex characters so the result parses as a real `Digest`.
     fn make_image_manifest(config_digest: &str, layer_digest: &str) -> oci::ImageManifest {
+        fn normalize(d: &str) -> String {
+            match d.strip_prefix("sha256:") {
+                Some(rest) if rest.len() < 64 => {
+                    let padding = "a".repeat(64 - rest.len());
+                    format!("sha256:{rest}{padding}")
+                }
+                _ => d.to_string(),
+            }
+        }
         oci::ImageManifest {
             media_type: Some(MEDIA_TYPE_OCI_IMAGE_MANIFEST.to_string()),
             artifact_type: Some(MEDIA_TYPE_PACKAGE_V1.to_string()),
             config: oci::Descriptor {
                 media_type: MEDIA_TYPE_PACKAGE_METADATA_V1.to_string(),
-                digest: config_digest.to_string(),
+                digest: normalize(config_digest),
                 size: 100,
                 urls: None,
                 annotations: None,
             },
             layers: vec![oci::Descriptor {
                 media_type: crate::MEDIA_TYPE_TAR_GZ.to_string(),
-                digest: layer_digest.to_string(),
+                digest: normalize(layer_digest),
                 size: 200,
                 urls: None,
                 annotations: None,
@@ -978,7 +959,7 @@ mod tests {
     /// Serialize a manifest and compute its digest, returning (bytes, digest_string).
     fn serialize_manifest(manifest: &oci::Manifest) -> (Vec<u8>, String) {
         let data = serde_json::to_vec(manifest).unwrap();
-        let digest = Digest::sha256(&data).to_string();
+        let digest = Algorithm::Sha256.hash(&data).to_string();
         (data, digest)
     }
 
@@ -1038,7 +1019,7 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_manifest_success() {
-        let manifest = oci::Manifest::Image(make_image_manifest("sha256:cfg", "sha256:layer"));
+        let manifest = oci::Manifest::Image(make_image_manifest("sha256:cff", "sha256:1a0e"));
         let (manifest_data, digest_str) = serialize_manifest(&manifest);
 
         let id = test_identifier("1.0");
@@ -1057,7 +1038,7 @@ mod tests {
 
     #[tokio::test]
     async fn pull_manifest_digest_mismatch() {
-        let manifest = oci::Manifest::Image(make_image_manifest("sha256:cfg", "sha256:layer"));
+        let manifest = oci::Manifest::Image(make_image_manifest("sha256:cff", "sha256:1a0e"));
         let (manifest_data, _real_digest) = serialize_manifest(&manifest);
         let wrong_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
 
@@ -1072,7 +1053,7 @@ mod tests {
         let result = client.pull_manifest(&id).await;
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
-        assert!(err_msg.contains("digest mismatch"), "got: {}", err_msg);
+        assert!(err_msg.to_lowercase().contains("digest mismatch"), "got: {}", err_msg);
     }
 
     #[tokio::test]
@@ -1110,7 +1091,7 @@ mod tests {
 
     #[tokio::test]
     async fn pull_manifest_accepts_any_media_types() {
-        let mut m = make_image_manifest("sha256:cfg", "sha256:layer");
+        let mut m = make_image_manifest("sha256:cff", "sha256:1a0e");
         m.config.media_type = "application/vnd.other.config".to_string();
         m.artifact_type = Some("application/vnd.other.artifact".to_string());
         let manifest = oci::Manifest::Image(m);
@@ -1156,7 +1137,7 @@ mod tests {
     async fn pull_metadata_success() {
         let metadata_json = br#"{"type":"bundle","version":1}"#;
         let data = StubTransportData::new();
-        let manifest = make_image_manifest("sha256:cfg", "sha256:layer");
+        let manifest = make_image_manifest("sha256:cff", "sha256:1a0e");
         let id = setup_manifest_and_blob(&data, manifest, metadata_json);
         let client = stub(&data);
 
@@ -1167,7 +1148,7 @@ mod tests {
     #[tokio::test]
     async fn pull_metadata_rejects_wrong_config_media_type() {
         let metadata_json = br#"{"type":"bundle","version":1}"#;
-        let mut manifest = make_image_manifest("sha256:cfg", "sha256:layer");
+        let mut manifest = make_image_manifest("sha256:cff", "sha256:1a0e");
         manifest.config.media_type = "application/vnd.wrong".to_string();
 
         let data = StubTransportData::new();
@@ -1188,7 +1169,7 @@ mod tests {
         let path = dir.path().join("blob");
         tokio::fs::write(&path, b"hello world").await.unwrap();
 
-        let expected = Digest::sha256(b"hello world").to_string();
+        let expected = Algorithm::Sha256.hash(b"hello world");
         verify_blob_digest(&path, &expected).await.unwrap();
         assert!(path.exists(), "matching blob must not be deleted");
     }
@@ -1201,55 +1182,100 @@ mod tests {
 
         // Claim the digest of different bytes — simulating a registry
         // that served different content for the same digest (CWE-345).
-        let expected = Digest::sha256(b"honest bytes").to_string();
+        let expected = Algorithm::Sha256.hash(b"honest bytes");
+        let expected_str = expected.to_string();
 
         let err = verify_blob_digest(&path, &expected).await.unwrap_err();
         match err {
             ClientError::DigestMismatch { expected: e, actual } => {
-                assert_eq!(e, expected);
-                assert_ne!(actual, expected);
+                assert_eq!(e, expected_str);
+                assert_ne!(actual, expected_str);
             }
             other => panic!("expected DigestMismatch, got {other:?}"),
         }
         assert!(!path.exists(), "tampered blob must be deleted");
     }
 
-    // ── pull_content tests ──────────────────────────────────────
-
     #[tokio::test]
-    async fn pull_content_rejects_wrong_artifact_type() {
-        let mut manifest = make_image_manifest("sha256:cfg", "sha256:layer");
-        manifest.artifact_type = Some("application/vnd.wrong".to_string());
-
-        let data = StubTransportData::new();
-        let id = setup_manifest_and_blob(&data, manifest.clone(), b"{}");
-        let client = stub(&data);
-
-        let metadata: metadata::Metadata = serde_json::from_str(r#"{"type":"bundle","version":1}"#).unwrap();
+    async fn verify_blob_digest_accepts_sha512_match() {
+        // Regression for algorithm-blind verify: before the fix, any
+        // non-SHA256 expected digest would be hashed with SHA-256 and
+        // produce a spurious DigestMismatch even on honest bytes.
         let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        let data = b"hello world".to_vec();
+        tokio::fs::write(&path, &data).await.unwrap();
 
-        match client.pull_content(&id, Some(&manifest), &metadata, dir.path()).await {
-            Err(e) => assert!(e.to_string().contains("Invalid manifest"), "got: {}", e),
-            Ok(_) => panic!("should reject wrong artifact type"),
-        }
+        let expected = Digest::Sha512(hex::encode(<sha2::Sha512 as sha2::Digest>::digest(&data)));
+        verify_blob_digest(&path, &expected).await.unwrap();
+        assert!(path.exists(), "matching blob must not be deleted");
     }
 
     #[tokio::test]
-    async fn pull_content_rejects_empty_layers() {
-        let mut manifest = make_image_manifest("sha256:cfg", "sha256:layer");
-        manifest.layers.clear();
+    async fn verify_blob_digest_rejects_sha512_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        tokio::fs::write(&path, b"evil bytes").await.unwrap();
+
+        // A real SHA-512 of "honest bytes" — the verify path must
+        // compute SHA-512 of the file (not SHA-256) and still report
+        // a clean mismatch when the bytes differ.
+        let expected = Digest::Sha512(hex::encode(<sha2::Sha512 as sha2::Digest>::digest(b"honest bytes")));
+        let err = verify_blob_digest(&path, &expected).await.unwrap_err();
+        match err {
+            ClientError::DigestMismatch { expected: e, actual } => {
+                assert!(e.starts_with("sha512:"), "expected algorithm preserved in error: {e}");
+                assert!(
+                    actual.starts_with("sha512:"),
+                    "actual must also be SHA-512, got: {actual}"
+                );
+                assert_ne!(e, actual);
+            }
+            other => panic!("expected DigestMismatch, got {other:?}"),
+        }
+        assert!(!path.exists(), "tampered blob must be deleted");
+    }
+
+    // ── pull_layer tests ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn pull_layer_rejects_bytes_not_matching_descriptor_digest() {
+        // Claim a digest for bytes that hash to something else — simulates
+        // a registry serving different content for the declared digest
+        // (CWE-345). `pull_layer` must surface `DigestMismatch` and leave
+        // no blob file on disk (verify_blob_digest's unlink invariant).
+        let claimed_digest = format!("sha256:{}", "a".repeat(64));
+        let evil_bytes = b"bytes that definitely do not hash to all-a".to_vec();
 
         let data = StubTransportData::new();
-        let id = setup_manifest_and_blob(&data, manifest.clone(), b"{}");
+        data.write().blobs.insert(claimed_digest.clone(), evil_bytes);
         let client = stub(&data);
 
+        let id = test_pinned("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let layer = oci::Descriptor {
+            media_type: crate::MEDIA_TYPE_TAR_GZ.to_string(),
+            digest: claimed_digest.clone(),
+            size: 0,
+            urls: None,
+            annotations: None,
+        };
         let metadata: metadata::Metadata = serde_json::from_str(r#"{"type":"bundle","version":1}"#).unwrap();
         let dir = tempfile::tempdir().unwrap();
 
-        match client.pull_content(&id, Some(&manifest), &metadata, dir.path()).await {
-            Err(e) => assert!(e.to_string().contains("no layers"), "got: {}", e),
-            Ok(_) => panic!("should reject empty layers"),
+        let result = client.pull_layer(&id, &layer, &metadata, dir.path()).await;
+        match result {
+            Err(ClientError::DigestMismatch { expected, actual }) => {
+                assert_eq!(expected, claimed_digest);
+                assert_ne!(actual, claimed_digest);
+            }
+            other => panic!("expected DigestMismatch, got {other:?}"),
         }
+
+        let blob_path = dir.path().join("content.tar.gz");
+        assert!(
+            !blob_path.exists(),
+            "tampered layer blob must be unlinked after digest mismatch"
+        );
     }
 
     // ── TempStore tests ─────────────────────────────────────────────
@@ -1375,7 +1401,7 @@ mod tests {
                 annotations: None,
             };
             let existing_bytes = serde_json::to_vec(&oci::Manifest::ImageIndex(existing)).unwrap();
-            let existing_digest = oci::Digest::sha256(&existing_bytes).to_string();
+            let existing_digest = oci::Algorithm::Sha256.hash(&existing_bytes).to_string();
             data.write().manifests.insert(
                 native::Reference::from(&id).to_string(),
                 (existing_bytes, existing_digest),
@@ -1413,7 +1439,7 @@ mod tests {
                 annotations: None,
             };
             let existing_bytes = serde_json::to_vec(&oci::Manifest::ImageIndex(existing)).unwrap();
-            let existing_digest = oci::Digest::sha256(&existing_bytes).to_string();
+            let existing_digest = oci::Algorithm::Sha256.hash(&existing_bytes).to_string();
             data.write().manifests.insert(
                 native::Reference::from(&id).to_string(),
                 (existing_bytes, existing_digest),
@@ -1449,7 +1475,7 @@ mod tests {
             };
             let manifest = oci::Manifest::Image(image_manifest);
             let manifest_bytes = serde_json::to_vec(&manifest).unwrap();
-            let manifest_digest = oci::Digest::sha256(&manifest_bytes).to_string();
+            let manifest_digest = oci::Algorithm::Sha256.hash(&manifest_bytes).to_string();
             data.write().manifests.insert(
                 native::Reference::from(&id).to_string(),
                 (manifest_bytes.clone(), manifest_digest.clone()),
@@ -1583,7 +1609,7 @@ mod tests {
 
         #[tokio::test]
         async fn fetch_manifest_authenticates_with_pull() {
-            let manifest = oci::Manifest::Image(make_image_manifest("sha256:cfg", "sha256:layer"));
+            let manifest = oci::Manifest::Image(make_image_manifest("sha256:cff", "sha256:1a0e"));
             let (manifest_data, digest_str) = serialize_manifest(&manifest);
 
             let id = test_identifier("1.0");
@@ -1842,6 +1868,110 @@ mod tests {
                 msg.contains("not found") || msg.contains("blob"),
                 "error message should mention not-found / blob, got: {msg}"
             );
+        }
+
+        /// A `LayerRef::File` with an unrecognized extension must be
+        /// rejected with `InvalidManifest` before any network I/O.
+        /// Without this guard the push path would stamp `media_type = "blob"`
+        /// or silently default to tar+gzip, shipping a manifest that no
+        /// consumer can extract.
+        #[tokio::test]
+        async fn unknown_file_extension_is_rejected() {
+            let dir = tempfile::tempdir().unwrap();
+            let weird_path = dir.path().join("archive.bogus");
+            tokio::fs::write(&weird_path, b"irrelevant bytes").await.unwrap();
+
+            let data = StubTransportData::new();
+            let client = stub_with_capture(&data);
+
+            let layers = [LayerRef::File(weird_path)];
+            let err = client
+                .push_multi_layer_manifest(&info("1.0.0"), &layers)
+                .await
+                .expect_err("unknown extensions must fail before push");
+
+            assert!(
+                matches!(err, ClientError::InvalidManifest(_)),
+                "expected InvalidManifest, got {err:?}"
+            );
+        }
+    }
+
+    // ── Cascade tag ordering ────────────────────────────────────────
+
+    /// `push_manifest_and_merge_tags` must push the manifest once, then
+    /// merge the resulting platform entry into the primary tag's index
+    /// and into each `extra_tags` entry in input order. The order of
+    /// recorded transport calls is what OCX clients actually observe —
+    /// tests over that contract prevent silent reorderings that would
+    /// leave earlier tags pointing at stale indexes.
+    mod cascade_order {
+        use super::*;
+        use crate::publisher::LayerRef;
+
+        fn test_identifier(tag: &str) -> Identifier {
+            Identifier::new_registry("test/pkg", "example.com").clone_with_tag(tag)
+        }
+
+        fn stub_with_capture(data: &StubTransportData) -> Client {
+            data.write().capture_pushes = true;
+            Client::with_transport(Box::new(StubTransport::new(data.clone())))
+        }
+
+        fn info(tag: &str) -> Info {
+            Info {
+                identifier: test_identifier(tag),
+                metadata: metadata::Metadata::Bundle(package::metadata::bundle::Bundle {
+                    version: package::metadata::bundle::Version::V1,
+                    strip_components: None,
+                    env: Default::default(),
+                    dependencies: Default::default(),
+                }),
+                platform: "linux/amd64".parse().unwrap(),
+            }
+        }
+
+        #[tokio::test]
+        async fn push_manifest_and_merge_tags_processes_tags_in_input_order() {
+            let dir = tempfile::tempdir().unwrap();
+            let archive_path = dir.path().join("pkg.tar.gz");
+            tokio::fs::write(&archive_path, b"fake-archive").await.unwrap();
+
+            let data = StubTransportData::new();
+            let client = stub_with_capture(&data);
+
+            let layers = [LayerRef::File(archive_path)];
+            let extra_tags = ["3".to_string(), "latest".to_string()];
+            client
+                .push_manifest_and_merge_tags(&info("1.2.3"), &layers, &extra_tags)
+                .await
+                .expect("push should succeed");
+
+            // Extract only push_manifest / push_manifest_raw / pull_manifest_raw
+            // calls from the recorded transport log — those are the ordered
+            // high-level operations we care about here.
+            let relevant: Vec<String> = data
+                .read()
+                .calls
+                .iter()
+                .filter(|c| *c == "push_manifest" || *c == "push_manifest_raw" || *c == "pull_manifest_raw")
+                .cloned()
+                .collect();
+
+            // Expected cascade: push the image manifest once, then for
+            // each tag (primary, "3", "latest") pull (attempt to read
+            // existing index) + push_manifest_raw (write updated index).
+            // Ordering must be stable across every run.
+            let expected = vec![
+                "push_manifest_raw", // the image manifest itself
+                "pull_manifest_raw", // primary tag existing index lookup
+                "push_manifest_raw", // primary tag index push
+                "pull_manifest_raw", // extra_tags[0] lookup
+                "push_manifest_raw", // extra_tags[0] push
+                "pull_manifest_raw", // extra_tags[1] lookup
+                "push_manifest_raw", // extra_tags[1] push
+            ];
+            assert_eq!(relevant, expected, "cascade calls must follow input tag order");
         }
     }
 }

--- a/crates/ocx_lib/src/oci/client.rs
+++ b/crates/ocx_lib/src/oci/client.rs
@@ -608,7 +608,7 @@ impl Client {
                         log::trace!("Layer {}: verified, media_type={}, size={}", digest, media_type, size);
 
                         Ok(oci::Descriptor {
-                            media_type: (*media_type).to_string(),
+                            media_type: media_type.as_media_type().to_string(),
                             digest: digest.to_string(),
                             size: size as i64,
                             urls: None,
@@ -1775,7 +1775,7 @@ mod tests {
 
             let layers = [LayerRef::Digest {
                 digest: oci::Digest::try_from(layer_digest).unwrap(),
-                media_type: crate::MEDIA_TYPE_TAR_XZ,
+                media_type: crate::publisher::ArchiveMediaType::TarXz,
             }];
             let (manifest, _bytes, _digest) = client
                 .push_multi_layer_manifest(&info("2.0.0"), &layers)
@@ -1816,7 +1816,7 @@ mod tests {
 
             let layers = [LayerRef::Digest {
                 digest: oci::Digest::try_from(missing_digest).unwrap(),
-                media_type: crate::MEDIA_TYPE_TAR_GZ,
+                media_type: crate::publisher::ArchiveMediaType::TarGz,
             }];
             let err = client
                 .push_multi_layer_manifest(&info("2.0.0"), &layers)

--- a/crates/ocx_lib/src/oci/client.rs
+++ b/crates/ocx_lib/src/oci/client.rs
@@ -11,9 +11,16 @@ use crate::{
     utility,
 };
 
+use futures::stream::{self, StreamExt, TryStreamExt};
 use tracing::Instrument;
 
 use super::{Digest, Identifier, native};
+
+/// Maximum number of layer push/verify operations to run concurrently.
+///
+/// Each `LayerRef::File` reads the full archive into memory before
+/// uploading, so unbounded fan-out would OOM on multi-GB layers.
+const LAYER_PUSH_CONCURRENCY: usize = 4;
 
 mod builder;
 pub mod error;
@@ -451,19 +458,18 @@ impl Client {
     pub async fn push_package(
         &self,
         package_info: Info,
-        file: impl AsRef<std::path::Path>,
+        layers: &[crate::publisher::LayerRef],
     ) -> Result<(Digest, oci::Manifest)> {
-        let path = file.as_ref();
         log::debug!(
-            "Pushing package {} from file {}",
+            "Pushing package {} with {} layer(s)",
             package_info.identifier,
-            path.display()
+            layers.len()
         );
 
         let image = native::Reference::from(&package_info.identifier);
         self.transport.ensure_auth(&image, oci::RegistryOperation::Push).await?;
 
-        let (manifest, manifest_data, manifest_sha256) = self.push_image_manifest(&package_info, path).await?;
+        let (manifest, manifest_data, manifest_sha256) = self.push_multi_layer_manifest(&package_info, layers).await?;
 
         let (index_digest, index) = self
             .update_image_index(&package_info, &manifest_data, &manifest_sha256)
@@ -473,47 +479,106 @@ impl Client {
         Ok((index_digest, oci::Manifest::ImageIndex(index)))
     }
 
-    /// Pushes config blob + package blob + image manifest. Returns the manifest,
-    /// its serialized bytes, and its SHA-256 digest string.
-    pub(crate) async fn push_image_manifest(
+    /// Pushes config blob + N layer blobs + image manifest.
+    ///
+    /// For `LayerRef::File` layers: reads file, computes digest, uploads blob.
+    /// For `LayerRef::Digest` layers: HEADs the blob to verify existence
+    /// and learn its size, and uses the caller-supplied `media_type`
+    /// for the manifest descriptor. The OCI spec does not expose a
+    /// layer's media type via blob HEAD, so the caller is responsible
+    /// for declaring it at the CLI (see `LayerRef::FromStr`).
+    /// Returns the manifest, its serialized bytes, and its SHA-256 digest string.
+    pub(crate) async fn push_multi_layer_manifest(
         &self,
         package_info: &Info,
-        path: &std::path::Path,
+        layers: &[crate::publisher::LayerRef],
     ) -> std::result::Result<(oci::ImageManifest, Vec<u8>, String), ClientError> {
+        use crate::publisher::LayerRef;
+
+        if layers.is_empty() {
+            return Err(ClientError::InvalidManifest(
+                "package must have at least one layer".to_string(),
+            ));
+        }
+
         let image = native::Reference::from(&package_info.identifier);
 
-        let package_media_type = media_type_from_path(path)
-            .map(|mt| mt.to_string())
-            .ok_or_else(|| ClientError::InvalidManifest(format!("unsupported archive: {}", path.display())))?;
+        // Upload file layers and verify digest layers concurrently, preserving
+        // input order so manifest descriptors match the caller-supplied order.
+        // Bounded by `LAYER_PUSH_CONCURRENCY` to cap in-memory archive buffers.
+        let layer_descriptors: Vec<oci::Descriptor> = stream::iter(layers.iter())
+            .map(|layer| async {
+                match layer {
+                    LayerRef::File(path) => {
+                        let package_media_type =
+                            media_type_from_path(path).map(|mt| mt.to_string()).ok_or_else(|| {
+                                ClientError::InvalidManifest(format!("unsupported archive: {}", path.display()))
+                            })?;
 
-        let package_data = tokio::fs::read(path).await.map_err(|e| ClientError::Io {
-            path: path.to_path_buf(),
-            source: e,
-        })?;
-        let package_data_len = package_data.len();
-        let package_digest = Digest::sha256(&package_data).to_string();
+                        let package_data = tokio::fs::read(path).await.map_err(|e| ClientError::Io {
+                            path: path.to_path_buf(),
+                            source: e,
+                        })?;
+                        let package_data_len = package_data.len();
+                        let package_digest = Digest::sha256(&package_data).to_string();
 
-        log::trace!("Calculated package digest: {}", package_digest);
+                        log::trace!(
+                            "Layer {}: digest={}, size={}",
+                            path.display(),
+                            package_digest,
+                            package_data_len
+                        );
 
-        {
-            let bar = crate::cli::progress::ProgressBar::bytes(
-                tracing::info_span!("Uploading", package = %package_info.identifier),
-                package_data_len as u64,
-                &package_info.identifier,
-            );
-            let on_progress = bar.callback();
+                        let bar = crate::cli::progress::ProgressBar::bytes(
+                            tracing::info_span!("Uploading", layer = %path.display()),
+                            package_data_len as u64,
+                            &package_info.identifier,
+                        );
+                        let on_progress = bar.callback();
+                        let span = bar.into_span();
+                        self.transport
+                            .push_blob(&image, package_data, &package_digest, on_progress)
+                            .instrument(span)
+                            .await?;
 
-            let _guard = bar.enter();
-            self.transport
-                .push_blob(&image, package_data, &package_digest, on_progress)
-                .await?;
-        }
+                        Ok::<oci::Descriptor, ClientError>(oci::Descriptor {
+                            media_type: package_media_type,
+                            digest: package_digest,
+                            size: package_data_len as i64,
+                            urls: None,
+                            annotations: None,
+                        })
+                    }
+                    LayerRef::Digest { digest, media_type } => {
+                        // The caller supplies `media_type` because the OCI
+                        // distribution spec does not expose a layer's media
+                        // type via blob HEAD — only the blob bytes and
+                        // Content-Length. See `LayerRef::FromStr` for the
+                        // `sha256:<hex>.<ext>` CLI syntax that carries this
+                        // information from the user to here.
+                        let size = self.transport.head_blob(&image, &digest.to_string()).await?;
+
+                        log::trace!("Layer {}: verified, media_type={}, size={}", digest, media_type, size);
+
+                        Ok(oci::Descriptor {
+                            media_type: (*media_type).to_string(),
+                            digest: digest.to_string(),
+                            size: size as i64,
+                            urls: None,
+                            annotations: None,
+                        })
+                    }
+                }
+            })
+            .buffered(LAYER_PUSH_CONCURRENCY)
+            .try_collect()
+            .await?;
 
         // Config blob — tiny, no progress needed.
         let config_data = serde_json::to_vec(&package_info.metadata).map_err(ClientError::Serialization)?;
         let config_data_len = config_data.len();
         let config_sha256 = Digest::sha256(&config_data).to_string();
-        log::trace!("Calculated config digest: {}", config_sha256);
+        log::trace!("Config digest: {}", config_sha256);
         self.transport
             .push_blob(&image, config_data, &config_sha256, transport::no_progress())
             .await?;
@@ -528,13 +593,7 @@ impl Client {
                 urls: None,
                 annotations: None,
             },
-            layers: vec![oci::Descriptor {
-                media_type: package_media_type,
-                digest: package_digest,
-                size: package_data_len as i64,
-                urls: None,
-                annotations: None,
-            }],
+            layers: layer_descriptors,
             annotations: None,
             ..Default::default()
         };
@@ -1480,7 +1539,8 @@ mod tests {
                 platform: "linux/amd64".parse().unwrap(),
             };
 
-            let _ = client.push_package(info, &archive_path).await;
+            let layers = [crate::publisher::LayerRef::File(archive_path)];
+            let _ = client.push_package(info, &layers).await;
             let calls = auth_calls(&data);
             // Must authenticate with Push before any blob/manifest operations.
             assert!(!calls.is_empty(), "push_package must call ensure_auth");
@@ -1554,7 +1614,8 @@ mod tests {
                 platform: "linux/amd64".parse().unwrap(),
             };
 
-            let _ = client.push_package(info, &archive_path).await;
+            let layers = [crate::publisher::LayerRef::File(archive_path)];
+            let _ = client.push_package(info, &layers).await;
 
             // Verify auth happened before any transport method calls.
             let inner = data.read();
@@ -1565,6 +1626,126 @@ mod tests {
                 inner.calls.iter().any(|c| c.starts_with("push_blob:")),
                 "push_blob should follow ensure_auth, calls: {:?}",
                 inner.calls
+            );
+        }
+    }
+
+    // ── Multi-layer digest reuse tests ──────────────────────────────
+    //
+    // Regression test for the fabricated-`tar+gzip` bug on the
+    // `LayerRef::Digest` path. Before this fix, the push code
+    // unconditionally stamped `application/vnd.oci.image.layer.v1.tar+gzip`
+    // on every digest-referenced layer, so reusing a `.tar.xz` or
+    // `.zip` layer produced a manifest that broke every consumer's
+    // `package pull`.
+    //
+    // The fix makes the CLI declare the media type alongside the
+    // digest (see `LayerRef::FromStr`'s `sha256:<hex>.<ext>` syntax)
+    // and threads it straight into the manifest descriptor. These
+    // tests assert the supplied media type round-trips unchanged.
+
+    mod multi_layer_digest_resolve {
+        use super::*;
+        use crate::package::{self, info::Info, metadata};
+        use crate::publisher::LayerRef;
+
+        fn test_identifier(tag: &str) -> Identifier {
+            Identifier::new_registry("test/pkg", "example.com").clone_with_tag(tag)
+        }
+
+        fn stub_with_capture(data: &StubTransportData) -> Client {
+            data.write().capture_pushes = true;
+            Client::with_transport(Box::new(StubTransport::new(data.clone())))
+        }
+
+        fn bundle_metadata() -> metadata::Metadata {
+            metadata::Metadata::Bundle(package::metadata::bundle::Bundle {
+                version: package::metadata::bundle::Version::V1,
+                strip_components: None,
+                env: Default::default(),
+                dependencies: Default::default(),
+            })
+        }
+
+        fn info(tag: &str) -> Info {
+            Info {
+                identifier: test_identifier(tag),
+                metadata: bundle_metadata(),
+                platform: "linux/amd64".parse().unwrap(),
+            }
+        }
+
+        /// A digest-referenced layer must carry the media type declared
+        /// by the caller, not a fabricated `tar+gzip`. Regression for
+        /// the original Bug 2.
+        #[tokio::test]
+        async fn digest_layer_uses_supplied_media_type_tar_xz() {
+            let layer_digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+            let layer_size: i64 = 4096;
+
+            let data = StubTransportData::new();
+            // The stub's `head_blob` returns the length of whatever
+            // bytes we seed under this digest, so the size in the
+            // resulting manifest descriptor will match.
+            data.write()
+                .blobs
+                .insert(layer_digest.to_string(), vec![0u8; layer_size as usize]);
+            let client = stub_with_capture(&data);
+
+            let layers = [LayerRef::Digest {
+                digest: oci::Digest::try_from(layer_digest).unwrap(),
+                media_type: crate::MEDIA_TYPE_TAR_XZ,
+            }];
+            let (manifest, _bytes, _digest) = client
+                .push_multi_layer_manifest(&info("2.0.0"), &layers)
+                .await
+                .expect("push_multi_layer_manifest must succeed with a live blob and declared media type");
+
+            assert_eq!(manifest.layers.len(), 1);
+            assert_eq!(
+                manifest.layers[0].media_type,
+                crate::MEDIA_TYPE_TAR_XZ,
+                "the manifest must carry the caller-declared media type verbatim — no tar+gzip fabrication"
+            );
+            assert_eq!(manifest.layers[0].size, layer_size);
+            assert_eq!(manifest.layers[0].digest, layer_digest);
+
+            // `head_blob` should still be called — it's the transport-
+            // level contract for fetching the blob's size. The Bug 1
+            // fix ensures its native implementation reads
+            // `Content-Length` from a real HEAD rather than pulling
+            // the whole blob into memory.
+            let inner = data.read();
+            assert!(
+                inner.calls.iter().any(|c| c == &format!("head_blob:{layer_digest}")),
+                "head_blob should be called exactly once to fetch the layer size, calls: {:?}",
+                inner.calls
+            );
+        }
+
+        /// When the requested digest blob does not exist in the
+        /// registry, the push must fail with `BlobNotFound` surfaced by
+        /// `head_blob`.
+        #[tokio::test]
+        async fn digest_layer_not_found_in_registry_errors() {
+            let missing_digest = "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+
+            let data = StubTransportData::new();
+            let client = stub_with_capture(&data);
+
+            let layers = [LayerRef::Digest {
+                digest: oci::Digest::try_from(missing_digest).unwrap(),
+                media_type: crate::MEDIA_TYPE_TAR_GZ,
+            }];
+            let err = client
+                .push_multi_layer_manifest(&info("2.0.0"), &layers)
+                .await
+                .expect_err("push must fail when the referenced blob is absent");
+
+            let msg = err.to_string().to_lowercase();
+            assert!(
+                msg.contains("not found") || msg.contains("blob"),
+                "error message should mention not-found / blob, got: {msg}"
             );
         }
     }

--- a/crates/ocx_lib/src/oci/client.rs
+++ b/crates/ocx_lib/src/oci/client.rs
@@ -562,12 +562,26 @@ impl Client {
                                 ClientError::InvalidManifest(format!("unsupported archive: {}", path.display()))
                             })?;
 
+                        // BOUNDED: LAYER_PUSH_CONCURRENCY caps simultaneous
+                        // in-memory archives at 4 × (layer size). Do not raise
+                        // the constant without either switching to a streaming
+                        // push path or auditing the RSS budget for the largest
+                        // layers callers ship.
                         let package_data = tokio::fs::read(path).await.map_err(|e| ClientError::Io {
                             path: path.to_path_buf(),
                             source: e,
                         })?;
                         let package_data_len = package_data.len();
-                        let package_digest = Digest::sha256(&package_data).to_string();
+                        // Hash on a blocking thread: Digest::sha256 is
+                        // CPU-bound over potentially hundreds of MB and
+                        // would otherwise stall the Tokio executor mid-
+                        // `buffered()` stream.
+                        let (package_data, package_digest) = tokio::task::spawn_blocking(move || {
+                            let digest = Digest::sha256(&package_data).to_string();
+                            (package_data, digest)
+                        })
+                        .await
+                        .map_err(|e| ClientError::Internal(Box::new(e)))?;
 
                         log::trace!(
                             "Layer {}: digest={}, size={}",

--- a/crates/ocx_lib/src/oci/client.rs
+++ b/crates/ocx_lib/src/oci/client.rs
@@ -35,6 +35,49 @@ pub use transport::OciTransport;
 
 use error::ClientError;
 
+/// Verifies that a blob on disk hashes to its claimed digest.
+///
+/// Streams the file through SHA-256 and compares against `expected`
+/// (an OCI digest string like `sha256:<hex>`). On mismatch, removes
+/// the blob and returns [`ClientError::DigestMismatch`]. This defends
+/// against a compromised or misbehaving registry serving different
+/// bytes for the same digest (CWE-345).
+///
+/// This is the **second line of defense** against bad registry
+/// responses. The first line is the archive walker in
+/// `utility::fs::assemble`, which validates the on-disk structure
+/// (entry count caps, depth caps, symlink containment, overlap
+/// detection) during extraction. The walker catches malformed or
+/// malicious *archive contents*; this function catches the narrower
+/// case of a registry serving different bytes for the same digest —
+/// i.e. a digest/bytes mismatch that the walker cannot see because
+/// it operates after extraction.
+async fn verify_blob_digest(blob_path: &std::path::Path, expected: &str) -> std::result::Result<(), ClientError> {
+    let actual = Digest::sha256_file(blob_path).await.map_err(|e| ClientError::Io {
+        path: blob_path.to_path_buf(),
+        source: e,
+    })?;
+    if actual.to_string() == expected {
+        return Ok(());
+    }
+    // Best-effort cleanup of the tampered blob so a subsequent pull
+    // retries from the registry instead of re-reading the bad bytes.
+    // The primary error reported to the caller is the digest
+    // mismatch; a failure to unlink is logged for diagnostics but
+    // must not mask it.
+    if let Err(e) = tokio::fs::remove_file(blob_path).await {
+        log::debug!(
+            "failed to remove tampered blob at {} after digest mismatch: {}",
+            blob_path.display(),
+            e
+        );
+    }
+    Err(ClientError::DigestMismatch {
+        expected: expected.to_string(),
+        actual: actual.to_string(),
+    })
+}
+
 pub struct Client {
     transport: Box<dyn OciTransport>,
     pub(super) lock_timeout: std::time::Duration,
@@ -340,6 +383,8 @@ impl Client {
                 .await?;
         }
 
+        verify_blob_digest(&blob_path, &blob_layer.digest).await?;
+
         self.extract_to_temp(identifier, metadata, blob_compression, blob_file_ext, output_dir)
             .await?;
 
@@ -398,6 +443,8 @@ impl Client {
                 .pull_blob_to_file(&image, &layer.digest, &blob_path, blob_total_size, on_progress)
                 .await?;
         }
+
+        verify_blob_digest(&blob_path, &layer.digest).await?;
 
         // Extract archive + codesign.
         self.extract_to_temp(identifier, metadata, blob_compression, blob_file_ext, output_dir)
@@ -1117,6 +1164,40 @@ mod tests {
         assert!(result.is_err());
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("Invalid manifest"), "got: {}", err_msg);
+    }
+
+    // ── verify_blob_digest tests ────────────────────────────────
+
+    #[tokio::test]
+    async fn verify_blob_digest_accepts_matching_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        tokio::fs::write(&path, b"hello world").await.unwrap();
+
+        let expected = Digest::sha256(b"hello world").to_string();
+        verify_blob_digest(&path, &expected).await.unwrap();
+        assert!(path.exists(), "matching blob must not be deleted");
+    }
+
+    #[tokio::test]
+    async fn verify_blob_digest_rejects_tampered_content_and_deletes_blob() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        tokio::fs::write(&path, b"evil bytes").await.unwrap();
+
+        // Claim the digest of different bytes — simulating a registry
+        // that served different content for the same digest (CWE-345).
+        let expected = Digest::sha256(b"honest bytes").to_string();
+
+        let err = verify_blob_digest(&path, &expected).await.unwrap_err();
+        match err {
+            ClientError::DigestMismatch { expected: e, actual } => {
+                assert_eq!(e, expected);
+                assert_ne!(actual, expected);
+            }
+            other => panic!("expected DigestMismatch, got {other:?}"),
+        }
+        assert!(!path.exists(), "tampered blob must be deleted");
     }
 
     // ── pull_content tests ──────────────────────────────────────

--- a/crates/ocx_lib/src/oci/client/error.rs
+++ b/crates/ocx_lib/src/oci/client/error.rs
@@ -23,8 +23,13 @@ pub enum ClientError {
     #[error("Manifest not found: {0}")]
     ManifestNotFound(String),
     /// A referenced blob does not exist in the registry.
-    #[error("Blob not found in registry '{registry}': {digest}")]
-    BlobNotFound { registry: String, digest: String },
+    ///
+    /// `digest_str` is the stringified OCI digest (e.g.
+    /// `sha256:<hex>`). It is already flattened from [`crate::oci::Digest`]
+    /// at the call site, so the field name reflects that callers
+    /// cannot assume it is re-parseable back into a structured type.
+    #[error("Blob not found in registry '{registry}': {digest_str}")]
+    BlobNotFound { registry: String, digest_str: String },
     /// A registry operation failed.
     #[error("Registry operation failed: {0}")]
     Registry(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/crates/ocx_lib/src/oci/client/error.rs
+++ b/crates/ocx_lib/src/oci/client/error.rs
@@ -22,6 +22,9 @@ pub enum ClientError {
     /// The requested manifest does not exist in the registry.
     #[error("Manifest not found: {0}")]
     ManifestNotFound(String),
+    /// A referenced blob does not exist in the registry.
+    #[error("Blob not found in registry '{registry}': {digest}")]
+    BlobNotFound { registry: String, digest: String },
     /// A registry operation failed.
     #[error("Registry operation failed: {0}")]
     Registry(#[source] Box<dyn std::error::Error + Send + Sync>),

--- a/crates/ocx_lib/src/oci/client/error.rs
+++ b/crates/ocx_lib/src/oci/client/error.rs
@@ -3,6 +3,8 @@
 
 use std::path::PathBuf;
 
+use crate::oci::{Digest, Identifier, PinnedIdentifier, native};
+
 /// Errors that can occur during OCI client operations.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -10,8 +12,9 @@ pub enum ClientError {
     /// Authentication with the registry failed.
     #[error("Registry authentication failed: {0}")]
     Authentication(#[source] Box<dyn std::error::Error + Send + Sync>),
-    /// Manifest digest mismatch between expected and actual.
-    #[error("Manifest digest mismatch: expected '{expected}', got '{actual}'")]
+    /// Digest mismatch between expected and actual content hash.
+    /// Fires for manifest digests and for verified blob digests.
+    #[error("Digest mismatch: expected '{expected}', got '{actual}'")]
     DigestMismatch { expected: String, actual: String },
     /// Expected an image manifest but got an image index or unknown type.
     #[error("Expected an image manifest, got an image index")]
@@ -24,12 +27,13 @@ pub enum ClientError {
     ManifestNotFound(String),
     /// A referenced blob does not exist in the registry.
     ///
-    /// `digest_str` is the stringified OCI digest (e.g.
-    /// `sha256:<hex>`). It is already flattened from [`crate::oci::Digest`]
-    /// at the call site, so the field name reflects that callers
-    /// cannot assume it is re-parseable back into a structured type.
-    #[error("Blob not found in registry '{registry}': {digest_str}")]
-    BlobNotFound { registry: String, digest_str: String },
+    /// The identifier is the canonical OCX `registry/repository[:tag]@digest`
+    /// form: the registry + repository of the image the lookup was
+    /// issued against, plus the missing blob's digest. The advisory
+    /// tag (when present) is the tag of the image that triggered the
+    /// blob resolution — not the blob itself.
+    #[error("Blob not found: {0}")]
+    BlobNotFound(PinnedIdentifier),
     /// A registry operation failed.
     #[error("Registry operation failed: {0}")]
     Registry(#[source] Box<dyn std::error::Error + Send + Sync>),
@@ -55,5 +59,33 @@ impl ClientError {
     /// Wrap any error as a [`ClientError::Internal`].
     pub fn internal(error: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self::Internal(Box::new(error))
+    }
+
+    /// Builds a [`ClientError::BlobNotFound`] from the image the lookup
+    /// was issued against and the missing blob's digest.
+    ///
+    /// The image's own digest (if any) is dropped — the stored identifier
+    /// carries the *blob* digest, which is what was actually missing.
+    /// Falls back to [`ClientError::Registry`] if the image reference
+    /// cannot produce a well-formed [`PinnedIdentifier`]. This path is
+    /// unreachable after a HEAD succeeded against the registry: the
+    /// transport has already used `image` to issue a real HTTP request,
+    /// so the reference is known-valid by construction. The debug
+    /// assertions fire loudly in dev builds to catch any regression.
+    pub fn blob_not_found(image: &native::Reference, blob_digest: &Digest) -> Self {
+        let identifier = match Identifier::try_from(image.clone()) {
+            Ok(id) => id.clone_with_digest(blob_digest.clone()),
+            Err(e) => {
+                debug_assert!(false, "unreachable after HEAD succeeded: {e}");
+                return Self::Registry(Box::new(e));
+            }
+        };
+        match PinnedIdentifier::try_from(identifier) {
+            Ok(pinned) => Self::BlobNotFound(pinned),
+            Err(e) => {
+                debug_assert!(false, "unreachable after HEAD succeeded: {e}");
+                Self::Registry(Box::new(e))
+            }
+        }
     }
 }

--- a/crates/ocx_lib/src/oci/client/native_transport.rs
+++ b/crates/ocx_lib/src/oci/client/native_transport.rs
@@ -201,7 +201,7 @@ impl OciTransport for NativeTransport {
             Ok(Some(size)) => Ok(size),
             Ok(None) => Err(ClientError::BlobNotFound {
                 registry: image.registry().to_string(),
-                digest: digest.to_string(),
+                digest_str: digest.to_string(),
             }),
             Err(e) => Err(registry_error(e)),
         }

--- a/crates/ocx_lib/src/oci/client/native_transport.rs
+++ b/crates/ocx_lib/src/oci/client/native_transport.rs
@@ -195,6 +195,18 @@ impl OciTransport for NativeTransport {
             .map_err(registry_error)
     }
 
+    async fn head_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<u64> {
+        log::debug!("HEAD blob {} for image {}", digest, image);
+        match self.client.fetch_blob_size(image, digest).await {
+            Ok(Some(size)) => Ok(size),
+            Ok(None) => Err(ClientError::BlobNotFound {
+                registry: image.registry().to_string(),
+                digest: digest.to_string(),
+            }),
+            Err(e) => Err(registry_error(e)),
+        }
+    }
+
     async fn push_manifest(&self, image: &oci::native::Reference, manifest: &oci::Manifest) -> Result<String> {
         self.client.push_manifest(image, manifest).await.map_err(registry_error)
     }

--- a/crates/ocx_lib/src/oci/client/native_transport.rs
+++ b/crates/ocx_lib/src/oci/client/native_transport.rs
@@ -159,11 +159,12 @@ impl OciTransport for NativeTransport {
         Ok((data.to_vec(), digest))
     }
 
-    async fn pull_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<Vec<u8>> {
-        log::debug!("Pulling blob {} for image {} into memory", digest, image);
+    async fn pull_blob(&self, image: &oci::native::Reference, digest: &oci::Digest) -> Result<Vec<u8>> {
+        let digest_str = digest.to_string();
+        log::debug!("Pulling blob {} for image {} into memory", digest_str, image);
         let mut buf = Vec::new();
         self.client
-            .pull_blob(image, digest, &mut buf)
+            .pull_blob(image, digest_str.as_str(), &mut buf)
             .await
             .map_err(registry_error)?;
         Ok(buf)
@@ -172,12 +173,13 @@ impl OciTransport for NativeTransport {
     async fn pull_blob_to_file(
         &self,
         image: &oci::native::Reference,
-        digest: &str,
+        digest: &oci::Digest,
         path: &Path,
         total_size: u64,
         on_progress: ProgressFn,
     ) -> Result<()> {
-        log::debug!("Pulling blob {} for image {} to {}", digest, image, path.display());
+        let digest_str = digest.to_string();
+        log::debug!("Pulling blob {} for image {} to {}", digest_str, image, path.display());
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| io_error(parent, e))?;
         }
@@ -190,19 +192,17 @@ impl OciTransport for NativeTransport {
             .map_err(|e| io_error(path, e))?;
         let writer = ProgressWriter::new(file, total_size, on_progress);
         self.client
-            .pull_blob(image, digest, writer)
+            .pull_blob(image, digest_str.as_str(), writer)
             .await
             .map_err(registry_error)
     }
 
-    async fn head_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<u64> {
-        log::debug!("HEAD blob {} for image {}", digest, image);
-        match self.client.fetch_blob_size(image, digest).await {
+    async fn head_blob(&self, image: &oci::native::Reference, digest: &oci::Digest) -> Result<u64> {
+        let digest_str = digest.to_string();
+        log::debug!("HEAD blob {} for image {}", digest_str, image);
+        match self.client.fetch_blob_size(image, digest_str.as_str()).await {
             Ok(Some(size)) => Ok(size),
-            Ok(None) => Err(ClientError::BlobNotFound {
-                registry: image.registry().to_string(),
-                digest_str: digest.to_string(),
-            }),
+            Ok(None) => Err(ClientError::blob_not_found(image, digest)),
             Err(e) => Err(registry_error(e)),
         }
     }
@@ -230,7 +230,7 @@ impl OciTransport for NativeTransport {
         &self,
         image: &oci::native::Reference,
         data: Vec<u8>,
-        digest: &str,
+        digest: &oci::Digest,
         on_progress: ProgressFn,
     ) -> Result<String> {
         self.do_push_blob(image, data, digest, on_progress).await
@@ -251,21 +251,26 @@ impl NativeTransport {
         &self,
         image: &oci::native::Reference,
         data: Vec<u8>,
-        digest: &str,
+        digest: &oci::Digest,
         on_progress: ProgressFn,
     ) -> Result<String> {
-        log::debug!("Checking if blob {} already exists in registry", digest);
-        match self.client.blob_exists(image, digest).await {
+        let digest_str = digest.to_string();
+        log::debug!("Checking if blob {} already exists in registry", digest_str);
+        match self.client.blob_exists(image, digest_str.as_str()).await {
             Ok(true) => {
-                log::debug!("Blob {} already exists, skipping upload", digest);
+                log::debug!("Blob {} already exists, skipping upload", digest_str);
                 on_progress(data.len() as u64);
-                return Ok(digest.to_string());
+                return Ok(digest_str);
             }
             Ok(false) => {
-                log::debug!("Blob {} does not exist, uploading", digest);
+                log::debug!("Blob {} does not exist, uploading", digest_str);
             }
             Err(e) => {
-                log::warn!("Failed to check blob {} existence, will attempt upload: {}", digest, e);
+                log::warn!(
+                    "Failed to check blob {} existence, will attempt upload: {}",
+                    digest_str,
+                    e
+                );
             }
         }
 
@@ -295,7 +300,11 @@ impl NativeTransport {
             std::future::ready(Some((Ok(chunk), (index + 1, confirmed))))
         });
 
-        match self.client.push_blob_stream(image, progress_stream, digest).await {
+        match self
+            .client
+            .push_blob_stream(image, progress_stream, digest_str.as_str())
+            .await
+        {
             Ok(url) => {
                 on_progress(total);
                 Ok(url)
@@ -304,7 +313,7 @@ impl NativeTransport {
                 log::warn!("Registry spec violation during chunked push: {}", violation);
                 log::warn!("Falling back to monolithic push (no progress)");
                 self.client
-                    .push_blob(image, fallback_data, digest)
+                    .push_blob(image, fallback_data, digest_str.as_str())
                     .await
                     .map_err(registry_error)
             }

--- a/crates/ocx_lib/src/oci/client/test_transport.rs
+++ b/crates/ocx_lib/src/oci/client/test_transport.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 
 use super::error::ClientError;
 use super::transport::{OciTransport, Result};
-use crate::oci::{self, Digest, RegistryOperation};
+use crate::oci::{self, Algorithm, RegistryOperation};
 
 /// Test data backing a [`StubTransport`].
 ///
@@ -174,35 +174,35 @@ impl OciTransport for StubTransport {
         }
     }
 
-    async fn head_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<u64> {
-        self.record(&format!("head_blob:{}", digest));
+    async fn head_blob(&self, image: &oci::native::Reference, digest: &oci::Digest) -> Result<u64> {
+        let digest_key = digest.to_string();
+        self.record(&format!("head_blob:{}", digest_key));
         let inner = self.data.read();
-        match inner.blobs.get(digest) {
+        match inner.blobs.get(&digest_key) {
             Some(blob) => Ok(blob.len() as u64),
-            None => Err(ClientError::BlobNotFound {
-                registry: image.registry().to_string(),
-                digest_str: digest.to_string(),
-            }),
+            None => Err(ClientError::blob_not_found(image, digest)),
         }
     }
 
-    async fn pull_blob(&self, _image: &oci::native::Reference, digest: &str) -> Result<Vec<u8>> {
-        self.record(&format!("pull_blob:{}", digest));
+    async fn pull_blob(&self, _image: &oci::native::Reference, digest: &oci::Digest) -> Result<Vec<u8>> {
+        let digest_key = digest.to_string();
+        self.record(&format!("pull_blob:{}", digest_key));
         let inner = self.data.read();
-        Ok(inner.blobs.get(digest).cloned().unwrap_or_default())
+        Ok(inner.blobs.get(&digest_key).cloned().unwrap_or_default())
     }
 
     async fn pull_blob_to_file(
         &self,
         _image: &oci::native::Reference,
-        digest: &str,
+        digest: &oci::Digest,
         path: &std::path::Path,
         total_size: u64,
         on_progress: super::transport::ProgressFn,
     ) -> Result<()> {
-        self.record(&format!("pull_blob_to_file:{}", digest));
+        let digest_key = digest.to_string();
+        self.record(&format!("pull_blob_to_file:{}", digest_key));
         let inner = self.data.read();
-        if let Some(blob) = inner.blobs.get(digest) {
+        if let Some(blob) = inner.blobs.get(&digest_key) {
             let blob = blob.clone();
             drop(inner); // release lock before I/O
             if let Some(parent) = path.parent() {
@@ -233,7 +233,7 @@ impl OciTransport for StubTransport {
         _media_type: &str,
     ) -> Result<String> {
         self.record("push_manifest_raw");
-        let digest = Digest::sha256(&data).to_string();
+        let digest = Algorithm::Sha256.hash(&data).to_string();
         if self.data.read().capture_pushes {
             self.data
                 .write()
@@ -252,7 +252,7 @@ impl OciTransport for StubTransport {
         &self,
         _image: &oci::native::Reference,
         data: Vec<u8>,
-        digest: &str,
+        digest: &oci::Digest,
         on_progress: super::transport::ProgressFn,
     ) -> Result<String> {
         self.record(&format!("push_blob:{}", digest));

--- a/crates/ocx_lib/src/oci/client/test_transport.rs
+++ b/crates/ocx_lib/src/oci/client/test_transport.rs
@@ -181,7 +181,7 @@ impl OciTransport for StubTransport {
             Some(blob) => Ok(blob.len() as u64),
             None => Err(ClientError::BlobNotFound {
                 registry: image.registry().to_string(),
-                digest: digest.to_string(),
+                digest_str: digest.to_string(),
             }),
         }
     }

--- a/crates/ocx_lib/src/oci/client/test_transport.rs
+++ b/crates/ocx_lib/src/oci/client/test_transport.rs
@@ -174,6 +174,18 @@ impl OciTransport for StubTransport {
         }
     }
 
+    async fn head_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<u64> {
+        self.record(&format!("head_blob:{}", digest));
+        let inner = self.data.read();
+        match inner.blobs.get(digest) {
+            Some(blob) => Ok(blob.len() as u64),
+            None => Err(ClientError::BlobNotFound {
+                registry: image.registry().to_string(),
+                digest: digest.to_string(),
+            }),
+        }
+    }
+
     async fn pull_blob(&self, _image: &oci::native::Reference, digest: &str) -> Result<Vec<u8>> {
         self.record(&format!("pull_blob:{}", digest));
         let inner = self.data.read();

--- a/crates/ocx_lib/src/oci/client/transport.rs
+++ b/crates/ocx_lib/src/oci/client/transport.rs
@@ -72,7 +72,7 @@ pub trait OciTransport: Send + Sync {
     ///
     /// Suitable for small blobs (config, metadata) where writing to disk
     /// and reading back would be wasteful.
-    async fn pull_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<Vec<u8>>;
+    async fn pull_blob(&self, image: &oci::native::Reference, digest: &oci::Digest) -> Result<Vec<u8>>;
 
     /// Pulls a blob and writes it to the specified file path.
     ///
@@ -83,7 +83,7 @@ pub trait OciTransport: Send + Sync {
     async fn pull_blob_to_file(
         &self,
         image: &oci::native::Reference,
-        digest: &str,
+        digest: &oci::Digest,
         path: &Path,
         total_size: u64,
         on_progress: ProgressFn,
@@ -92,7 +92,7 @@ pub trait OciTransport: Send + Sync {
     /// HEAD a blob to verify existence and retrieve its content length.
     ///
     /// Returns `Ok(size)` if the blob exists, `Err(ClientError::BlobNotFound)` if not.
-    async fn head_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<u64>;
+    async fn head_blob(&self, image: &oci::native::Reference, digest: &oci::Digest) -> Result<u64>;
 
     // ── Write operations ─────────────────────────────────────────────
 
@@ -117,7 +117,7 @@ pub trait OciTransport: Send + Sync {
         &self,
         image: &oci::native::Reference,
         data: Vec<u8>,
-        digest: &str,
+        digest: &oci::Digest,
         on_progress: ProgressFn,
     ) -> Result<String>;
 

--- a/crates/ocx_lib/src/oci/client/transport.rs
+++ b/crates/ocx_lib/src/oci/client/transport.rs
@@ -89,6 +89,11 @@ pub trait OciTransport: Send + Sync {
         on_progress: ProgressFn,
     ) -> Result<()>;
 
+    /// HEAD a blob to verify existence and retrieve its content length.
+    ///
+    /// Returns `Ok(size)` if the blob exists, `Err(ClientError::BlobNotFound)` if not.
+    async fn head_blob(&self, image: &oci::native::Reference, digest: &str) -> Result<u64>;
+
     // ── Write operations ─────────────────────────────────────────────
 
     /// Pushes a typed OCI manifest and returns the resulting digest string.

--- a/crates/ocx_lib/src/oci/digest.rs
+++ b/crates/ocx_lib/src/oci/digest.rs
@@ -31,6 +31,28 @@ impl Digest {
         Self::Sha256(hex::encode(<sha2::Sha256 as sha2::Digest>::digest(data)))
     }
 
+    /// Streams a file from disk through SHA-256 without loading it
+    /// into memory, returning a [`Digest::Sha256`].
+    ///
+    /// Used by the pull path to verify that a blob written to disk
+    /// matches its claimed digest before extraction, without
+    /// reallocating the full archive.
+    pub async fn sha256_file(path: &std::path::Path) -> std::io::Result<Self> {
+        use tokio::io::AsyncReadExt;
+
+        let mut file = tokio::fs::File::open(path).await?;
+        let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = file.read(&mut buf).await?;
+            if n == 0 {
+                break;
+            }
+            sha2::Digest::update(&mut hasher, &buf[..n]);
+        }
+        Ok(Self::Sha256(hex::encode(sha2::Digest::finalize(hasher))))
+    }
+
     /// Returns the algorithm prefix and hex string without allocating.
     ///
     /// Algorithm strings are sourced from [`Self::ALGORITHMS`] — the single

--- a/crates/ocx_lib/src/oci/digest.rs
+++ b/crates/ocx_lib/src/oci/digest.rs
@@ -8,6 +8,92 @@ use serde::{Deserialize, Serialize};
 use error::DigestError;
 
 const DIGEST_SHORT_LEN: usize = 12;
+
+/// Supported digest hash algorithms. The single source of truth for the
+/// algorithm concept: every place that hashes bytes or a file goes through
+/// one of [`Algorithm::hash`], [`Algorithm::hash_file`], or
+/// [`Algorithm::hash_file_read`], and every runtime dispatch on the
+/// algorithm identity flows through one of these methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Algorithm {
+    Sha256,
+    Sha384,
+    Sha512,
+}
+
+impl Algorithm {
+    /// Every supported algorithm, in parse/Display-prefix order.
+    pub const ALL: &'static [Self] = &[Self::Sha256, Self::Sha384, Self::Sha512];
+
+    /// OCI-spec algorithm prefix, e.g. `"sha256"`.
+    pub const fn prefix(self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Sha384 => "sha384",
+            Self::Sha512 => "sha512",
+        }
+    }
+
+    /// Expected hex-string length for this algorithm's digest output.
+    pub const fn hex_len(self) -> usize {
+        match self {
+            Self::Sha256 => 64,
+            Self::Sha384 => 96,
+            Self::Sha512 => 128,
+        }
+    }
+
+    /// Hashes `bytes` in memory with this algorithm.
+    pub fn hash(self, bytes: impl AsRef<[u8]>) -> Digest {
+        match self {
+            Self::Sha256 => Digest::Sha256(hex::encode(<sha2::Sha256 as sha2::Digest>::digest(bytes))),
+            Self::Sha384 => Digest::Sha384(hex::encode(<sha2::Sha384 as sha2::Digest>::digest(bytes))),
+            Self::Sha512 => Digest::Sha512(hex::encode(<sha2::Sha512 as sha2::Digest>::digest(bytes))),
+        }
+    }
+
+    /// Streams the file at `path` through this algorithm without loading
+    /// it into memory. The read-and-hash loop runs on
+    /// [`tokio::task::spawn_blocking`] so neither synchronous disk I/O
+    /// nor the hash state update stalls the async executor.
+    pub async fn hash_file(self, path: &std::path::Path) -> std::io::Result<Digest> {
+        let hex = match self {
+            Self::Sha256 => hash_file_hex::<sha2::Sha256>(path.to_path_buf()).await?,
+            Self::Sha384 => hash_file_hex::<sha2::Sha384>(path.to_path_buf()).await?,
+            Self::Sha512 => hash_file_hex::<sha2::Sha512>(path.to_path_buf()).await?,
+        };
+        Ok(match self {
+            Self::Sha256 => Digest::Sha256(hex),
+            Self::Sha384 => Digest::Sha384(hex),
+            Self::Sha512 => Digest::Sha512(hex),
+        })
+    }
+
+    /// Reads a file into memory and hashes it in a single disk pass,
+    /// returning `(bytes, digest)`. Used by the push path where the
+    /// blob body must be held in memory for upload and must also be
+    /// digested.
+    pub async fn hash_file_read(self, path: &std::path::Path) -> std::io::Result<(Vec<u8>, Digest)> {
+        let (bytes, hex) = match self {
+            Self::Sha256 => hash_file_read_hex::<sha2::Sha256>(path.to_path_buf()).await?,
+            Self::Sha384 => hash_file_read_hex::<sha2::Sha384>(path.to_path_buf()).await?,
+            Self::Sha512 => hash_file_read_hex::<sha2::Sha512>(path.to_path_buf()).await?,
+        };
+        let digest = match self {
+            Self::Sha256 => Digest::Sha256(hex),
+            Self::Sha384 => Digest::Sha384(hex),
+            Self::Sha512 => Digest::Sha512(hex),
+        };
+        Ok((bytes, digest))
+    }
+}
+
+impl std::fmt::Display for Algorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.prefix())
+    }
+}
+
 /// Small wrapper of the OCI digest, with some extra convenience methods.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Digest {
@@ -20,59 +106,25 @@ pub enum Digest {
 }
 
 impl Digest {
-    /// All supported digest algorithm names, matching the enum variants.
-    ///
-    /// This is the single source of truth for algorithm string identifiers.
-    /// Used by CAS path validation, Display, and TryFrom implementations.
-    pub const ALGORITHMS: &[&str] = &["sha256", "sha384", "sha512"];
-
-    /// Creates a new digest from the given data, using the SHA256 algorithm.
-    pub fn sha256(data: impl AsRef<[u8]>) -> Self {
-        Self::Sha256(hex::encode(<sha2::Sha256 as sha2::Digest>::digest(data)))
-    }
-
-    /// Streams a file from disk through SHA-256 without loading it
-    /// into memory, returning a [`Digest::Sha256`].
-    ///
-    /// Used by the pull path to verify that a blob written to disk
-    /// matches its claimed digest before extraction, without
-    /// reallocating the full archive.
-    pub async fn sha256_file(path: &std::path::Path) -> std::io::Result<Self> {
-        use tokio::io::AsyncReadExt;
-
-        let mut file = tokio::fs::File::open(path).await?;
-        let mut hasher = <sha2::Sha256 as sha2::Digest>::new();
-        let mut buf = vec![0u8; 64 * 1024];
-        loop {
-            let n = file.read(&mut buf).await?;
-            if n == 0 {
-                break;
-            }
-            sha2::Digest::update(&mut hasher, &buf[..n]);
-        }
-        Ok(Self::Sha256(hex::encode(sha2::Digest::finalize(hasher))))
-    }
-
     /// Returns the algorithm prefix and hex string without allocating.
-    ///
-    /// Algorithm strings are sourced from [`Self::ALGORITHMS`] — the single
-    /// source of truth for algorithm names.
     pub fn parts(&self) -> (&str, &str) {
-        match self {
-            Digest::Sha256(hex) => (Self::ALGORITHMS[0], hex),
-            Digest::Sha384(hex) => (Self::ALGORITHMS[1], hex),
-            Digest::Sha512(hex) => (Self::ALGORITHMS[2], hex),
-        }
+        (self.algorithm().prefix(), self.hex())
     }
 
-    /// Algorithm prefix, e.g. `"sha256"`.
-    pub fn algorithm(&self) -> &str {
-        self.parts().0
+    /// The algorithm that produced this digest.
+    pub fn algorithm(&self) -> Algorithm {
+        match self {
+            Digest::Sha256(_) => Algorithm::Sha256,
+            Digest::Sha384(_) => Algorithm::Sha384,
+            Digest::Sha512(_) => Algorithm::Sha512,
+        }
     }
 
     /// Returns the hex string of the digest (without the algorithm prefix).
     pub fn hex(&self) -> &str {
-        self.parts().1
+        match self {
+            Digest::Sha256(hex) | Digest::Sha384(hex) | Digest::Sha512(hex) => hex,
+        }
     }
 
     /// Returns the first [`DIGEST_SHORT_LEN`] characters of the hex string for display purposes.
@@ -88,6 +140,64 @@ impl Digest {
     }
 }
 
+/// Streams a file through any `sha2::Digest` hasher in 64 KiB chunks on a
+/// blocking thread, returning the lowercase hex output. Shared across the
+/// [`Algorithm::hash_file`] variants so the read-and-hash loop is not
+/// triplicated.
+async fn hash_file_hex<H>(path: std::path::PathBuf) -> std::io::Result<String>
+where
+    H: sha2::Digest + Send + 'static,
+    sha2::digest::Output<H>: AsRef<[u8]>,
+{
+    tokio::task::spawn_blocking(move || {
+        use std::io::Read;
+
+        let mut file = std::fs::File::open(&path)?;
+        let mut hasher = H::new();
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = file.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            sha2::Digest::update(&mut hasher, &buf[..n]);
+        }
+        Ok(hex::encode(hasher.finalize()))
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
+/// Like [`hash_file_hex`], but also returns the file bytes. Each 64 KiB
+/// chunk is hashed as it is read, so there is no second pass over the
+/// buffer after I/O completes.
+async fn hash_file_read_hex<H>(path: std::path::PathBuf) -> std::io::Result<(Vec<u8>, String)>
+where
+    H: sha2::Digest + Send + 'static,
+    sha2::digest::Output<H>: AsRef<[u8]>,
+{
+    tokio::task::spawn_blocking(move || {
+        use std::io::Read;
+
+        let mut file = std::fs::File::open(&path)?;
+        let expected_len = file.metadata().map(|m| m.len() as usize).unwrap_or(0);
+        let mut bytes = Vec::with_capacity(expected_len);
+        let mut hasher = H::new();
+        let mut buf = vec![0u8; 64 * 1024];
+        loop {
+            let n = file.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            sha2::Digest::update(&mut hasher, &buf[..n]);
+            bytes.extend_from_slice(&buf[..n]);
+        }
+        Ok((bytes, hex::encode(hasher.finalize())))
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
 impl std::fmt::Display for Digest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let (algorithm, hex) = self.parts();
@@ -99,35 +209,19 @@ impl TryFrom<&str> for Digest {
     type Error = DigestError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        fn check_digest(value: &str, digest: &str, expected_len: usize) -> Result<(), DigestError> {
-            if digest.len() == expected_len && digest.chars().all(|c| c.is_ascii_hexdigit()) {
-                Ok(())
-            } else {
-                Err(DigestError::Invalid(value.to_owned()))
+        for algorithm in Algorithm::ALL {
+            if let Some(hex) = value.strip_prefix(algorithm.prefix()).and_then(|s| s.strip_prefix(':')) {
+                if hex.len() != algorithm.hex_len() || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+                    return Err(DigestError::Invalid(value.to_owned()));
+                }
+                return Ok(match algorithm {
+                    Algorithm::Sha256 => Digest::Sha256(hex.to_string()),
+                    Algorithm::Sha384 => Digest::Sha384(hex.to_string()),
+                    Algorithm::Sha512 => Digest::Sha512(hex.to_string()),
+                });
             }
         }
-
-        if let Some(hex) = value
-            .strip_prefix(Digest::ALGORITHMS[0])
-            .and_then(|s| s.strip_prefix(':'))
-        {
-            check_digest(value, hex, 64)?;
-            Ok(Digest::Sha256(hex.to_string()))
-        } else if let Some(hex) = value
-            .strip_prefix(Digest::ALGORITHMS[1])
-            .and_then(|s| s.strip_prefix(':'))
-        {
-            check_digest(value, hex, 96)?;
-            Ok(Digest::Sha384(hex.to_string()))
-        } else if let Some(hex) = value
-            .strip_prefix(Digest::ALGORITHMS[2])
-            .and_then(|s| s.strip_prefix(':'))
-        {
-            check_digest(value, hex, 128)?;
-            Ok(Digest::Sha512(hex.to_string()))
-        } else {
-            Err(DigestError::Invalid(value.to_owned()))
-        }
+        Err(DigestError::Invalid(value.to_owned()))
     }
 }
 
@@ -201,9 +295,9 @@ mod tests {
     }
 
     #[test]
-    fn algorithms_constant_covers_all_variants() {
+    fn algorithm_all_covers_all_variants() {
         // If a new variant is added to Digest, this test will fail until
-        // ALGORITHMS is updated to include the new algorithm string.
+        // Algorithm::ALL is updated to include the new algorithm.
         // The round-trip (Display → TryFrom) ensures that `parts()`, `Display`,
         // and `TryFrom` all agree on the algorithm prefix strings.
         let all = [
@@ -213,8 +307,8 @@ mod tests {
         ];
         for d in &all {
             assert!(
-                Digest::ALGORITHMS.contains(&d.algorithm()),
-                "Digest::ALGORITHMS is missing '{}'",
+                Algorithm::ALL.contains(&d.algorithm()),
+                "Algorithm::ALL is missing '{}'",
                 d.algorithm()
             );
             // Round-trip: parts() → Display → TryFrom. If any of the three
@@ -225,9 +319,9 @@ mod tests {
             assert_eq!(&parsed, d, "round-trip mismatch for {}", d.algorithm());
         }
         assert_eq!(
-            Digest::ALGORITHMS.len(),
+            Algorithm::ALL.len(),
             all.len(),
-            "Digest::ALGORITHMS has entries not covered by test variants"
+            "Algorithm::ALL has entries not covered by test variants"
         );
     }
 
@@ -236,9 +330,12 @@ mod tests {
         let d256 = Digest::Sha256("a".repeat(64));
         let d384 = Digest::Sha384("b".repeat(96));
         let d512 = Digest::Sha512("c".repeat(128));
-        assert_eq!(d256.algorithm(), "sha256");
-        assert_eq!(d384.algorithm(), "sha384");
-        assert_eq!(d512.algorithm(), "sha512");
+        assert_eq!(d256.algorithm(), Algorithm::Sha256);
+        assert_eq!(d384.algorithm(), Algorithm::Sha384);
+        assert_eq!(d512.algorithm(), Algorithm::Sha512);
+        assert_eq!(d256.algorithm().to_string(), "sha256");
+        assert_eq!(d384.algorithm().to_string(), "sha384");
+        assert_eq!(d512.algorithm().to_string(), "sha512");
     }
 
     #[test]
@@ -272,5 +369,123 @@ mod tests {
         let d512 = Digest::Sha512("cd".repeat(64));
         assert!(d512.to_short_string().starts_with("sha512:"));
         assert_eq!(d512.to_short_string().len(), "sha512:".len() + DIGEST_SHORT_LEN);
+    }
+
+    #[tokio::test]
+    async fn hash_file_read_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty");
+        tokio::fs::write(&path, b"").await.unwrap();
+
+        let (bytes, digest) = Algorithm::Sha256.hash_file_read(&path).await.unwrap();
+        assert!(bytes.is_empty());
+        assert_eq!(digest, Algorithm::Sha256.hash(&[] as &[u8]));
+    }
+
+    #[tokio::test]
+    async fn hash_file_read_small_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small");
+        let data = b"hello world".to_vec();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let (bytes, digest) = Algorithm::Sha256.hash_file_read(&path).await.unwrap();
+        assert_eq!(bytes, data);
+        assert_eq!(digest, Algorithm::Sha256.hash(&data));
+    }
+
+    #[tokio::test]
+    async fn hash_file_read_larger_than_chunk() {
+        // Exceeds the 64 KiB internal read buffer so the loop runs multiple iterations.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big");
+        let data: Vec<u8> = (0..(64 * 1024 * 3 + 7)).map(|i| (i % 251) as u8).collect();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let (bytes, digest) = Algorithm::Sha256.hash_file_read(&path).await.unwrap();
+        assert_eq!(bytes, data);
+        assert_eq!(digest, Algorithm::Sha256.hash(&data));
+    }
+
+    #[tokio::test]
+    async fn hash_file_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty");
+        tokio::fs::write(&path, b"").await.unwrap();
+
+        let digest = Algorithm::Sha256.hash_file(&path).await.unwrap();
+        assert_eq!(digest, Algorithm::Sha256.hash(&[] as &[u8]));
+    }
+
+    #[tokio::test]
+    async fn hash_file_small() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("small");
+        let data = b"hello world".to_vec();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let digest = Algorithm::Sha256.hash_file(&path).await.unwrap();
+        assert_eq!(digest, Algorithm::Sha256.hash(&data));
+    }
+
+    #[tokio::test]
+    async fn hash_file_larger_than_chunk() {
+        // Exceeds the 64 KiB internal read buffer so the loop runs multiple iterations.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("big");
+        let data: Vec<u8> = (0..(64 * 1024 * 3 + 7)).map(|i| (i % 251) as u8).collect();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let digest = Algorithm::Sha256.hash_file(&path).await.unwrap();
+        assert_eq!(digest, Algorithm::Sha256.hash(&data));
+    }
+
+    #[tokio::test]
+    async fn hash_file_sha384_matches_direct_sha2() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        let data = b"hello world".to_vec();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let digest = Algorithm::Sha384.hash_file(&path).await.unwrap();
+        let expected = Digest::Sha384(hex::encode(<sha2::Sha384 as sha2::Digest>::digest(&data)));
+        assert_eq!(digest, expected);
+    }
+
+    #[tokio::test]
+    async fn hash_file_sha512_matches_direct_sha2() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        let data: Vec<u8> = (0..(64 * 1024 * 2 + 13)).map(|i| (i % 251) as u8).collect();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        let digest = Algorithm::Sha512.hash_file(&path).await.unwrap();
+        let expected = Digest::Sha512(hex::encode(<sha2::Sha512 as sha2::Digest>::digest(&data)));
+        assert_eq!(digest, expected);
+    }
+
+    #[tokio::test]
+    async fn algorithm_dispatch_selects_correct_hasher() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("blob");
+        let data = b"algorithm dispatch".to_vec();
+        tokio::fs::write(&path, &data).await.unwrap();
+
+        // Hash the same file under each algorithm via the Digest's algorithm()
+        // accessor — exercises the round-trip that verify paths rely on.
+        let sha256_seed = Digest::Sha256("0".repeat(64));
+        let sha384_seed = Digest::Sha384("0".repeat(96));
+        let sha512_seed = Digest::Sha512("0".repeat(128));
+
+        let sha256_actual = sha256_seed.algorithm().hash_file(&path).await.unwrap();
+        let sha384_actual = sha384_seed.algorithm().hash_file(&path).await.unwrap();
+        let sha512_actual = sha512_seed.algorithm().hash_file(&path).await.unwrap();
+
+        assert!(matches!(sha256_actual, Digest::Sha256(_)));
+        assert!(matches!(sha384_actual, Digest::Sha384(_)));
+        assert!(matches!(sha512_actual, Digest::Sha512(_)));
+        assert_eq!(sha256_actual, Algorithm::Sha256.hash_file(&path).await.unwrap());
+        assert_eq!(sha384_actual, Algorithm::Sha384.hash_file(&path).await.unwrap());
+        assert_eq!(sha512_actual, Algorithm::Sha512.hash_file(&path).await.unwrap());
     }
 }

--- a/crates/ocx_lib/src/package/cascade.rs
+++ b/crates/ocx_lib/src/package/cascade.rs
@@ -193,7 +193,7 @@ pub async fn resolve_cascade_tags(
 pub async fn push_with_cascade(
     client: &oci::Client,
     package_info: package::info::Info,
-    file: impl AsRef<std::path::Path>,
+    layers: &[crate::publisher::LayerRef],
     other_versions: BTreeSet<Version>,
     version: &Version,
 ) -> Result<()> {
@@ -207,7 +207,7 @@ pub async fn push_with_cascade(
     .await?;
 
     log::debug!("Pushing package with identifier {}", package_info.identifier);
-    let (_manifest, manifest_data, manifest_sha256) = client.push_image_manifest(&package_info, file.as_ref()).await?;
+    let (_manifest, manifest_data, manifest_sha256) = client.push_multi_layer_manifest(&package_info, layers).await?;
     let manifest_size = manifest_data.len() as i64;
 
     let primary_tag = package_info.identifier.tag_or_latest().to_string();

--- a/crates/ocx_lib/src/package/cascade.rs
+++ b/crates/ocx_lib/src/package/cascade.rs
@@ -206,33 +206,9 @@ pub async fn push_with_cascade(
     )
     .await?;
 
-    log::debug!("Pushing package with identifier {}", package_info.identifier);
-    let (_manifest, manifest_data, manifest_sha256) = client.push_multi_layer_manifest(&package_info, layers).await?;
-    let manifest_size = manifest_data.len() as i64;
-
-    let primary_tag = package_info.identifier.tag_or_latest().to_string();
     client
-        .merge_platform_into_index(
-            &package_info.identifier,
-            primary_tag,
-            &package_info.platform,
-            &manifest_sha256,
-            manifest_size,
-        )
+        .push_manifest_and_merge_tags(&package_info, layers, &cascade_tags)
         .await?;
-
-    for tag in &cascade_tags {
-        log::debug!("Cascading to {tag}");
-        client
-            .merge_platform_into_index(
-                &package_info.identifier,
-                tag.clone(),
-                &package_info.platform,
-                &manifest_sha256,
-                manifest_size,
-            )
-            .await?;
-    }
 
     Ok(())
 }
@@ -606,7 +582,7 @@ mod tests {
                 annotations: None,
             });
             let manifest_data = serde_json::to_vec(&index).unwrap();
-            let digest = oci::Digest::sha256(&manifest_data).to_string();
+            let digest = oci::Algorithm::Sha256.hash(&manifest_data).to_string();
             data.write()
                 .manifests
                 .insert(oci::native::Reference::from(&id).to_string(), (manifest_data, digest));
@@ -684,7 +660,7 @@ mod tests {
             let id = test_identifier().clone_with_tag(blocker.to_string());
             let manifest = oci::Manifest::Image(oci::ImageManifest::default());
             let manifest_data = serde_json::to_vec(&manifest).unwrap();
-            let digest = oci::Digest::sha256(&manifest_data).to_string();
+            let digest = oci::Algorithm::Sha256.hash(&manifest_data).to_string();
             data.write()
                 .manifests
                 .insert(oci::native::Reference::from(&id).to_string(), (manifest_data, digest));

--- a/crates/ocx_lib/src/package_manager/error.rs
+++ b/crates/ocx_lib/src/package_manager/error.rs
@@ -70,6 +70,9 @@ pub enum PackageErrorKind {
         _0.identifier
     )]
     OfflineManifestMissing(Box<OfflineManifestMissing>),
+    /// A referenced blob (layer digest) was not present in the registry.
+    #[error("blob {digest_str} not found in registry '{registry}'")]
+    BlobNotFound { registry: String, digest_str: String },
     /// Multiple candidates matched the platform selection.
     #[error("ambiguous selection: {}", _0.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", "))]
     SelectionAmbiguous(Vec<oci::Identifier>),
@@ -95,7 +98,12 @@ pub enum PackageErrorKind {
 
 impl From<crate::oci::client::error::ClientError> for PackageErrorKind {
     fn from(e: crate::oci::client::error::ClientError) -> Self {
-        Self::Internal(e.into())
+        match e {
+            crate::oci::client::error::ClientError::BlobNotFound { registry, digest_str } => {
+                Self::BlobNotFound { registry, digest_str }
+            }
+            other => Self::Internal(other.into()),
+        }
     }
 }
 
@@ -129,4 +137,33 @@ pub enum DependencyError {
     /// Dependency setup coordination failed (capacity, timeout, or abandoned leader).
     #[error("Dependency setup failed: {0}")]
     SetupFailed(#[from] crate::utility::singleflight::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::oci::client::error::ClientError;
+
+    #[test]
+    fn client_blob_not_found_routes_to_typed_kind() {
+        let e = ClientError::BlobNotFound {
+            registry: "example.com".to_string(),
+            digest_str: "sha256:abc".to_string(),
+        };
+        let kind: PackageErrorKind = e.into();
+        match kind {
+            PackageErrorKind::BlobNotFound { registry, digest_str } => {
+                assert_eq!(registry, "example.com");
+                assert_eq!(digest_str, "sha256:abc");
+            }
+            other => panic!("expected BlobNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn other_client_errors_still_route_to_internal() {
+        let e = ClientError::ManifestNotFound("example.com/pkg".to_string());
+        let kind: PackageErrorKind = e.into();
+        assert!(matches!(kind, PackageErrorKind::Internal(_)));
+    }
 }

--- a/crates/ocx_lib/src/package_manager/error.rs
+++ b/crates/ocx_lib/src/package_manager/error.rs
@@ -71,8 +71,12 @@ pub enum PackageErrorKind {
     )]
     OfflineManifestMissing(Box<OfflineManifestMissing>),
     /// A referenced blob (layer digest) was not present in the registry.
-    #[error("blob {digest_str} not found in registry '{registry}'")]
-    BlobNotFound { registry: String, digest_str: String },
+    ///
+    /// The identifier is `registry/repository[:tag]@<blob-digest>` — see
+    /// [`crate::oci::client::error::ClientError::BlobNotFound`] for the
+    /// canonical construction contract.
+    #[error("blob not found: {0}")]
+    BlobNotFound(oci::PinnedIdentifier),
     /// Multiple candidates matched the platform selection.
     #[error("ambiguous selection: {}", _0.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", "))]
     SelectionAmbiguous(Vec<oci::Identifier>),
@@ -99,9 +103,7 @@ pub enum PackageErrorKind {
 impl From<crate::oci::client::error::ClientError> for PackageErrorKind {
     fn from(e: crate::oci::client::error::ClientError) -> Self {
         match e {
-            crate::oci::client::error::ClientError::BlobNotFound { registry, digest_str } => {
-                Self::BlobNotFound { registry, digest_str }
-            }
+            crate::oci::client::error::ClientError::BlobNotFound(pinned) => Self::BlobNotFound(pinned),
             other => Self::Internal(other.into()),
         }
     }
@@ -146,15 +148,17 @@ mod tests {
 
     #[test]
     fn client_blob_not_found_routes_to_typed_kind() {
-        let e = ClientError::BlobNotFound {
-            registry: "example.com".to_string(),
-            digest_str: "sha256:abc".to_string(),
-        };
+        let image: oci::native::Reference = "example.com/foo/bar:1.0".parse().unwrap();
+        let blob_str = format!("sha256:{}", "a".repeat(64));
+        let blob = oci::Digest::try_from(blob_str.as_str()).unwrap();
+        let e = ClientError::blob_not_found(&image, &blob);
         let kind: PackageErrorKind = e.into();
         match kind {
-            PackageErrorKind::BlobNotFound { registry, digest_str } => {
-                assert_eq!(registry, "example.com");
-                assert_eq!(digest_str, "sha256:abc");
+            PackageErrorKind::BlobNotFound(pinned) => {
+                assert_eq!(pinned.registry(), "example.com");
+                assert_eq!(pinned.repository(), "foo/bar");
+                assert_eq!(pinned.tag(), Some("1.0"));
+                assert_eq!(pinned.digest().to_string(), blob_str);
             }
             other => panic!("expected BlobNotFound, got {other:?}"),
         }

--- a/crates/ocx_lib/src/package_manager/tasks/common.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/common.rs
@@ -19,6 +19,7 @@ use crate::{
     package_manager::error::{self, PackageError, PackageErrorKind},
     prelude::SerdeExt,
     reference_manager::ReferenceManager,
+    utility,
 };
 
 /// Finds a package in the object store without index resolution.
@@ -36,9 +37,9 @@ pub async fn find_in_store(
     let content = pkg.content();
     let metadata_path = pkg.metadata();
     let resolve_path = pkg.resolve();
-    if tokio::fs::try_exists(&content).await.unwrap_or(false)
-        && tokio::fs::try_exists(&metadata_path).await.unwrap_or(false)
-        && tokio::fs::try_exists(&resolve_path).await.unwrap_or(false)
+    if utility::fs::path_exists_lossy(&content).await
+        && utility::fs::path_exists_lossy(&metadata_path).await
+        && utility::fs::path_exists_lossy(&resolve_path).await
     {
         let (metadata_result, resolved_result): (crate::Result<metadata::Metadata>, crate::Result<ResolvedPackage>) = tokio::join!(
             metadata::Metadata::read_json(&metadata_path),

--- a/crates/ocx_lib/src/package_manager/tasks/garbage_collection/reachability_graph.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/garbage_collection/reachability_graph.rs
@@ -18,6 +18,7 @@ use crate::{
     file_structure::{CasTier, FileStructure},
     log,
     profile::ProfileSnapshot,
+    utility,
 };
 
 /// Maximum concurrent I/O tasks for graph building.
@@ -196,7 +197,7 @@ async fn has_live_refs(pkg_dir: &Path) -> bool {
         let path = entry.path();
         if crate::symlink::is_link(&path)
             && let Ok(target) = tokio::fs::read_link(&path).await
-            && tokio::fs::try_exists(&target).await.unwrap_or(false)
+            && utility::fs::path_exists_lossy(&target).await
         {
             return true;
         }

--- a/crates/ocx_lib/src/package_manager/tasks/pull.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/pull.rs
@@ -13,7 +13,7 @@ use crate::{
     package::{install_info::InstallInfo, install_status::InstallStatus, metadata, resolved_package::ResolvedPackage},
     package_manager::{self, error::PackageError, error::PackageErrorKind},
     prelude::SerdeExt,
-    utility::singleflight,
+    utility::{self, singleflight},
 };
 
 use super::super::PackageManager;
@@ -237,7 +237,7 @@ async fn setup_owned(
     // Defense layer 2 — skip if already fully installed (cross-process).
     if let Some(info) = mgr.find_plain(pinned).await? {
         let install_path = mgr.file_structure().packages.install_status(pinned);
-        if tokio::fs::try_exists(&install_path).await.unwrap_or(false) {
+        if utility::fs::path_exists_lossy(&install_path).await {
             log::debug!("Package '{}' already fully installed, skipping.", pinned);
             // Top up chain refs in case the already-installed package was
             // resolved via a different image-index path (alias tag). See
@@ -267,7 +267,7 @@ async fn setup_owned(
     // lock, it may have already installed the package.
     if let Some(info) = mgr.find_plain(pinned).await? {
         let install_path = mgr.file_structure().packages.install_status(pinned);
-        if tokio::fs::try_exists(&install_path).await.unwrap_or(false) {
+        if utility::fs::path_exists_lossy(&install_path).await {
             log::debug!(
                 "Package '{}' installed by another process while waiting for lock, skipping.",
                 pinned
@@ -286,12 +286,11 @@ async fn setup_owned(
     let manifest = resolved.final_manifest.clone();
     let metadata = client.pull_metadata(pinned, Some(&manifest)).await?;
 
-    // Validate manifest before any extraction work.
+    // Validate manifest before any extraction work. Zero layers is valid —
+    // the package is a config-only artifact whose `content/` is the empty
+    // directory and whose metadata is the only carried payload.
     media_type_select_some(&manifest.artifact_type, &[MEDIA_TYPE_PACKAGE_V1])
         .map_err(|e| PackageErrorKind::from(oci::client::error::ClientError::internal(e)))?;
-    if manifest.layers.is_empty() {
-        return Err(oci::client::error::ClientError::InvalidManifest("manifest has no layers".to_string()).into());
-    }
 
     // Wrap the temp directory in a PackageDir so all sibling-file accesses
     // use the canonical accessors instead of hardcoded strings.
@@ -615,7 +614,7 @@ async fn extract_layer_inner(
 ) -> Result<(), PackageErrorKind> {
     // Step 2: find-plain — skip if already extracted on disk.
     let layer_content = fs.layers.content(pinned.registry(), layer_digest);
-    if tokio::fs::try_exists(&layer_content).await.unwrap_or(false) {
+    if utility::fs::path_exists_lossy(&layer_content).await {
         log::debug!("Layer {} already present on disk, skipping.", layer_digest);
         return Ok(());
     }
@@ -637,7 +636,7 @@ async fn extract_layer_inner(
     };
 
     // Step 4: post-lock recheck.
-    if tokio::fs::try_exists(&layer_content).await.unwrap_or(false) {
+    if utility::fs::path_exists_lossy(&layer_content).await {
         log::debug!(
             "Layer {} installed by another process while waiting for lock, skipping.",
             layer_digest
@@ -665,7 +664,7 @@ async fn extract_layer_inner(
         Ok(()) => {
             log::debug!("Extracted layer {} to {}", layer_digest, layer_path.display());
         }
-        Err(_) if tokio::fs::try_exists(&layer_content).await.unwrap_or(false) => {
+        Err(_) if utility::fs::path_exists_lossy(&layer_content).await => {
             // Another process extracted the same layer — discard our copy.
             log::debug!("Layer {} already exists (race), cleaning up temp.", layer_digest);
             // Best-effort cleanup — stale temps are reclaimed by TempStore::try_acquire.

--- a/crates/ocx_lib/src/package_manager/tasks/pull.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/pull.rs
@@ -292,19 +292,6 @@ async fn setup_owned(
     if manifest.layers.is_empty() {
         return Err(oci::client::error::ClientError::InvalidManifest("manifest has no layers".to_string()).into());
     }
-    // Multi-layer assembly is deferred to issue #22. Fail fast on the manifest
-    // — the source of truth — so a legitimately multi-layered artifact does
-    // not pay the full download + extraction cost before hitting a typed
-    // error. The walker itself already supports merging multiple layers into
-    // a single `content/` tree (see the multi-layer tests in
-    // `utility/fs/assemble.rs`); the remaining gap is pipeline-level
-    // (dependency ordering across layers, refs/layers/ bookkeeping for N>1).
-    if manifest.layers.len() > 1 {
-        return Err(oci::client::error::ClientError::InvalidManifest(
-            "multi-layer package assembly is not yet supported (#22)".to_string(),
-        )
-        .into());
-    }
 
     // Wrap the temp directory in a PackageDir so all sibling-file accesses
     // use the canonical accessors instead of hardcoded strings.
@@ -343,13 +330,17 @@ async fn setup_owned(
         .map_err(|e| PackageErrorKind::Internal(crate::Error::InternalFile(layers_dir.clone(), e)))?;
     link_layers_in_temp(&pkg, pinned.registry(), &layer_digests, fs)?;
 
-    // Assemble package content/ by hardlinking files from the single layer.
-    // The walker mirrors the layer's directory tree into a real content/
+    // Assemble package content/ by hardlinking files from all layers.
+    // The walker mirrors each layer's directory tree into a single content/
     // directory — regular files become hardlinks; intra-layer symlinks are
-    // preserved verbatim. The multi-layer guard above (`manifest.layers.len()
-    // > 1`) ensures `layer_digests` has exactly one entry here.
-    let layer_content = fs.layers.content(pinned.registry(), &layer_digests[0]);
-    crate::utility::fs::assemble_from_layer(&layer_content, &pkg.content())
+    // preserved verbatim. Layers must not overlap (same file in two layers
+    // is an error).
+    let layer_contents: Vec<std::path::PathBuf> = layer_digests
+        .iter()
+        .map(|d| fs.layers.content(pinned.registry(), d))
+        .collect();
+    let sources: Vec<&std::path::Path> = layer_contents.iter().map(AsRef::as_ref).collect();
+    crate::utility::fs::assemble_from_layers(&sources, &pkg.content())
         .await
         .map_err(PackageErrorKind::Internal)?;
 

--- a/crates/ocx_lib/src/publisher.rs
+++ b/crates/ocx_lib/src/publisher.rs
@@ -8,6 +8,10 @@
 //! It is the publishing counterpart to [`PackageManager`](crate::package_manager::PackageManager),
 //! which handles local-store operations.
 
+mod layer_ref;
+
+pub use layer_ref::LayerRef;
+
 use std::collections::BTreeSet;
 use std::path::Path;
 
@@ -44,22 +48,31 @@ impl Publisher {
         self.client.ensure_auth(identifier, oci::RegistryOperation::Push).await
     }
 
-    /// Push a package to the registry without cascade.
-    pub async fn push(&self, info: Info, file: &Path) -> Result<()> {
+    /// Push a package with one or more layers to the registry.
+    ///
+    /// Each `LayerRef::File` is uploaded as a new blob. Each `LayerRef::Digest`
+    /// is verified to exist via HEAD. The manifest contains one descriptor per
+    /// layer in the order provided.
+    pub async fn push(&self, info: Info, layers: &[LayerRef]) -> Result<()> {
         log::debug!("Pushing package with identifier {}", info.identifier);
-        self.client.push_package(info, file).await?;
+        self.client.push_package(info, layers).await?;
         Ok(())
     }
 
-    /// Push a package and cascade rolling tags.
+    /// Push a package with cascade tag management.
     ///
     /// `existing_versions` is the set of versions already in the registry,
     /// used to compute which rolling tags this push should update.
-    pub async fn push_cascade(&self, info: Info, file: &Path, existing_versions: BTreeSet<Version>) -> Result<()> {
+    pub async fn push_cascade(
+        &self,
+        info: Info,
+        layers: &[LayerRef],
+        existing_versions: BTreeSet<Version>,
+    ) -> Result<()> {
         let version = Version::parse(info.identifier.tag_or_latest())
             .ok_or_else(|| crate::package::error::Error::VersionInvalid(info.identifier.tag_or_latest().to_string()))?;
 
-        package::cascade::push_with_cascade(&self.client, info, file, existing_versions, &version).await
+        package::cascade::push_with_cascade(&self.client, info, layers, existing_versions, &version).await
     }
 
     /// Push a complete description artifact to the `__ocx.desc` tag.

--- a/crates/ocx_lib/src/publisher.rs
+++ b/crates/ocx_lib/src/publisher.rs
@@ -10,7 +10,7 @@
 
 mod layer_ref;
 
-pub use layer_ref::LayerRef;
+pub use layer_ref::{ArchiveMediaType, LayerRef};
 
 use std::collections::BTreeSet;
 use std::path::Path;

--- a/crates/ocx_lib/src/publisher/layer_ref.rs
+++ b/crates/ocx_lib/src/publisher/layer_ref.rs
@@ -7,21 +7,63 @@ use std::path::PathBuf;
 
 use crate::{MEDIA_TYPE_TAR_GZ, MEDIA_TYPE_TAR_XZ, oci};
 
-/// Archive file extensions OCX accepts after a layer digest.
+/// Supported archive media types for digest layer references.
 ///
-/// Each tuple is `(suffix, media_type)` where `suffix` does *not*
-/// include the leading dot. Ordered so longer suffixes are tried
-/// first, which matters when `tgz`/`tar.gz` overlap prefixes on the
-/// same digest token.
-const KNOWN_LAYER_EXTENSIONS: &[(&str, &str)] = &[
-    ("tar.gz", MEDIA_TYPE_TAR_GZ),
-    ("tgz", MEDIA_TYPE_TAR_GZ),
-    ("tar.xz", MEDIA_TYPE_TAR_XZ),
-    ("txz", MEDIA_TYPE_TAR_XZ),
-];
+/// The OCI distribution spec does not expose a layer's media type via
+/// blob HEAD, so when pushing a cross-package digest reference the
+/// publisher must re-declare the format. This closed enum makes the
+/// set of acceptable values total — `FromStr` and `Display` round-trip
+/// without any runtime fallback — and prevents stringly-typed drift in
+/// callers constructing `LayerRef::Digest` directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArchiveMediaType {
+    /// `application/vnd.oci.image.layer.v1.tar+gzip`
+    TarGz,
+    /// `application/vnd.oci.image.layer.v1.tar+xz`
+    TarXz,
+}
+
+impl ArchiveMediaType {
+    /// All supported archive media types. The single source of truth
+    /// for iteration — `FromStr` walks this set when resolving an
+    /// extension suffix back to a variant.
+    pub const ALL: &'static [Self] = &[Self::TarGz, Self::TarXz];
+
+    /// Returns the OCI media type string for the manifest descriptor.
+    pub fn as_media_type(self) -> &'static str {
+        match self {
+            Self::TarGz => MEDIA_TYPE_TAR_GZ,
+            Self::TarXz => MEDIA_TYPE_TAR_XZ,
+        }
+    }
+
+    /// Filename extensions (without the leading dot) that map to this
+    /// media type. The first entry is the canonical form; any
+    /// additional entries are accepted aliases. `FromStr` tries them
+    /// in order, so the canonical form wins when a string could match
+    /// multiple.
+    pub fn extensions(self) -> &'static [&'static str] {
+        match self {
+            Self::TarGz => &["tar.gz", "tgz"],
+            Self::TarXz => &["tar.xz", "txz"],
+        }
+    }
+
+    /// Returns the canonical filename extension (without the leading dot).
+    pub fn canonical_extension(self) -> &'static str {
+        self.extensions()[0]
+    }
+}
+
+impl std::fmt::Display for ArchiveMediaType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_media_type())
+    }
+}
 
 /// Error produced when a string cannot be parsed as a [`LayerRef`].
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum LayerRefParseError {
     /// A bare digest (`sha256:abc...`) was supplied without a media
     /// type extension suffix. Digest references must spell out the
@@ -50,7 +92,7 @@ pub enum LayerRef {
     /// [`FromStr`](std::str::FromStr) impl for the CLI syntax.
     Digest {
         digest: oci::Digest,
-        media_type: &'static str,
+        media_type: ArchiveMediaType,
     },
 }
 
@@ -59,12 +101,7 @@ impl std::fmt::Display for LayerRef {
         match self {
             LayerRef::File(path) => write!(f, "{}", path.display()),
             LayerRef::Digest { digest, media_type } => {
-                let ext = KNOWN_LAYER_EXTENSIONS
-                    .iter()
-                    .find(|(_, mt)| mt == media_type)
-                    .map(|(ext, _)| *ext)
-                    .unwrap_or("bin");
-                write!(f, "{digest}.{ext}")
+                write!(f, "{digest}.{}", media_type.canonical_extension())
             }
         }
     }
@@ -100,12 +137,17 @@ impl std::str::FromStr for LayerRef {
         let looks_like_path = s.starts_with("./") || s.starts_with('/');
 
         if !looks_like_path {
-            for (ext, media_type) in KNOWN_LAYER_EXTENSIONS {
-                let suffix = format!(".{ext}");
-                if let Some(hex_part) = s.strip_suffix(&suffix)
-                    && let Ok(digest) = oci::Digest::try_from(hex_part)
-                {
-                    return Ok(LayerRef::Digest { digest, media_type });
+            for media_type in ArchiveMediaType::ALL {
+                for ext in media_type.extensions() {
+                    let suffix = format!(".{ext}");
+                    if let Some(hex_part) = s.strip_suffix(&suffix)
+                        && let Ok(digest) = oci::Digest::try_from(hex_part)
+                    {
+                        return Ok(LayerRef::Digest {
+                            digest,
+                            media_type: *media_type,
+                        });
+                    }
                 }
             }
 
@@ -136,7 +178,7 @@ mod tests {
         match lr {
             LayerRef::Digest { digest, media_type } => {
                 assert!(matches!(digest, oci::Digest::Sha256(ref h) if h == &hex));
-                assert_eq!(media_type, MEDIA_TYPE_TAR_GZ);
+                assert_eq!(media_type, ArchiveMediaType::TarGz);
             }
             _ => panic!("expected Digest variant, got {lr:?}"),
         }
@@ -148,7 +190,7 @@ mod tests {
         let input = format!("sha256:{hex}.tgz");
         let lr: LayerRef = input.parse().unwrap();
         match lr {
-            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, MEDIA_TYPE_TAR_GZ),
+            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, ArchiveMediaType::TarGz),
             _ => panic!("expected Digest variant"),
         }
     }
@@ -159,7 +201,7 @@ mod tests {
         let input = format!("sha256:{hex}.tar.xz");
         let lr: LayerRef = input.parse().unwrap();
         match lr {
-            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, MEDIA_TYPE_TAR_XZ),
+            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, ArchiveMediaType::TarXz),
             _ => panic!("expected Digest variant"),
         }
     }
@@ -170,7 +212,7 @@ mod tests {
         let input = format!("sha256:{hex}.txz");
         let lr: LayerRef = input.parse().unwrap();
         match lr {
-            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, MEDIA_TYPE_TAR_XZ),
+            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, ArchiveMediaType::TarXz),
             _ => panic!("expected Digest variant"),
         }
     }
@@ -238,7 +280,7 @@ mod tests {
         let hex = "a".repeat(64);
         let lr = LayerRef::Digest {
             digest: oci::Digest::Sha256(hex.clone()),
-            media_type: MEDIA_TYPE_TAR_GZ,
+            media_type: ArchiveMediaType::TarGz,
         };
         assert_eq!(lr.to_string(), format!("sha256:{hex}.tar.gz"));
     }
@@ -248,7 +290,7 @@ mod tests {
         let hex = "b".repeat(64);
         let lr = LayerRef::Digest {
             digest: oci::Digest::Sha256(hex.clone()),
-            media_type: MEDIA_TYPE_TAR_XZ,
+            media_type: ArchiveMediaType::TarXz,
         };
         assert_eq!(lr.to_string(), format!("sha256:{hex}.tar.xz"));
     }
@@ -259,5 +301,38 @@ mod tests {
         let input = format!("sha256:{hex}.tar.gz");
         let lr: LayerRef = input.parse().unwrap();
         assert_eq!(lr.to_string(), input);
+    }
+
+    #[test]
+    fn tgz_alias_round_trips_to_canonical_tar_gz() {
+        let hex = "a".repeat(64);
+        let short = format!("sha256:{hex}.tgz");
+        let lr: LayerRef = short.parse().unwrap();
+        // Canonical display normalizes the alias to `tar.gz`.
+        assert_eq!(lr.to_string(), format!("sha256:{hex}.tar.gz"));
+        // The re-parsed canonical form is structurally equal to the original parse.
+        let reparsed: LayerRef = lr.to_string().parse().unwrap();
+        match (lr, reparsed) {
+            (
+                LayerRef::Digest {
+                    digest: d1,
+                    media_type: m1,
+                },
+                LayerRef::Digest {
+                    digest: d2,
+                    media_type: m2,
+                },
+            ) => {
+                assert_eq!(d1, d2);
+                assert_eq!(m1, m2);
+            }
+            _ => panic!("expected Digest variants"),
+        }
+    }
+
+    #[test]
+    fn archive_media_type_as_media_type_matches_constants() {
+        assert_eq!(ArchiveMediaType::TarGz.as_media_type(), MEDIA_TYPE_TAR_GZ);
+        assert_eq!(ArchiveMediaType::TarXz.as_media_type(), MEDIA_TYPE_TAR_XZ);
     }
 }

--- a/crates/ocx_lib/src/publisher/layer_ref.rs
+++ b/crates/ocx_lib/src/publisher/layer_ref.rs
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The OCX Authors
+
+//! Layer reference type for multi-layer package push operations.
+
+use std::path::PathBuf;
+
+use crate::{MEDIA_TYPE_TAR_GZ, MEDIA_TYPE_TAR_XZ, oci};
+
+/// Archive file extensions OCX accepts after a layer digest.
+///
+/// Each tuple is `(suffix, media_type)` where `suffix` does *not*
+/// include the leading dot. Ordered so longer suffixes are tried
+/// first, which matters when `tgz`/`tar.gz` overlap prefixes on the
+/// same digest token.
+const KNOWN_LAYER_EXTENSIONS: &[(&str, &str)] = &[
+    ("tar.gz", MEDIA_TYPE_TAR_GZ),
+    ("tgz", MEDIA_TYPE_TAR_GZ),
+    ("tar.xz", MEDIA_TYPE_TAR_XZ),
+    ("txz", MEDIA_TYPE_TAR_XZ),
+];
+
+/// Error produced when a string cannot be parsed as a [`LayerRef`].
+#[derive(Debug, thiserror::Error)]
+pub enum LayerRefParseError {
+    /// A bare digest (`sha256:abc...`) was supplied without a media
+    /// type extension suffix. Digest references must spell out the
+    /// original archive format because the OCI distribution spec does
+    /// not return a usable media type from a blob HEAD.
+    #[error(
+        "'{0}' is a bare layer digest; append an extension suffix to declare the media type, e.g. '{0}.tar.gz' or '{0}.tar.xz'"
+    )]
+    BareDigest(String),
+}
+
+/// A reference to a layer in a multi-layer package.
+///
+/// Layers are ordered: index 0 is the base layer, index N is the top
+/// layer. With overlap-free semantics, order doesn't affect the
+/// assembled result, but it determines error messages and manifest
+/// descriptor order.
+#[derive(Debug, Clone)]
+pub enum LayerRef {
+    /// An archive file to upload as a new layer. Media type is
+    /// inferred from the file extension at push time.
+    File(PathBuf),
+    /// An existing layer already present in the registry, referenced
+    /// by digest. The `media_type` is declared by the caller because
+    /// the OCI spec does not expose it via blob HEAD; see the
+    /// [`FromStr`](std::str::FromStr) impl for the CLI syntax.
+    Digest {
+        digest: oci::Digest,
+        media_type: &'static str,
+    },
+}
+
+impl std::fmt::Display for LayerRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LayerRef::File(path) => write!(f, "{}", path.display()),
+            LayerRef::Digest { digest, media_type } => {
+                let ext = KNOWN_LAYER_EXTENSIONS
+                    .iter()
+                    .find(|(_, mt)| mt == media_type)
+                    .map(|(ext, _)| *ext)
+                    .unwrap_or("bin");
+                write!(f, "{digest}.{ext}")
+            }
+        }
+    }
+}
+
+impl std::str::FromStr for LayerRef {
+    type Err = LayerRefParseError;
+
+    /// Parses a string as a `LayerRef`.
+    ///
+    /// Recognised shapes, in order:
+    ///
+    /// 1. **`sha256:<hex>.<ext>`** — a layer digest with an archive
+    ///    extension suffix declaring the media type. Accepted
+    ///    extensions are `tar.gz`, `tgz`, `tar.xz`, `txz`. Produces
+    ///    [`LayerRef::Digest`].
+    ///
+    /// 2. **Bare digest** (`sha256:<hex>` with no suffix) — rejected
+    ///    with [`LayerRefParseError::BareDigest`]. Fabricating a media
+    ///    type here would break consumers that pull a reused
+    ///    non-gzip layer, so OCX requires the caller to spell it out.
+    ///
+    /// 3. **Anything else** — treated as a file path and produces
+    ///    [`LayerRef::File`]. To force file interpretation of a
+    ///    pathological filename that happens to match shape 1, prefix
+    ///    it with `./` (standard Unix disambiguation).
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Pathological filename escape: a leading `./` or `/` means
+        // "definitely a file path," even if the remainder would
+        // otherwise parse as a digest+ext. This is the standard Unix
+        // convention for disambiguating filenames that resemble
+        // special tokens.
+        let looks_like_path = s.starts_with("./") || s.starts_with('/');
+
+        if !looks_like_path {
+            for (ext, media_type) in KNOWN_LAYER_EXTENSIONS {
+                let suffix = format!(".{ext}");
+                if let Some(hex_part) = s.strip_suffix(&suffix)
+                    && let Ok(digest) = oci::Digest::try_from(hex_part)
+                {
+                    return Ok(LayerRef::Digest { digest, media_type });
+                }
+            }
+
+            if oci::Digest::try_from(s).is_ok() {
+                return Err(LayerRefParseError::BareDigest(s.to_string()));
+            }
+        }
+
+        Ok(LayerRef::File(PathBuf::from(s)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_file_path() {
+        let lr: LayerRef = "./archive.tar.xz".parse().unwrap();
+        assert!(matches!(lr, LayerRef::File(p) if p == std::path::Path::new("./archive.tar.xz")));
+    }
+
+    #[test]
+    fn parse_digest_tar_gz() {
+        let hex = "a".repeat(64);
+        let input = format!("sha256:{hex}.tar.gz");
+        let lr: LayerRef = input.parse().unwrap();
+        match lr {
+            LayerRef::Digest { digest, media_type } => {
+                assert!(matches!(digest, oci::Digest::Sha256(ref h) if h == &hex));
+                assert_eq!(media_type, MEDIA_TYPE_TAR_GZ);
+            }
+            _ => panic!("expected Digest variant, got {lr:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_digest_tgz() {
+        let hex = "a".repeat(64);
+        let input = format!("sha256:{hex}.tgz");
+        let lr: LayerRef = input.parse().unwrap();
+        match lr {
+            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, MEDIA_TYPE_TAR_GZ),
+            _ => panic!("expected Digest variant"),
+        }
+    }
+
+    #[test]
+    fn parse_digest_tar_xz() {
+        let hex = "b".repeat(64);
+        let input = format!("sha256:{hex}.tar.xz");
+        let lr: LayerRef = input.parse().unwrap();
+        match lr {
+            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, MEDIA_TYPE_TAR_XZ),
+            _ => panic!("expected Digest variant"),
+        }
+    }
+
+    #[test]
+    fn parse_digest_txz() {
+        let hex = "c".repeat(64);
+        let input = format!("sha256:{hex}.txz");
+        let lr: LayerRef = input.parse().unwrap();
+        match lr {
+            LayerRef::Digest { media_type, .. } => assert_eq!(media_type, MEDIA_TYPE_TAR_XZ),
+            _ => panic!("expected Digest variant"),
+        }
+    }
+
+    #[test]
+    fn parse_digest_sha512_with_ext() {
+        let hex = "d".repeat(128);
+        let input = format!("sha512:{hex}.tar.xz");
+        let lr: LayerRef = input.parse().unwrap();
+        assert!(matches!(
+            lr,
+            LayerRef::Digest { digest: oci::Digest::Sha512(ref h), .. } if h == &hex
+        ));
+    }
+
+    #[test]
+    fn parse_bare_digest_is_rejected() {
+        let hex = "a".repeat(64);
+        let input = format!("sha256:{hex}");
+        let err = input.parse::<LayerRef>().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("bare layer digest"), "got: {msg}");
+        assert!(msg.contains(".tar.gz") || msg.contains(".tar.xz"), "got: {msg}");
+    }
+
+    #[test]
+    fn parse_invalid_digest_hex_falls_back_to_file() {
+        // "sha256:tooshort.tar.gz" — algorithm prefix looks right but
+        // hex length is invalid, so it doesn't match as a digest and
+        // falls through to the file-path fallback.
+        let lr: LayerRef = "sha256:tooshort.tar.gz".parse().unwrap();
+        assert!(matches!(lr, LayerRef::File(p) if p == std::path::Path::new("sha256:tooshort.tar.gz")));
+    }
+
+    #[test]
+    fn parse_no_prefix_becomes_file() {
+        let lr: LayerRef = "just-a-filename.tar.gz".parse().unwrap();
+        assert!(matches!(lr, LayerRef::File(p) if p == std::path::Path::new("just-a-filename.tar.gz")));
+    }
+
+    #[test]
+    fn parse_dot_slash_forces_file_even_on_digest_shape() {
+        // Pathological: a file in cwd literally named after a digest +
+        // extension. The `./` prefix forces file-path interpretation.
+        let hex = "a".repeat(64);
+        let input = format!("./sha256:{hex}.tar.gz");
+        let lr: LayerRef = input.parse().unwrap();
+        assert!(matches!(lr, LayerRef::File(_)));
+    }
+
+    #[test]
+    fn parse_absolute_path() {
+        let lr: LayerRef = "/tmp/layer.tar.gz".parse().unwrap();
+        assert!(matches!(lr, LayerRef::File(p) if p == std::path::Path::new("/tmp/layer.tar.gz")));
+    }
+
+    #[test]
+    fn display_file() {
+        let lr = LayerRef::File(PathBuf::from("my/archive.tar.xz"));
+        assert_eq!(lr.to_string(), "my/archive.tar.xz");
+    }
+
+    #[test]
+    fn display_digest_tar_gz() {
+        let hex = "a".repeat(64);
+        let lr = LayerRef::Digest {
+            digest: oci::Digest::Sha256(hex.clone()),
+            media_type: MEDIA_TYPE_TAR_GZ,
+        };
+        assert_eq!(lr.to_string(), format!("sha256:{hex}.tar.gz"));
+    }
+
+    #[test]
+    fn display_digest_tar_xz() {
+        let hex = "b".repeat(64);
+        let lr = LayerRef::Digest {
+            digest: oci::Digest::Sha256(hex.clone()),
+            media_type: MEDIA_TYPE_TAR_XZ,
+        };
+        assert_eq!(lr.to_string(), format!("sha256:{hex}.tar.xz"));
+    }
+
+    #[test]
+    fn display_round_trips_for_digest() {
+        let hex = "a".repeat(64);
+        let input = format!("sha256:{hex}.tar.gz");
+        let lr: LayerRef = input.parse().unwrap();
+        assert_eq!(lr.to_string(), input);
+    }
+}

--- a/crates/ocx_lib/src/publisher/layer_ref.rs
+++ b/crates/ocx_lib/src/publisher/layer_ref.rs
@@ -69,10 +69,26 @@ pub enum LayerRefParseError {
     /// type extension suffix. Digest references must spell out the
     /// original archive format because the OCI distribution spec does
     /// not return a usable media type from a blob HEAD.
-    #[error(
-        "'{0}' is a bare layer digest; append an extension suffix to declare the media type, e.g. '{0}.tar.gz' or '{0}.tar.xz'"
-    )]
+    #[error("{}", format_bare_digest(.0))]
     BareDigest(String),
+}
+
+/// Renders the bare-digest error message, enumerating every accepted
+/// extension from [`ArchiveMediaType::ALL`] so adding a new archive
+/// format updates the hint automatically.
+fn format_bare_digest(digest: &str) -> String {
+    let extensions: Vec<String> = ArchiveMediaType::ALL
+        .iter()
+        .flat_map(|mt| mt.extensions().iter().map(|ext| format!("'.{ext}'")))
+        .collect();
+    let canonical = ArchiveMediaType::ALL
+        .first()
+        .expect("ArchiveMediaType::ALL is a non-empty const")
+        .canonical_extension();
+    format!(
+        "'{digest}' is a bare layer digest; append an extension suffix (one of {}) to declare the media type, e.g. '{digest}.{canonical}'",
+        extensions.join(", ")
+    )
 }
 
 /// A reference to a layer in a multi-layer package.
@@ -235,7 +251,15 @@ mod tests {
         let err = input.parse::<LayerRef>().unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("bare layer digest"), "got: {msg}");
-        assert!(msg.contains(".tar.gz") || msg.contains(".tar.xz"), "got: {msg}");
+        // Every canonical + alias extension declared by ArchiveMediaType::ALL
+        // must surface in the hint so callers discover the accepted syntax
+        // without consulting docs.
+        for media_type in ArchiveMediaType::ALL {
+            for ext in media_type.extensions() {
+                let needle = format!(".{ext}");
+                assert!(msg.contains(&needle), "missing extension '{needle}' in: {msg}");
+            }
+        }
     }
 
     #[test]

--- a/crates/ocx_lib/src/reference_manager.rs
+++ b/crates/ocx_lib/src/reference_manager.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use crate::{Error, Result, file_structure::FileStructure, file_structure::cas_ref_name, log, symlink};
+use crate::{Error, Result, file_structure::FileStructure, file_structure::cas_ref_name, log, symlink, utility};
 
 /// Manages forward symlinks and their back-references inside the object store.
 ///
@@ -236,7 +236,7 @@ impl ReferenceManager {
 
         for obj in &package_dirs {
             let refs_dir = obj.refs_symlinks_dir();
-            if !tokio::fs::try_exists(&refs_dir).await.unwrap_or(false) {
+            if !utility::fs::path_exists_lossy(&refs_dir).await {
                 continue;
             }
             let content = obj.content();

--- a/crates/ocx_lib/src/utility/fs.rs
+++ b/crates/ocx_lib/src/utility/fs.rs
@@ -10,6 +10,25 @@ pub use assemble::{AssemblyError, AssemblyStats, assemble_from_layer, assemble_f
 pub use dir_walker::{DirWalker, WalkDecision};
 pub use drop_file::DropFile;
 
+/// Returns whether `path` exists, swallowing any I/O error as `false`.
+///
+/// Wraps [`tokio::fs::try_exists`] and emits a `debug!` log whenever
+/// the probe fails (permission denied, transient I/O, etc.) so the
+/// swallow is still observable in diagnostic output. Use when the
+/// caller is tolerant of a missing path — either because a follow-up
+/// fallible operation will naturally surface the same error with
+/// better context, or because absence and I/O failure are handled
+/// identically at the call site.
+pub async fn path_exists_lossy(path: &std::path::Path) -> bool {
+    match tokio::fs::try_exists(path).await {
+        Ok(exists) => exists,
+        Err(e) => {
+            crate::log::debug!("path_exists_lossy probe failed for {}: {}", path.display(), e);
+            false
+        }
+    }
+}
+
 /// Moves `src` directory to `dst` via same-filesystem rename.
 ///
 /// Creates parent directories of `dst` if needed. If `dst` already exists

--- a/crates/ocx_lib/src/utility/fs/assemble.rs
+++ b/crates/ocx_lib/src/utility/fs/assemble.rs
@@ -1646,28 +1646,6 @@ mod tests {
         assert!(result.is_err(), "walker must reject a layer exceeding the entry cap");
     }
 
-    /// Item 1: multi-layer manifests are rejected at the pull boundary with
-    /// a typed `ClientError::InvalidManifest` referencing issue #22. This
-    /// test locks in the error surface so a future regression that replaces
-    /// the typed error with a panic is caught at test time.
-    ///
-    /// Note: the actual check lives in `pull.rs`, not the walker. This test
-    /// exists here because the walker is the thing that *could* handle
-    /// multi-layer merging (tests above already lock in that contract), so
-    /// this file is the natural place to document "the walker supports N>1
-    /// but the pipeline gates at N=1".
-    #[test]
-    fn multi_layer_error_surface_is_documented_here() {
-        // This is a compile-time assertion that `ClientError::InvalidManifest`
-        // is the chosen error variant for the pull-side multi-layer gate.
-        // If the variant is renamed or removed, this test stops compiling
-        // and points the reader at the call site in `pull.rs`.
-        let err = crate::oci::client::error::ClientError::InvalidManifest(
-            "multi-layer package assembly is not yet supported (#22)".to_string(),
-        );
-        assert!(format!("{err}").contains("multi-layer"));
-    }
-
     // ── 3.1: Boundary / degenerate inputs ───────────────────────────────────
 
     /// ML-1: Empty sources slice returns AssemblyStats::default() and does NOT

--- a/crates/ocx_lib/src/utility/fs/assemble.rs
+++ b/crates/ocx_lib/src/utility/fs/assemble.rs
@@ -201,11 +201,6 @@ async fn assemble_from_layers_with_cap(
     dest_content: &Path,
     max_entries: usize,
 ) -> Result<AssemblyStats> {
-    // ── Early return: nothing to assemble. ──────────────────────────────────
-    if sources.is_empty() {
-        return Ok(AssemblyStats::default());
-    }
-
     // ── Pre-condition: all sources must be existing directories. ────────────
     for src in sources {
         let meta = tokio::fs::metadata(src)
@@ -220,9 +215,11 @@ async fn assemble_from_layers_with_cap(
     }
 
     // ── Pre-condition: prepare dest_content. ────────────────────────────────
-    if !tokio::fs::try_exists(dest_content).await.unwrap_or(false) {
+    // Always created, even with zero sources — callers rely on `content/`
+    // existing after assembly (e.g. config-only packages with no layers).
+    if !super::path_exists_lossy(dest_content).await {
         if let Some(parent) = dest_content.parent()
-            && !tokio::fs::try_exists(parent).await.unwrap_or(false)
+            && !super::path_exists_lossy(parent).await
         {
             return Err(crate::error::file_error(
                 dest_content,
@@ -232,6 +229,11 @@ async fn assemble_from_layers_with_cap(
         tokio::fs::create_dir(dest_content)
             .await
             .map_err(|e| crate::error::file_error(dest_content, e))?;
+    }
+
+    // ── Early return: no sources to walk, empty content/ is the result. ─────
+    if sources.is_empty() {
+        return Ok(AssemblyStats::default());
     }
 
     // ── Parallel directory-level fan-out (multi-layer). ─────────────────────
@@ -1648,11 +1650,11 @@ mod tests {
 
     // ── 3.1: Boundary / degenerate inputs ───────────────────────────────────
 
-    /// ML-1: Empty sources slice returns AssemblyStats::default() and does NOT
-    /// create dest_content. The no-op contract: if there is nothing to assemble,
-    /// the destination should not be touched at all.
+    /// ML-1: Empty sources slice returns AssemblyStats::default() and creates
+    /// an empty dest_content. Consumers (e.g. the pull pipeline for config-only
+    /// packages with zero layers) rely on `content/` existing after assembly.
     #[tokio::test]
-    async fn ml_empty_sources_is_noop() {
+    async fn ml_empty_sources_creates_empty_dest() {
         let (_dir, root) = setup();
         std::fs::create_dir_all(root.join("pkg")).unwrap();
         let dest = root.join("pkg/content");
@@ -1665,8 +1667,13 @@ mod tests {
             "empty sources must return default stats"
         );
         assert!(
-            !dest.exists(),
-            "empty sources must NOT create dest_content — nothing to assemble"
+            dest.is_dir(),
+            "empty sources must create dest_content as an empty directory"
+        );
+        assert_eq!(
+            std::fs::read_dir(&dest).unwrap().count(),
+            0,
+            "dest_content must contain no entries"
         );
     }
 

--- a/crates/ocx_mirror/src/pipeline/push.rs
+++ b/crates/ocx_mirror/src/pipeline/push.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use anyhow::Result;
 use ocx_lib::package::info::Info;
 use ocx_lib::package::version::Version;
-use ocx_lib::publisher::Publisher;
+use ocx_lib::publisher::{LayerRef, Publisher};
 
 use super::mirror_result::MirrorResult;
 use super::mirror_task::VariantContext;
@@ -31,10 +31,11 @@ pub async fn push_and_cascade(
 ) -> Result<MirrorResult> {
     let version_str = info.identifier.tag_or_latest().to_string();
     let platform = info.platform.clone();
+    let layers = [LayerRef::File(bundle_path.to_path_buf())];
 
     if cascade {
         publisher
-            .push_cascade(info.clone(), bundle_path, cascade_versions.clone())
+            .push_cascade(info.clone(), &layers, cascade_versions.clone())
             .await?;
 
         // Default variant aliasing: generate unadorned tags for the default variant.
@@ -53,7 +54,7 @@ pub async fn push_and_cascade(
                 platform: info.platform,
             };
             publisher
-                .push_cascade(bare_info, bundle_path, cascade_versions.clone())
+                .push_cascade(bare_info, &layers, cascade_versions.clone())
                 .await?;
         }
 
@@ -64,7 +65,7 @@ pub async fn push_and_cascade(
         });
     }
 
-    publisher.push(info, bundle_path).await?;
+    publisher.push(info, &layers).await?;
 
     Ok(MirrorResult::Pushed {
         version: version_str,

--- a/crates/ocx_mirror/src/pipeline/verify.rs
+++ b/crates/ocx_mirror/src/pipeline/verify.rs
@@ -4,20 +4,30 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
+use ocx_lib::oci::Digest as OciDigest;
 use sha2::{Digest, Sha256};
 
 use crate::spec::VerifyConfig;
 
-/// Verify a downloaded file's SHA256 digest against an expected value.
+/// Verify a downloaded file's digest against an expected value.
+///
+/// The `expected` string is parsed as an OCI digest (`sha256:…`,
+/// `sha384:…`, or `sha512:…`) and the file is hashed with the
+/// matching algorithm. Returns an error for an unparseable digest
+/// string or a content mismatch.
 pub async fn verify_digest(file: &Path, expected: &str) -> Result<()> {
-    let data = tokio::fs::read(file).await?;
-    let hash = Sha256::digest(&data);
-    let actual = format!("sha256:{}", hex::encode(hash));
+    let expected_digest =
+        OciDigest::try_from(expected).with_context(|| format!("invalid digest string '{expected}'"))?;
+    let actual = expected_digest
+        .algorithm()
+        .hash_file(file)
+        .await
+        .with_context(|| format!("failed to hash {}", file.display()))?;
 
-    if actual != expected {
+    if actual != expected_digest {
         bail!(
-            "digest mismatch for {}: expected {expected}, got {actual}",
+            "digest mismatch for {}: expected {expected_digest}, got {actual}",
             file.display()
         );
     }
@@ -123,6 +133,33 @@ mod tests {
         .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("digest mismatch"));
+    }
+
+    #[tokio::test]
+    async fn verify_correct_sha512_digest() {
+        // Regression: before the algorithm-aware fix, the verify path
+        // hashed every file with SHA-256 and compared against the raw
+        // `sha512:…` string, producing a spurious mismatch.
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.bin");
+        let content = b"hello world";
+        tokio::fs::write(&file, content).await.unwrap();
+
+        let hash = sha2::Sha512::digest(content);
+        let expected = format!("sha512:{}", hex::encode(hash));
+
+        verify_digest(&file, &expected).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_unparseable_digest() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.bin");
+        tokio::fs::write(&file, b"hello world").await.unwrap();
+
+        let result = verify_digest(&file, "not-a-digest").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid digest string"));
     }
 
     #[test]

--- a/test/tests/test_multi_layer.py
+++ b/test/tests/test_multi_layer.py
@@ -1,0 +1,374 @@
+"""Multi-layer package push and pull acceptance tests.
+
+These tests exercise the full lifecycle of multi-layer packages:
+push with multiple --layer flags, install with multi-layer assembly,
+layer reuse via digest references, and error paths.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import urllib.request
+from pathlib import Path
+
+from src import OcxRunner, assert_dir_exists, current_platform
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_layer_content(
+    tmp_path: Path,
+    name: str,
+    files: dict[str, str],
+) -> Path:
+    """Create a directory with the given file tree, ready for bundling."""
+    layer_dir = tmp_path / f"layer-{name}"
+    for rel_path, content in files.items():
+        p = layer_dir / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        if rel_path.startswith("bin/"):
+            p.chmod(p.stat().st_mode | stat.S_IEXEC)
+    return layer_dir
+
+
+def _bundle_layer(
+    ocx: OcxRunner,
+    layer_dir: Path,
+    tmp_path: Path,
+    *,
+    ext: str = "tar.gz",
+) -> Path:
+    """Bundle a layer directory into an archive.
+
+    `ext` controls the output format — `package create` picks compression
+    from the output filename extension, so "tar.gz"/"tgz" → gzip,
+    "tar.xz"/"txz" → xz.
+    """
+    bundle = tmp_path / f"{layer_dir.name}.{ext}"
+    metadata_path = tmp_path / f"{layer_dir.name}-meta.json"
+    metadata_path.write_text(json.dumps({
+        "type": "bundle",
+        "version": 1,
+        "env": [
+            {"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"},
+        ],
+    }))
+    ocx.plain("package", "create", "-m", str(metadata_path), "-o", str(bundle), str(layer_dir))
+    return bundle
+
+
+def _push_multi_layer(
+    ocx: OcxRunner,
+    repo: str,
+    tag: str,
+    layers: list[str],
+    tmp_path: Path,
+    *,
+    new: bool = True,
+    cascade: bool = False,
+    metadata_path: Path | None = None,
+) -> str:
+    """Push a multi-layer package. Layers are positional args after the identifier.
+
+    Returns the fully-qualified identifier.
+    """
+    fq = f"{ocx.registry}/{repo}:{tag}"
+    if metadata_path is None:
+        metadata_path = tmp_path / f"meta-{repo}-{tag}.json"
+        metadata_path.write_text(json.dumps({
+            "type": "bundle",
+            "version": 1,
+            "env": [
+                {"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"},
+            ],
+        }))
+
+    plat = current_platform()
+    args = ["package", "push", "-p", plat, "-m", str(metadata_path)]
+    if new:
+        args.append("-n")
+    if cascade:
+        args.append("--cascade")
+    args.append(fq)
+    args.extend(layers)
+    ocx.plain(*args)
+    return fq
+
+
+# ---------------------------------------------------------------------------
+# Push tests
+# ---------------------------------------------------------------------------
+
+
+def test_push_multi_layer_files(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push a 2-layer package from archive files, verify it succeeds."""
+    layer_a = _make_layer_content(tmp_path, "a", {"lib/liba.so": "liba"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool": "#!/bin/sh\necho hello\n"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    fq = _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle_a), str(bundle_b)], tmp_path)
+    # If we get here without error, the push succeeded.
+    assert fq.endswith(f"{unique_repo}:1.0.0")
+
+
+def test_push_single_layer(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """A single positional layer is accepted (no flag needed)."""
+    layer = _make_layer_content(tmp_path, "only", {"bin/tool": "#!/bin/sh\necho ok\n"})
+    bundle = _bundle_layer(ocx, layer, tmp_path)
+
+    _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle)], tmp_path)
+
+
+def test_push_no_layer_fails(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push with no layers (just the identifier) fails."""
+    meta = tmp_path / "meta.json"
+    meta.write_text(json.dumps({
+        "type": "bundle", "version": 1,
+        "env": [{"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"}],
+    }))
+    plat = current_platform()
+    fq = f"{ocx.registry}/{unique_repo}:1.0.0"
+    result = ocx.run(
+        "package", "push", "-p", plat, "-m", str(meta), "-n", fq,
+        check=False, format=None,
+    )
+    assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests (push + install)
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_multi_layer(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push a 2-layer package, install it, verify all files from both layers present."""
+    layer_a = _make_layer_content(tmp_path, "a", {"lib/liba.so": "liba-content"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool": "#!/bin/sh\necho hello\n"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    short = f"{unique_repo}:1.0.0"
+    _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle_a), str(bundle_b)], tmp_path)
+    ocx.plain("index", "update", short)
+    result = ocx.json("install", short)
+    content = Path(result[short]["path"])
+
+    assert_dir_exists(content)
+    assert (content / "lib" / "liba.so").exists(), "File from layer A missing"
+    assert (content / "lib" / "liba.so").read_text() == "liba-content"
+    assert (content / "bin" / "tool").exists(), "File from layer B missing"
+
+
+def test_round_trip_shared_directory(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push a 2-layer package where layers share a directory (bin/), install, verify merged."""
+    layer_a = _make_layer_content(tmp_path, "a", {"bin/tool_a": "#!/bin/sh\necho a\n"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool_b": "#!/bin/sh\necho b\n"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    short = f"{unique_repo}:1.0.0"
+    _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle_a), str(bundle_b)], tmp_path)
+    ocx.plain("index", "update", short)
+    result = ocx.json("install", short)
+    content = Path(result[short]["path"])
+
+    assert (content / "bin" / "tool_a").exists(), "File from layer A missing in shared dir"
+    assert (content / "bin" / "tool_b").exists(), "File from layer B missing in shared dir"
+
+
+def test_round_trip_layer_overlap_fails(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push a 2-layer package with overlapping files, install fails with overlap error."""
+    layer_a = _make_layer_content(tmp_path, "a", {"bin/conflict": "#!/bin/sh\necho a\n"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/conflict": "#!/bin/sh\necho b\n"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    short = f"{unique_repo}:1.0.0"
+    _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle_a), str(bundle_b)], tmp_path)
+    ocx.plain("index", "update", short)
+
+    result = ocx.run("install", short, check=False)
+    assert result.returncode != 0
+    assert "overlap" in result.stderr.lower() or "conflict" in result.stderr.lower()
+
+
+def _fetch_manifest(registry: str, repo: str, ref: str) -> dict:
+    url = f"http://{registry}/v2/{repo}/manifests/{ref}"
+    accept = "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json"
+    req = urllib.request.Request(url, headers={"Accept": accept})
+    resp = urllib.request.urlopen(req, timeout=5)
+    return json.loads(resp.read())
+
+
+def _fetch_layer_digest(registry: str, repo: str, tag: str) -> str:
+    """Walk `repo:tag` (image index → per-platform image manifest) and
+    return the first layer descriptor's digest."""
+    index = _fetch_manifest(registry, repo, tag)
+    first_manifest_digest = index["manifests"][0]["digest"]
+    image_manifest = _fetch_manifest(registry, repo, first_manifest_digest)
+    return image_manifest["layers"][0]["digest"]
+
+
+def test_push_digest_layer_reuse(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push layer A (tar.gz) as v1, then push v2 with A by digest + new layer B."""
+    layer_a = _make_layer_content(tmp_path, "a", {"lib/shared.so": "shared-lib"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/new_tool": "#!/bin/sh\necho v2\n"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle_a)], tmp_path)
+    ocx.plain("index", "update", f"{unique_repo}:1.0.0")
+
+    layer_a_digest = _fetch_layer_digest(ocx.registry, unique_repo, "1.0.0")
+
+    # The new CLI syntax requires the caller to declare the media type
+    # of the reused layer alongside its digest. `.tar.gz` maps to
+    # application/vnd.oci.image.layer.v1.tar+gzip via the existing
+    # filename extension table.
+    _push_multi_layer(
+        ocx, unique_repo, "2.0.0",
+        [f"{layer_a_digest}.tar.gz", str(bundle_b)],
+        tmp_path, new=False,
+    )
+    ocx.plain("index", "update", f"{unique_repo}:2.0.0")
+
+    result = ocx.json("install", f"{unique_repo}:2.0.0")
+    content = Path(result[f"{unique_repo}:2.0.0"]["path"])
+    assert (content / "lib" / "shared.so").exists(), "Digest-referenced layer A missing"
+    assert (content / "bin" / "new_tool").exists(), "File layer B missing"
+
+
+def test_push_digest_layer_reuse_tar_xz(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Regression for the fabricated-media-type bug: a `.tar.xz` layer
+    reused by digest must round-trip through push + install without
+    the publisher silently declaring it as `tar+gzip`.
+
+    On the buggy code the manifest for v2 would carry
+    `application/vnd.oci.image.layer.v1.tar+gzip` regardless of the
+    real archive format, and `ocx install` would then fail at pull
+    time because `compression::CompressionAlgorithm::from_media_type`
+    returns `Gzip` while the bytes on disk are xz-compressed.
+    """
+    layer_a = _make_layer_content(tmp_path, "a", {"lib/liba.so": "xz-shared"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool": "#!/bin/sh\necho hi\n"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path, ext="tar.xz")
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path, ext="tar.gz")
+
+    _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle_a)], tmp_path)
+    ocx.plain("index", "update", f"{unique_repo}:1.0.0")
+
+    layer_a_digest = _fetch_layer_digest(ocx.registry, unique_repo, "1.0.0")
+
+    _push_multi_layer(
+        ocx, unique_repo, "2.0.0",
+        [f"{layer_a_digest}.tar.xz", str(bundle_b)],
+        tmp_path, new=False,
+    )
+    ocx.plain("index", "update", f"{unique_repo}:2.0.0")
+
+    result = ocx.json("install", f"{unique_repo}:2.0.0")
+    content = Path(result[f"{unique_repo}:2.0.0"]["path"])
+    assert (content / "lib" / "liba.so").exists(), "xz layer A not extracted on consumer"
+    assert (content / "lib" / "liba.so").read_text() == "xz-shared"
+    assert (content / "bin" / "tool").exists(), "File layer B missing"
+
+
+def test_push_bare_digest_is_rejected(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """A bare `sha256:<hex>` with no `.<ext>` suffix must be refused at
+    the CLI layer — OCX refuses to guess the media type of a reused
+    layer, because a wrong guess silently breaks consumers."""
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool": "#!/bin/sh\necho ok\n"})
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    (tmp_path / "meta.json").write_text(json.dumps({
+        "type": "bundle", "version": 1,
+        "env": [{"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"}],
+    }))
+    bare_digest = "sha256:" + "0" * 64
+    result = ocx.run(
+        "package", "push", "-p", current_platform(),
+        "-m", str(tmp_path / "meta.json"),
+        "-n",
+        f"{ocx.registry}/{unique_repo}:1.0.0",
+        bare_digest,
+        str(bundle_b),
+        check=False, format=None,
+    )
+    assert result.returncode != 0
+    combined = (result.stderr + result.stdout).lower()
+    assert "bare layer digest" in combined or "extension suffix" in combined, (
+        f"expected a bare-digest error mentioning the required suffix, got:\n{result.stderr}\n{result.stdout}"
+    )
+
+
+def test_push_digest_layer_not_found(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """A well-formed `sha256:<hex>.tar.gz` pointing at a blob the
+    registry doesn't actually have fails with a clear error."""
+    fake_digest = "sha256:" + "0" * 64
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool": "#!/bin/sh\necho ok\n"})
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    (tmp_path / "meta.json").write_text(json.dumps({
+        "type": "bundle", "version": 1,
+        "env": [{"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"}],
+    }))
+    result = ocx.run(
+        "package", "push", "-p", current_platform(),
+        "-m", str(tmp_path / "meta.json"),
+        "-n",
+        f"{ocx.registry}/{unique_repo}:1.0.0",
+        f"{fake_digest}.tar.gz",
+        str(bundle_b),
+        check=False, format=None,
+    )
+    assert result.returncode != 0
+    assert "not found" in result.stderr.lower() or "blob" in result.stderr.lower()
+
+
+def test_cascade_multi_layer(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push a 2-layer package with --cascade, verify rolling tags exist."""
+    layer_a = _make_layer_content(tmp_path, "a", {"lib/liba.so": "liba"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool": "#!/bin/sh\necho hi\n"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+
+    _push_multi_layer(
+        ocx, unique_repo, "1.2.3",
+        [str(bundle_a), str(bundle_b)],
+        tmp_path, cascade=True,
+    )
+    # Index all tags so we can verify cascade
+    ocx.plain("index", "update", unique_repo)
+    result = ocx.json("index", "list", unique_repo)
+    tags = result[unique_repo]
+    assert "1.2.3" in tags
+    assert "1.2" in tags
+    assert "1" in tags

--- a/test/tests/test_multi_layer.py
+++ b/test/tests/test_multi_layer.py
@@ -351,6 +351,35 @@ def test_push_digest_layer_not_found(
     assert "not found" in result.stderr.lower() or "blob" in result.stderr.lower()
 
 
+def test_push_digest_only_without_metadata_fails(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """When every layer is a digest reference, `--metadata` is mandatory —
+    there is no file layer to sniff a sibling metadata path from. The
+    guard must fire before any network I/O."""
+    # Stage a real layer so we have a valid digest on the registry to
+    # reference. Without this, the push could fail for the wrong reason
+    # (BlobNotFound) and hide the guard we're trying to cover.
+    layer_a = _make_layer_content(tmp_path, "a", {"lib/a.so": "a"})
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle_a)], tmp_path)
+    ocx.plain("index", "update", f"{unique_repo}:1.0.0")
+    layer_a_digest = _fetch_layer_digest(ocx.registry, unique_repo, "1.0.0")
+
+    result = ocx.run(
+        "package", "push", "-p", current_platform(),
+        "-n",
+        f"{ocx.registry}/{unique_repo}:2.0.0",
+        f"{layer_a_digest}.tar.gz",
+        check=False, format=None,
+    )
+    assert result.returncode != 0
+    combined = (result.stderr + result.stdout).lower()
+    assert "--metadata" in combined or "metadata is required" in combined, (
+        f"expected a metadata-required error, got:\n{result.stderr}\n{result.stdout}"
+    )
+
+
 def test_cascade_multi_layer(
     ocx: OcxRunner, unique_repo: str, tmp_path: Path
 ):

--- a/test/tests/test_multi_layer.py
+++ b/test/tests/test_multi_layer.py
@@ -129,10 +129,12 @@ def test_push_single_layer(
     _push_multi_layer(ocx, unique_repo, "1.0.0", [str(bundle)], tmp_path)
 
 
-def test_push_no_layer_fails(
+def test_push_zero_layers_succeeds_with_metadata(
     ocx: OcxRunner, unique_repo: str, tmp_path: Path
 ):
-    """Push with no layers (just the identifier) fails."""
+    """Push with zero layers but explicit `--metadata` is a valid
+    OCI config-only artifact (e.g. referrer-only / description-only
+    manifests). Verify it round-trips via the registry manifest API."""
     meta = tmp_path / "meta.json"
     meta.write_text(json.dumps({
         "type": "bundle", "version": 1,
@@ -140,16 +142,66 @@ def test_push_no_layer_fails(
     }))
     plat = current_platform()
     fq = f"{ocx.registry}/{unique_repo}:1.0.0"
-    result = ocx.run(
+    ocx.plain(
         "package", "push", "-p", plat, "-m", str(meta), "-n", fq,
+    )
+
+    # Walk the index → per-platform manifest and confirm `layers: []`.
+    index = _fetch_manifest(ocx.registry, unique_repo, "1.0.0")
+    first_manifest_digest = index["manifests"][0]["digest"]
+    image_manifest = _fetch_manifest(ocx.registry, unique_repo, first_manifest_digest)
+    assert image_manifest["layers"] == [], (
+        f"expected empty layers array for config-only artifact, got: {image_manifest['layers']!r}"
+    )
+
+
+def test_push_zero_layers_without_metadata_fails(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push with zero layers and no `--metadata` is rejected before any
+    network I/O — the CLI cannot infer a sibling metadata path without
+    a file layer to key off."""
+    plat = current_platform()
+    fq = f"{ocx.registry}/{unique_repo}:1.0.0"
+    result = ocx.run(
+        "package", "push", "-p", plat, "-n", fq,
         check=False, format=None,
     )
     assert result.returncode != 0
+    combined = (result.stderr + result.stdout).lower()
+    assert "--metadata" in combined or "metadata is required" in combined, (
+        f"expected a metadata-required error, got:\n{result.stderr}\n{result.stdout}"
+    )
 
 
 # ---------------------------------------------------------------------------
 # Round-trip tests (push + install)
 # ---------------------------------------------------------------------------
+
+
+def test_round_trip_zero_layers(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """Push a config-only package (zero layers + metadata), install it,
+    verify the install succeeds and produces an empty content/ directory."""
+    meta = tmp_path / "meta.json"
+    meta.write_text(json.dumps({
+        "type": "bundle", "version": 1,
+        "env": [{"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"}],
+    }))
+    plat = current_platform()
+    short = f"{unique_repo}:1.0.0"
+    fq = f"{ocx.registry}/{short}"
+    ocx.plain("package", "push", "-p", plat, "-m", str(meta), "-n", fq)
+    ocx.plain("index", "update", short)
+
+    result = ocx.json("install", short)
+    content = Path(result[short]["path"])
+
+    assert_dir_exists(content)
+    assert list(content.iterdir()) == [], (
+        f"expected empty content/ for zero-layer package, got: {list(content.iterdir())!r}"
+    )
 
 
 def test_round_trip_multi_layer(
@@ -288,6 +340,21 @@ def test_push_digest_layer_reuse_tar_xz(
     )
     ocx.plain("index", "update", f"{unique_repo}:2.0.0")
 
+    # Walk the pushed v2 manifest and assert the reused layer descriptor
+    # carries the correct media type. Catches the regression at the
+    # manifest layer rather than waiting for install-time extraction to
+    # blow up on a mismatched compression algorithm.
+    index = _fetch_manifest(ocx.registry, unique_repo, "2.0.0")
+    image_manifest = _fetch_manifest(
+        ocx.registry, unique_repo, index["manifests"][0]["digest"]
+    )
+    reused = next(
+        layer for layer in image_manifest["layers"] if layer["digest"] == layer_a_digest
+    )
+    assert reused["mediaType"] == "application/vnd.oci.image.layer.v1.tar+xz", (
+        f"reused layer A should declare tar+xz, got {reused['mediaType']}"
+    )
+
     result = ocx.json("install", f"{unique_repo}:2.0.0")
     content = Path(result[f"{unique_repo}:2.0.0"]["path"])
     assert (content / "lib" / "liba.so").exists(), "xz layer A not extracted on consumer"
@@ -348,7 +415,7 @@ def test_push_digest_layer_not_found(
         check=False, format=None,
     )
     assert result.returncode != 0
-    assert "not found" in result.stderr.lower() or "blob" in result.stderr.lower()
+    assert "blob not found" in result.stderr.lower()
 
 
 def test_push_digest_only_without_metadata_fails(

--- a/test/tests/test_push_pull_three_layers.py
+++ b/test/tests/test_push_pull_three_layers.py
@@ -1,0 +1,85 @@
+"""Three-layer push/pull round-trip acceptance test.
+
+Ensures multi-layer support scales past the two-layer fixtures in
+`test_multi_layer.py`: three distinct archives, pushed in one command,
+pulled by `ocx install`, then assembled into a package whose `content/`
+is the disjoint union of all three layers.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from src import OcxRunner, assert_dir_exists, current_platform
+
+
+def _make_layer_content(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    layer_dir = tmp_path / f"layer-{name}"
+    for rel_path, content in files.items():
+        p = layer_dir / rel_path
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+        if rel_path.startswith("bin/"):
+            p.chmod(p.stat().st_mode | stat.S_IEXEC)
+    return layer_dir
+
+
+def _bundle_layer(ocx: OcxRunner, layer_dir: Path, tmp_path: Path, *, ext: str = "tar.gz") -> Path:
+    bundle = tmp_path / f"{layer_dir.name}.{ext}"
+    metadata_path = tmp_path / f"{layer_dir.name}-meta.json"
+    metadata_path.write_text(json.dumps({
+        "type": "bundle",
+        "version": 1,
+        "env": [
+            {"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"},
+        ],
+    }))
+    ocx.plain("package", "create", "-m", str(metadata_path), "-o", str(bundle), str(layer_dir))
+    return bundle
+
+
+def test_push_pull_three_layers(ocx: OcxRunner, unique_repo: str, tmp_path: Path):
+    """Push three distinct archive layers, install, verify content/ is the union.
+
+    Layers are intentionally non-overlapping — the assemble walker
+    rejects overlap, so a valid round-trip needs disjoint paths. Each
+    layer contributes one file under a different top-level directory:
+    `lib/`, `bin/`, `share/`.
+    """
+    layer_a = _make_layer_content(tmp_path, "a", {"lib/liba.so": "liba-content"})
+    layer_b = _make_layer_content(tmp_path, "b", {"bin/tool": "#!/bin/sh\necho hello\n"})
+    layer_c = _make_layer_content(tmp_path, "c", {"share/doc/NOTES.md": "# Notes\n"})
+
+    bundle_a = _bundle_layer(ocx, layer_a, tmp_path)
+    bundle_b = _bundle_layer(ocx, layer_b, tmp_path)
+    bundle_c = _bundle_layer(ocx, layer_c, tmp_path)
+
+    meta = tmp_path / "meta.json"
+    meta.write_text(json.dumps({
+        "type": "bundle",
+        "version": 1,
+        "env": [
+            {"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"},
+        ],
+    }))
+
+    short = f"{unique_repo}:1.0.0"
+    fq = f"{ocx.registry}/{short}"
+    plat = current_platform()
+    ocx.plain(
+        "package", "push", "-p", plat, "-m", str(meta), "-n", fq,
+        str(bundle_a), str(bundle_b), str(bundle_c),
+    )
+    ocx.plain("index", "update", short)
+
+    result = ocx.json("install", short)
+    content = Path(result[short]["path"])
+
+    assert_dir_exists(content)
+    assert (content / "lib" / "liba.so").exists(), "Layer A file missing"
+    assert (content / "lib" / "liba.so").read_text() == "liba-content"
+    assert (content / "bin" / "tool").exists(), "Layer B file missing"
+    assert (content / "share" / "doc" / "NOTES.md").exists(), "Layer C file missing"
+    assert (content / "share" / "doc" / "NOTES.md").read_text() == "# Notes\n"

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -680,8 +680,9 @@ ocx package push [OPTIONS] --platform <PLATFORM> <IDENTIFIER> <LAYERS>...
 
 - `<IDENTIFIER>`: Package identifier including the tag, e.g. `cmake:3.28.1_20260216120000`.
 - `<LAYERS>...`: One or more layers, in order (base layer first, top layer last). Each layer is either:
-  - a path to a pre-built archive file (`.tar.gz`, `.tar.xz`, `.zip`), or
-  - an OCI digest (e.g. `sha256:abc…`) of a layer that already exists in the target registry.
+  - a path to a pre-built archive file (`.tar.gz`, `.tgz`, `.tar.xz`, or `.txz`), or
+  - a digest reference of the form `sha256:<hex>.<ext>` (e.g. `sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08.tar.gz`) pointing at a layer that already exists in the target registry. The `<ext>` suffix is mandatory — OCI blob HEADs do not carry the original media type, so the publisher must declare it. Bare digests are rejected.
+  - To force file interpretation of a pathological filename that happens to match the digest shape, prefix it with `./` (e.g. `./sha256:abc….tar.gz`).
 
 **Options**
 
@@ -698,8 +699,10 @@ Digest-referenced layers are not re-uploaded — ocx only HEADs the registry to 
 # Push a fresh base + tool combination
 ocx package push -p linux/amd64 mytool:1.0.0 base.tar.gz tool.tar.gz
 
-# Reuse the same base by digest in a later release
-ocx package push -p linux/amd64 mytool:1.0.1 sha256:abc123… newtool.tar.gz
+# Reuse the same base by digest in a later release.
+# The digest is the full 64-char sha256 hex written verbatim —
+# the ellipsis is shown here only to keep the example short.
+ocx package push -p linux/amd64 mytool:1.0.1 sha256:<hex>.tar.gz newtool.tar.gz
 ```
 :::
 

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -668,7 +668,7 @@ digest are safe to run concurrently.
 
 #### `push` {#package-push}
 
-Publishes a package to the registry as one or more layers. Each layer is uploaded as an OCI blob and recorded in a single image manifest, in the order given on the command line.
+Publishes a package to the registry as zero or more layers. Each layer is uploaded as an OCI blob and recorded in a single image manifest, in the order given on the command line. A zero-layer push produces a config-only OCI artifact (referrer-only / description-only manifest) and requires `--metadata`.
 
 **Usage**
 
@@ -679,17 +679,19 @@ ocx package push [OPTIONS] --platform <PLATFORM> <IDENTIFIER> <LAYERS>...
 **Arguments**
 
 - `<IDENTIFIER>`: Package identifier including the tag, e.g. `cmake:3.28.1_20260216120000`.
-- `<LAYERS>...`: One or more layers, in order (base layer first, top layer last). Each layer is either:
+- `<LAYERS>...`: Zero or more layers, in order (base layer first, top layer last). Each layer is either:
   - a path to a pre-built archive file (`.tar.gz`, `.tgz`, `.tar.xz`, or `.txz`), or
   - a digest reference of the form `sha256:<hex>.<ext>` (e.g. `sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08.tar.gz`) pointing at a layer that already exists in the target registry. The `<ext>` suffix is mandatory — OCI blob HEADs do not carry the original media type, so the publisher must declare it. Bare digests are rejected.
+  - Extension aliases: `.tgz` is accepted as an alias for `.tar.gz`, and `.txz` for `.tar.xz`. The canonical forms `tar.gz` / `tar.xz` are what ocx emits internally — aliases are normalized on parse.
   - To force file interpretation of a pathological filename that happens to match the digest shape, prefix it with `./` (e.g. `./sha256:abc….tar.gz`).
+  - Omitting all layers produces a config-only OCI artifact with `layers: []`, valid for referrer-only / description-only manifests. `--metadata` is required in that case.
 
 **Options**
 
 - `-p`, `--platform <PLATFORM>`: Target platform of the package (required).
 - `-c`, `--cascade`: Cascade rolling releases. When set, pushing `cmake:3.28.1_20260216120000` automatically re-points the rolling ancestors (`cmake:3.28.1`, `cmake:3.28`, `cmake:3`, and `cmake:latest` if applicable) to the new build — only if this is genuinely the latest at each specificity level. See [tag cascades](../user-guide.md#versioning-cascade).
 - `-n`, `--new`: Declare this as a new package that does not exist in the registry yet. Skips the pre-push tag listing that is otherwise used for cascade resolution.
-- `-m`, `--metadata <PATH>`: Path to the metadata file. If omitted, ocx looks for a sidecar file next to the first file layer (e.g. `pkg.tar.gz` → `pkg-metadata.json`). Required when all layers are digest references.
+- `-m`, `--metadata <PATH>`: Path to the metadata file. If omitted, ocx looks for a sidecar file next to the first file layer (e.g. `pkg.tar.gz` → `pkg-metadata.json`). Required when no file layers are provided (all layers are digest references, or the layer list is empty).
 - `-h`, `--help`: Print help information.
 
 ::: tip Layer reuse

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -668,26 +668,44 @@ digest are safe to run concurrently.
 
 #### `push` {#package-push}
 
-Publishes a package bundle to the registry. A [candidate symlink](../user-guide.md#path-resolution) is created locally after a successful push.
+Publishes a package to the registry as one or more layers. Each layer is uploaded as an OCI blob and recorded in a single image manifest, in the order given on the command line.
 
 **Usage**
 
 ```shell
-ocx package push [OPTIONS] <IDENTIFIER> <CONTENT>
+ocx package push [OPTIONS] --platform <PLATFORM> <IDENTIFIER> <LAYERS>...
 ```
 
 **Arguments**
 
 - `<IDENTIFIER>`: Package identifier including the tag, e.g. `cmake:3.28.1_20260216120000`.
-- `<CONTENT>`: Path to the package bundle (`.tar.xz`) to publish.
+- `<LAYERS>...`: One or more layers, in order (base layer first, top layer last). Each layer is either:
+  - a path to a pre-built archive file (`.tar.gz`, `.tar.xz`, `.zip`), or
+  - an OCI digest (e.g. `sha256:abc…`) of a layer that already exists in the target registry.
 
 **Options**
 
 - `-p`, `--platform <PLATFORM>`: Target platform of the package (required).
 - `-c`, `--cascade`: Cascade rolling releases. When set, pushing `cmake:3.28.1_20260216120000` automatically re-points the rolling ancestors (`cmake:3.28.1`, `cmake:3.28`, `cmake:3`, and `cmake:latest` if applicable) to the new build — only if this is genuinely the latest at each specificity level. See [tag cascades](../user-guide.md#versioning-cascade).
 - `-n`, `--new`: Declare this as a new package that does not exist in the registry yet. Skips the pre-push tag listing that is otherwise used for cascade resolution.
-- `-m`, `--metadata <PATH>`: Path to the metadata file. If omitted, ocx looks for a sidecar file next to the bundle.
+- `-m`, `--metadata <PATH>`: Path to the metadata file. If omitted, ocx looks for a sidecar file next to the first file layer (e.g. `pkg.tar.gz` → `pkg-metadata.json`). Required when all layers are digest references.
 - `-h`, `--help`: Print help information.
+
+::: tip Layer reuse
+Digest-referenced layers are not re-uploaded — ocx only HEADs the registry to verify they exist. This is the foundation of the [layer dedup model](../user-guide.md#file-structure-layers): a base layer pushed once can be referenced from any number of subsequent packages by digest.
+
+```shell
+# Push a fresh base + tool combination
+ocx package push -p linux/amd64 mytool:1.0.0 base.tar.gz tool.tar.gz
+
+# Reuse the same base by digest in a later release
+ocx package push -p linux/amd64 mytool:1.0.1 sha256:abc123… newtool.tar.gz
+```
+:::
+
+::: warning Bring your own archives
+`ocx package push` does not bundle a directory for you. Each file layer must be a pre-built archive. Re-bundling the same content yields a non-deterministic digest (timestamps, compression entropy) and defeats layer reuse — use [`ocx package create`](#package-create) to produce a stable archive once, then push and reference it by digest from later commands.
+:::
 
 #### `describe` {#package-describe}
 

--- a/website/src/docs/user-guide.md
+++ b/website/src/docs/user-guide.md
@@ -105,7 +105,7 @@ The layer store enables a different kind of dedup than the package store. The pa
 [Docker image layers][docker-layers] are the same concept at the registry level: an image is a stack of layers, each addressed by digest, downloaded only when missing from the local cache. ocx applies this to binary packages instead of containers. [pnpm][pnpm] uses a comparable trick on the install side, storing every package version once in a content-addressed store and hardlinking them into individual `node_modules/` trees.
 :::
 
-**Publishing multi-layer packages.** When you call [`ocx package push`][cmd-package-push], every positional argument after the identifier is a layer. Each layer is either a path to a local archive file or a digest reference to a layer that already exists in the target registry:
+**Publishing multi-layer packages.** When you call [`ocx package push`][cmd-package-push], every positional argument after the identifier is a layer — zero or more. Each layer is either a path to a local archive file or a digest reference to a layer that already exists in the target registry. A push with zero layers is valid too: it produces a config-only OCI artifact (useful for referrer-only / description-only manifests) and requires `--metadata` since there is no file layer to sniff a sibling metadata path from.
 
 ```shell
 # Two-layer package: shared base + package-specific top
@@ -119,6 +119,10 @@ ocx package push -p linux/amd64 mytool:1.2.4 sha256:<hex>.tar.gz newtool.tar.gz
 ```
 
 The order matters for the manifest descriptor list, but assembled content must not overlap — two layers cannot contain the same file path. Overlap is rejected at install time with a clear error.
+
+::: info Digest verification on pull
+Every layer blob downloaded by `ocx install` or `ocx package pull` is streamed through SHA-256 on the way to disk and compared against the digest declared in the manifest before extraction. A mismatch — the registry serving different bytes for the same digest ([CWE-345](https://cwe.mitre.org/data/definitions/345.html)) — deletes the tampered file and fails the command. Zero-layer pulls are valid: a config-only package (produced by `ocx package push` with no file layers and `--metadata`) installs into an empty `content/` directory, which is the expected shape for referrer-only or description-only artifacts.
+:::
 
 ::: warning Bring your own archives
 `ocx package push` does **not** bundle a directory for you. Each layer must be a pre-built archive (`.tar.gz` / `.tgz` or `.tar.xz` / `.txz`). This is intentional: archive creation is non-deterministic (timestamps, compression entropy, file ordering), so re-bundling the same content yields a different digest and defeats layer reuse. Use [`ocx package create`][cmd-package-create] if you need to bundle a directory — that command produces a stable archive once, which you can then push and reference by digest from any number of subsequent packages.

--- a/website/src/docs/user-guide.md
+++ b/website/src/docs/user-guide.md
@@ -111,14 +111,19 @@ The layer store enables a different kind of dedup than the package store. The pa
 # Two-layer package: shared base + package-specific top
 ocx package push -p linux/amd64 mytool:1.2.3 base.tar.gz tool.tar.gz
 
-# Re-publish with the base layer reused by digest — no re-upload
-ocx package push -p linux/amd64 mytool:1.2.4 sha256:abc123… newtool.tar.gz
+# Re-publish with the base layer reused by digest — no re-upload.
+# The digest ref must spell out the original archive extension
+# (`.tar.gz` / `.tgz` / `.tar.xz` / `.txz`) — OCI blob HEADs do not
+# carry the media type, so ocx refuses to guess.
+ocx package push -p linux/amd64 mytool:1.2.4 sha256:<hex>.tar.gz newtool.tar.gz
 ```
 
 The order matters for the manifest descriptor list, but assembled content must not overlap — two layers cannot contain the same file path. Overlap is rejected at install time with a clear error.
 
 ::: warning Bring your own archives
-`ocx package push` does **not** bundle a directory for you. Each layer must be a pre-built archive (`.tar.gz`, `.tar.xz`, `.zip`). This is intentional: archive creation is non-deterministic (timestamps, compression entropy, file ordering), so re-bundling the same content yields a different digest and defeats layer reuse. Use [`ocx package create`][cmd-package-create] if you need to bundle a directory — that command produces a stable archive once, which you can then push and reference by digest from any number of subsequent packages.
+`ocx package push` does **not** bundle a directory for you. Each layer must be a pre-built archive (`.tar.gz` / `.tgz` or `.tar.xz` / `.txz`). This is intentional: archive creation is non-deterministic (timestamps, compression entropy, file ordering), so re-bundling the same content yields a different digest and defeats layer reuse. Use [`ocx package create`][cmd-package-create] if you need to bundle a directory — that command produces a stable archive once, which you can then push and reference by digest from any number of subsequent packages.
+
+If a file in your current directory is literally named like a digest reference (e.g. `sha256:abc….tar.gz`), prefix it with `./` to force file interpretation — bare `sha256:…` tokens are always parsed as digest refs.
 :::
 
 ::: tip Designing for reuse

--- a/website/src/docs/user-guide.md
+++ b/website/src/docs/user-guide.md
@@ -82,6 +82,51 @@ When `ocx install cmake:3.28` creates the symlink `symlinks/…/cmake/candidates
 
 *Commands: [`ocx install`][cmd-install] adds packages; [`ocx uninstall --purge`][cmd-uninstall] removes a specific one; [`ocx clean`][cmd-clean] removes all unreferenced packages.*
 
+#### Layers {#file-structure-layers}
+
+A package on disk looks monolithic — one `content/` directory under one digest — but the bytes inside it can come from more than one upstream archive. Each archive is a <Tooltip term="layer">An OCI image layer: a single tar archive (gzip or xz compressed) addressed in the registry by its own SHA-256 digest. The OCI image manifest lists all layers that compose a package; on pull, ocx extracts each layer once into the shared layer store and assembles them into the package's `content/` directory via hardlinks.</Tooltip>, stored once in `~/.ocx/layers/` and shared across every package that references it.
+
+<Tree>
+  <Node name="~/.ocx/layers/" icon="🗂️" open>
+    <Node name="{registry}/" icon="📁" open-icon="📂" open>
+      <Node name="sha256/ab/c123…/" icon="📁" open-icon="📂" open>
+        <Description>one directory per unique layer blob</Description>
+        <Node name="content/" icon="📂">
+          <Description>extracted layer files — hardlink source for assembled packages</Description>
+        </Node>
+      </Node>
+    </Node>
+  </Node>
+</Tree>
+
+The layer store enables a different kind of dedup than the package store. The package store dedups whole builds — two tags pointing at the exact same binary share one directory. The layer store dedups *parts* of builds: a 200 MB shared base layer used by ten packages is downloaded, extracted, and stored exactly once. Each package's `content/` is then assembled by hardlinking files from one or more layer directories, so the package looks complete even though no bytes were copied.
+
+::: info Similar to Docker image layers and pnpm's content store
+[Docker image layers][docker-layers] are the same concept at the registry level: an image is a stack of layers, each addressed by digest, downloaded only when missing from the local cache. ocx applies this to binary packages instead of containers. [pnpm][pnpm] uses a comparable trick on the install side, storing every package version once in a content-addressed store and hardlinking them into individual `node_modules/` trees.
+:::
+
+**Publishing multi-layer packages.** When you call [`ocx package push`][cmd-package-push], every positional argument after the identifier is a layer. Each layer is either a path to a local archive file or a digest reference to a layer that already exists in the target registry:
+
+```shell
+# Two-layer package: shared base + package-specific top
+ocx package push -p linux/amd64 mytool:1.2.3 base.tar.gz tool.tar.gz
+
+# Re-publish with the base layer reused by digest — no re-upload
+ocx package push -p linux/amd64 mytool:1.2.4 sha256:abc123… newtool.tar.gz
+```
+
+The order matters for the manifest descriptor list, but assembled content must not overlap — two layers cannot contain the same file path. Overlap is rejected at install time with a clear error.
+
+::: warning Bring your own archives
+`ocx package push` does **not** bundle a directory for you. Each layer must be a pre-built archive (`.tar.gz`, `.tar.xz`, `.zip`). This is intentional: archive creation is non-deterministic (timestamps, compression entropy, file ordering), so re-bundling the same content yields a different digest and defeats layer reuse. Use [`ocx package create`][cmd-package-create] if you need to bundle a directory — that command produces a stable archive once, which you can then push and reference by digest from any number of subsequent packages.
+:::
+
+::: tip Designing for reuse
+The layer reuse workflow is most valuable when you have many packages that share a large common base — a runtime library, a vendored toolchain, or a fixed dataset. Push the base once, record its digest, and reference it from every dependent package's push command. The registry stores it once; ocx downloads it once; every package gets a fresh `content/` view assembled from the same shared layer.
+:::
+
+*Commands: [`ocx package push`][cmd-package-push] publishes layered packages; [`ocx package create`][cmd-package-create] bundles a directory into a stable archive.*
+
 #### Tags {#file-structure-tags}
 
 When you run `ocx install cmake:3.28`, how does ocx know which binary to fetch? It looks up the tag `3.28` in the local tag store and finds the corresponding <Tooltip term="digest">The content fingerprint stored in the OCI registry manifest. A tag like `3.28` is just a human-readable alias; the digest is the canonical, immutable identifier that pinpoints the exact binary build behind that tag at index-update time.</Tooltip>. The tag store is a local copy of that mapping — no network required.
@@ -683,9 +728,12 @@ digest-derived.
 [terraform-lockfile]: https://developer.hashicorp.com/terraform/language/files/dependency-lock
 [docker-credential]: https://github.com/keirlawson/docker_credential
 [helm-oci]: https://helm.sh/docs/topics/registries/
+[docker-layers]: https://docs.docker.com/get-started/docker-concepts/building-images/understanding-image-layers/
+[pnpm]: https://pnpm.io/motivation#saving-disk-space
 
 <!-- commands -->
 [cmd-clean]: ./reference/command-line.md#clean
+[cmd-package-create]: ./reference/command-line.md#package-create
 [cmd-deselect]: ./reference/command-line.md#deselect
 [cmd-find]: ./reference/command-line.md#find
 [cmd-exec]: ./reference/command-line.md#exec


### PR DESCRIPTION
## Summary
- Add OCI multi-layer manifest support across push and pull: `ocx package push <id> <layers...>` accepts multiple pre-built archives or `sha256:<hex>.<ext>` digest references to layers already in the registry.
- Digest-referenced layers are verified via a real HEAD (`head_blob` on `OciTransport`, backed by `fetch_blob_size` in the patched `oci-client` fork) instead of downloading the full blob — avoids OOM on multi-GB reused base layers.
- Pull side drops the single-layer guard and routes through `assemble_from_layers`, which already supported N layers.

## Breaking change
\`ocx package push\` no longer accepts a positional content path or auto-bundles a directory. Each layer must be a pre-built archive (\`.tar.gz\`, \`.tar.xz\`) or a digest reference in \`sha256:<hex>.<ext>\` form. Use \`ocx package create\` to produce a stable archive once, then reference it from later pushes — re-bundling defeats layer reuse.

## Notes
- New \`LayerRef\` enum parsed by clap; bare \`sha256:<hex>\` without an extension is rejected at parse time because the OCI distribution spec exposes no way to recover media type from a blob HEAD.
- User-guide "Layers" section and \`package push\` reference updated.
- \`[workspace].exclude = ["external/rust-oci-client"]\` lets cargo/clippy/fmt run directly inside the fork while \`[patch.crates-io]\` still pulls it in here.

## Test plan
- [ ] \`task verify\`
- [ ] \`ocx package push\` with a mix of file-path layers and digest-ref layers against a local registry
- [ ] \`ocx package pull\` of a multi-layer manifest reassembles correctly
- [ ] HEAD-only size lookup confirmed (no full blob download) for digest-referenced layers