### PR TITLE
refactor(package): drop redundant root identifier from ResolvedPackage

### DIFF
--- a/crates/ocx_cli/src/command/deps.rs
+++ b/crates/ocx_cli/src/command/deps.rs
@@ -78,9 +78,9 @@ impl Deps {
                     }
                 }
                 // Root packages are always public — they are the roots of env resolution.
-                if seen.insert(info.resolved.identifier.digest()) {
+                if seen.insert(info.identifier.digest()) {
                     entries.push(api::data::deps::FlatDependency {
-                        identifier: oci::Identifier::from(info.resolved.identifier.clone()),
+                        identifier: oci::Identifier::from(info.identifier.clone()),
                         visibility: ocx_lib::package::metadata::visibility::Visibility::Public,
                     });
                 }
@@ -222,7 +222,7 @@ async fn resolve_dep_via_metadata(
     // the declared digest matches the stored content digest).
     let content = fs.packages.content(id);
     if tokio::fs::try_exists(&content).await.unwrap_or(false) {
-        return load_install_info(content).await;
+        return load_install_info(id.clone(), content).await;
     }
 
     // Fallback: the declared digest is an Image Index digest — look up the
@@ -230,10 +230,10 @@ async fn resolve_dep_via_metadata(
     let repo_key = oci::Repository::from(&**id);
     let resolved_id = resolved_map.get(&repo_key)?;
     let content = fs.packages.content(resolved_id);
-    load_install_info(content).await
+    load_install_info((*resolved_id).clone(), content).await
 }
 
-async fn load_install_info(content: std::path::PathBuf) -> Option<InstallInfo> {
+async fn load_install_info(identifier: oci::PinnedIdentifier, content: std::path::PathBuf) -> Option<InstallInfo> {
     let (metadata, resolved) = tokio::join!(
         Metadata::read_json(content.with_file_name("metadata.json")),
         ResolvedPackage::read_json(content.with_file_name("resolve.json")),
@@ -241,7 +241,7 @@ async fn load_install_info(content: std::path::PathBuf) -> Option<InstallInfo> {
     let metadata = metadata.ok()?;
     let resolved = resolved.ok()?;
     Some(InstallInfo {
-        identifier: resolved.identifier.clone(),
+        identifier,
         metadata,
         resolved,
         content,

--- a/crates/ocx_cli/src/command/index_catalog.rs
+++ b/crates/ocx_cli/src/command/index_catalog.rs
@@ -12,23 +12,39 @@ use crate::api;
 pub struct IndexCatalog {
     /// List tags for each repository in the catalog.
     #[clap(long)]
-    with_tags: bool,
+    tags: bool,
+
+    /// Registries to list repositories from (defaults to OCX_DEFAULT_REGISTRY).
+    #[arg(value_name = "REGISTRY")]
+    registries: Vec<String>,
 }
 
 impl IndexCatalog {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        let registry = context.default_registry();
+        let registries = if self.registries.is_empty() {
+            vec![context.default_registry()]
+        } else {
+            self.registries.clone()
+        };
 
-        let repositories = context.default_index().list_repositories(&registry).await?;
-        if !self.with_tags {
-            let catalog = api::data::catalog::Catalog::without_tags(repositories);
+        let mut repositories = Vec::new();
+        for registry in &registries {
+            let repos = context.default_index().list_repositories(registry).await?;
+            repositories.extend(repos.into_iter().map(|r| oci::Repository::new(registry, r)));
+        }
+        repositories.sort();
+
+        if !self.tags {
+            let names = repositories.iter().map(|r| r.to_string()).collect();
+            let catalog = api::data::catalog::Catalog::without_tags(names);
             context.api().report(&catalog)?;
             return Ok(ExitCode::SUCCESS);
         }
 
         let mut join_set = tokio::task::JoinSet::<anyhow::Result<(String, Vec<String>)>>::new();
-        for repository in repositories {
-            let identifier = oci::Identifier::new_registry(repository.clone(), registry.clone());
+        for repo in &repositories {
+            let identifier = oci::Identifier::new_registry(repo.repository(), repo.registry());
+            let display_name = repo.to_string();
             let context = context.clone();
             join_set.spawn(async move {
                 let tags = match context.default_index().list_tags(&identifier).await? {
@@ -38,11 +54,11 @@ impl IndexCatalog {
                         Vec::new()
                     }
                 };
-                Ok((identifier.repository().into(), tags))
+                Ok((display_name, tags))
             });
         }
 
-        let mut tags = std::collections::HashMap::new();
+        let mut tags = std::collections::BTreeMap::new();
         while let Some(result) = join_set.join_next().await {
             if let Ok(Ok((repository, repository_tags))) = result {
                 tags.insert(repository, repository_tags);
@@ -53,7 +69,7 @@ impl IndexCatalog {
             }
         }
 
-        let catalog = api::data::catalog::Catalog::with_tags(tags);
+        let catalog = api::data::catalog::Catalog::with_tags(tags.into_iter().collect());
         context.api().report(&catalog)?;
         Ok(ExitCode::SUCCESS)
     }

--- a/crates/ocx_lib/src/file_structure.rs
+++ b/crates/ocx_lib/src/file_structure.rs
@@ -11,7 +11,7 @@ mod tag_store;
 mod temp_store;
 
 pub use blob_store::{BlobDir, BlobStore};
-pub use cas_path::{CasTier, DIGEST_FILENAME, cas_ref_name, write_digest_file};
+pub use cas_path::{CasTier, DIGEST_FILENAME, cas_ref_name, read_digest_file, write_digest_file};
 pub use layer_store::{LayerDir, LayerStore};
 pub use package_store::{PackageDir, PackageStore};
 pub use symlink_store::{SymlinkKind, SymlinkStore};

--- a/crates/ocx_lib/src/file_structure/package_store.rs
+++ b/crates/ocx_lib/src/file_structure/package_store.rs
@@ -206,6 +206,14 @@ impl PackageStore {
         Ok(package_dir_for_content(content_path)?.join("resolve.json"))
     }
 
+    /// Returns the `digest` file path for the package that owns `content_path`.
+    ///
+    /// `content_path` may be a real path or a symlink; symlinks are resolved
+    /// before navigating to the sibling file.
+    pub fn digest_file_for_content(&self, content_path: &Path) -> Result<PathBuf> {
+        Ok(package_dir_for_content(content_path)?.join(super::cas_path::DIGEST_FILENAME))
+    }
+
     /// Lists all package directories currently present in the store.
     ///
     /// A package directory is identified by the presence of a `content/` child

--- a/crates/ocx_lib/src/package/resolved_package.rs
+++ b/crates/ocx_lib/src/package/resolved_package.rs
@@ -21,17 +21,14 @@ pub struct ResolvedDependency {
 /// Persisted resolution state for an installed package.
 ///
 /// Written to `resolve.json` in each object directory at install time.
-/// Contains the package's own fully-resolved identifier and its transitive
-/// dependency closure in topological order (deps before dependents).
-///
-/// The `identifier` is always the **platform-resolved** identifier — for
-/// multi-platform packages this is the platform-specific manifest digest,
-/// never the Image Index digest.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Contains the package's transitive dependency closure in topological order
+/// (deps before dependents). The root package's own identifier is **not**
+/// stored here — it is redundant with the caller context and would couple the
+/// identity of a shared, deduplicated package directory to whichever installer
+/// won the cross-repo race.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ResolvedPackage {
-    /// The fully resolved identifier of this package (registry/repo:tag@digest).
-    pub identifier: PinnedIdentifier,
-
     /// Transitive dependency closure with pre-computed visibility.
     /// Deps before dependents. The root package itself is **not** included.
     /// Leaf packages (no dependencies) have an empty vec.
@@ -40,28 +37,33 @@ pub struct ResolvedPackage {
 
 impl ResolvedPackage {
     /// Creates a leaf package with no dependencies.
-    pub fn new(identifier: PinnedIdentifier) -> Self {
+    pub fn new() -> Self {
         Self {
-            identifier,
             dependencies: Vec::new(),
         }
     }
 
     /// Builds the transitive dependency closure from resolved direct deps.
     ///
-    /// Each item is `(child_resolved, edge_visibility)` where `edge_visibility`
-    /// is the parent's declared visibility for this edge. Propagation rule:
-    /// if the child exports (consumer-visible), result = edge; otherwise Sealed.
-    /// Diamond deps use [`Visibility::merge`] — if any path makes a dep visible,
-    /// the final visibility is the most open.
+    /// Each item is `(child_id, child_resolved, edge_visibility)`. The
+    /// identifier is supplied separately because [`ResolvedPackage`] no longer
+    /// carries its own root identifier — that would couple shared package
+    /// directories to whichever installer won the cross-repo race.
+    ///
+    /// Propagation rule: if the child exports (consumer-visible), result =
+    /// edge; otherwise Sealed. Diamond deps use [`Visibility::merge`] — if any
+    /// path makes a dep visible, the final visibility is the most open.
     ///
     /// Preserves topological order (deps before dependents) and deduplicates
     /// by identity (advisory tags stripped).
-    pub fn with_dependencies(mut self, deps: impl IntoIterator<Item = (ResolvedPackage, Visibility)>) -> Self {
+    pub fn with_dependencies(
+        mut self,
+        deps: impl IntoIterator<Item = (PinnedIdentifier, ResolvedPackage, Visibility)>,
+    ) -> Self {
         // Maps stripped identity → index in self.dependencies for OR dedup.
         let mut seen: std::collections::HashMap<PinnedIdentifier, usize> = std::collections::HashMap::new();
 
-        for (dep, edge) in deps {
+        for (dep_id, dep, edge) in deps {
             // Bubble up transitive deps first (preserves topological order).
             for transitive in dep.dependencies {
                 let propagated = edge.propagate(transitive.visibility);
@@ -80,14 +82,14 @@ impl ResolvedPackage {
             }
 
             // Then add the direct dep itself.
-            let key = dep.identifier.strip_advisory();
+            let key = dep_id.strip_advisory();
             if let Some(&idx) = seen.get(&key) {
                 self.dependencies[idx].visibility = self.dependencies[idx].visibility.merge(edge);
             } else {
                 let idx = self.dependencies.len();
                 seen.insert(key, idx);
                 self.dependencies.push(ResolvedDependency {
-                    identifier: dep.identifier,
+                    identifier: dep_id,
                     visibility: edge,
                 });
             }
@@ -121,9 +123,39 @@ mod tests {
         PinnedIdentifier::try_from(id).unwrap()
     }
 
-    /// Helper: build a ResolvedPackage leaf with no dependencies.
-    fn leaf(repo: &str, hex: char) -> ResolvedPackage {
-        ResolvedPackage::new(make_pinned_repo(repo, hex))
+    /// Test wrapper pairing an identifier with its resolved closure.
+    ///
+    /// Production [`ResolvedPackage`] no longer carries an identifier, but
+    /// the test helpers need to chain resolutions by name — the wrapper keeps
+    /// the (id, resolved) tuple together while tests build graphs.
+    #[derive(Clone)]
+    struct TestPkg {
+        id: PinnedIdentifier,
+        resolved: ResolvedPackage,
+    }
+
+    impl std::ops::Deref for TestPkg {
+        type Target = ResolvedPackage;
+        fn deref(&self) -> &Self::Target {
+            &self.resolved
+        }
+    }
+
+    impl TestPkg {
+        fn with_dependencies(mut self, deps: impl IntoIterator<Item = (TestPkg, Visibility)>) -> Self {
+            self.resolved = self
+                .resolved
+                .with_dependencies(deps.into_iter().map(|(p, v)| (p.id, p.resolved, v)));
+            self
+        }
+    }
+
+    /// Helper: build a `TestPkg` leaf with no dependencies.
+    fn leaf(repo: &str, hex: char) -> TestPkg {
+        TestPkg {
+            id: make_pinned_repo(repo, hex),
+            resolved: ResolvedPackage::new(),
+        }
     }
 
     /// Helper: assert a dep at index has the expected repo and visibility.
@@ -144,7 +176,6 @@ mod tests {
             visibility: Visibility::Public,
         };
         let pkg = ResolvedPackage {
-            identifier: make_pinned(),
             dependencies: vec![dep.clone()],
         };
         let json = serde_json::to_string(&pkg).unwrap();
@@ -160,7 +191,6 @@ mod tests {
             visibility: Visibility::Sealed,
         };
         let pkg = ResolvedPackage {
-            identifier: make_pinned(),
             dependencies: vec![dep.clone()],
         };
         let json = serde_json::to_string(&pkg).unwrap();
@@ -181,7 +211,6 @@ mod tests {
             },
         ];
         let pkg = ResolvedPackage {
-            identifier: make_pinned(),
             dependencies: deps.clone(),
         };
         let json = serde_json::to_string(&pkg).unwrap();
@@ -191,35 +220,43 @@ mod tests {
 
     #[test]
     fn serde_leaf_package_empty_dependencies() {
-        let pkg = ResolvedPackage {
-            identifier: make_pinned(),
-            dependencies: vec![],
-        };
+        let pkg = ResolvedPackage { dependencies: vec![] };
         let json = serde_json::to_string(&pkg).unwrap();
         let deserialized: ResolvedPackage = serde_json::from_str(&json).unwrap();
         assert!(deserialized.dependencies.is_empty());
     }
 
     #[test]
-    fn deserialize_rejects_missing_identifier() {
+    fn deserialize_accepts_empty_dependencies() {
         let json = r#"{"dependencies": []}"#;
+        let pkg: ResolvedPackage = serde_json::from_str(json).unwrap();
+        assert!(pkg.dependencies.is_empty());
+    }
+
+    #[test]
+    fn deserialize_rejects_missing_dependencies() {
+        let json = "{}";
         let result = serde_json::from_str::<ResolvedPackage>(json);
         assert!(result.is_err());
     }
 
     #[test]
-    fn deserialize_rejects_missing_dependencies() {
+    fn deserialize_rejects_old_format_with_identifier_field() {
+        // Old format had a root `identifier` — rejected with deny_unknown_fields
+        // to force a fresh install rather than silently loading stale repo data.
         let id = make_pinned();
-        let json = format!(r#"{{"identifier": "{}"}}"#, id);
+        let json = format!(r#"{{"identifier":"{}","dependencies":[]}}"#, id);
         let result = serde_json::from_str::<ResolvedPackage>(&json);
-        assert!(result.is_err());
+        assert!(
+            result.is_err(),
+            "old format with root identifier field should fail deserialization"
+        );
     }
 
     #[test]
-    fn deserialize_rejects_old_format_bare_strings() {
-        let id = make_pinned();
+    fn deserialize_rejects_old_format_bare_string_deps() {
         let dep = make_dep_pinned();
-        let json = format!(r#"{{"identifier":"{}","dependencies":["{}"]}}"#, id, dep);
+        let json = format!(r#"{{"dependencies":["{}"]}}"#, dep);
         let result = serde_json::from_str::<ResolvedPackage>(&json);
         assert!(
             result.is_err(),

--- a/crates/ocx_lib/src/package_manager/tasks/common.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/common.rs
@@ -57,6 +57,37 @@ pub async fn find_in_store(
     }
 }
 
+/// Reconstructs the [`PinnedIdentifier`](oci::PinnedIdentifier) for a package
+/// loaded through an install symlink (candidate or current).
+///
+/// Registry and repository come from the caller-supplied [`oci::Identifier`].
+/// The digest is read from the shared package directory's `digest` file so the
+/// result is the truly installed content digest, not whatever first installer
+/// happened to win a cross-repo dedup race.
+///
+/// Tag handling depends on `kind`:
+/// - [`SymlinkKind::Candidate`]: caller's tag is preserved — candidate symlinks
+///   are keyed by tag, so the tag and digest always agree by construction.
+/// - [`SymlinkKind::Current`]: caller's tag is stripped. `current` points at
+///   whatever digest was most recently selected, which may have been installed
+///   under a different tag than the caller supplied. Keeping the caller's tag
+///   would produce a hybrid identifier (`pkg:old-tag@new-digest`) that never
+///   existed as a real install.
+pub async fn identifier_for_symlink(
+    objects: &PackageStore,
+    symlink_path: &Path,
+    identifier: &oci::Identifier,
+    kind: file_structure::SymlinkKind,
+) -> Result<oci::PinnedIdentifier, crate::Error> {
+    let digest_path = objects.digest_file_for_content(symlink_path)?;
+    let digest = file_structure::read_digest_file(&digest_path).await?;
+    let base = match kind {
+        file_structure::SymlinkKind::Candidate => identifier.clone(),
+        file_structure::SymlinkKind::Current => identifier.without_tag(),
+    };
+    Ok(oci::PinnedIdentifier::try_from(base.clone_with_digest(digest))?)
+}
+
 /// Loads metadata.json and resolve.json for an existing content path.
 ///
 /// Uses `PackageStore::metadata_for_content` / `resolve_for_content` which

--- a/crates/ocx_lib/src/package_manager/tasks/find.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/find.rs
@@ -98,7 +98,7 @@ mod tests {
     const VALID_METADATA_JSON: &str = r#"{"type":"bundle","version":1}"#;
 
     fn valid_resolve_json() -> String {
-        format!(r#"{{"identifier":"example.com/test/pkg@sha256:{SHA256_HEX}","dependencies":[]}}"#,)
+        r#"{"dependencies":[]}"#.to_string()
     }
 
     fn test_pinned() -> oci::PinnedIdentifier {

--- a/crates/ocx_lib/src/package_manager/tasks/find_symlink.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/find_symlink.rs
@@ -43,7 +43,11 @@ impl PackageManager {
             return Err(PackageErrorKind::SymlinkNotFound(kind));
         }
 
-        let (metadata, resolved) = super::common::load_object_data(&self.file_structure().packages, &symlink_path)
+        let packages = &self.file_structure().packages;
+        let (metadata, resolved) = super::common::load_object_data(packages, &symlink_path)
+            .await
+            .map_err(PackageErrorKind::Internal)?;
+        let identifier = super::common::identifier_for_symlink(packages, &symlink_path, package, kind)
             .await
             .map_err(PackageErrorKind::Internal)?;
 
@@ -55,7 +59,7 @@ impl PackageManager {
         );
 
         Ok(InstallInfo {
-            identifier: resolved.identifier.clone(),
+            identifier,
             metadata,
             resolved,
             content: symlink_path,

--- a/crates/ocx_lib/src/package_manager/tasks/profile_resolve.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/profile_resolve.rs
@@ -131,11 +131,23 @@ impl PackageManager {
         match entry.mode {
             ProfileMode::Candidate => {
                 let path = self.file_structure().symlinks.candidate(&entry.identifier);
-                resolve_symlink_entry(&self.file_structure().packages, entry, &path).await
+                resolve_symlink_entry(
+                    &self.file_structure().packages,
+                    entry,
+                    &path,
+                    crate::file_structure::SymlinkKind::Candidate,
+                )
+                .await
             }
             ProfileMode::Current => {
                 let path = self.file_structure().symlinks.current(&entry.identifier);
-                resolve_symlink_entry(&self.file_structure().packages, entry, &path).await
+                resolve_symlink_entry(
+                    &self.file_structure().packages,
+                    entry,
+                    &path,
+                    crate::file_structure::SymlinkKind::Current,
+                )
+                .await
             }
             ProfileMode::Content => resolve_content_entry(self, entry).await,
         }
@@ -146,6 +158,7 @@ async fn resolve_symlink_entry(
     objects: &crate::file_structure::PackageStore,
     entry: &ProfileEntry,
     symlink_path: &std::path::Path,
+    kind: crate::file_structure::SymlinkKind,
 ) -> ProfileEntryResolution {
     if !symlink_path.exists() {
         return ProfileEntryResolution::broken(
@@ -156,13 +169,23 @@ async fn resolve_symlink_entry(
     }
 
     match super::common::load_object_data(objects, symlink_path).await {
-        Ok((metadata, resolved)) => ProfileEntryResolution::Resolved(ResolvedProfileEntry {
-            identifier: resolved.identifier.clone(),
-            mode: entry.mode,
-            content_path: symlink_path.to_path_buf(),
-            metadata,
-            resolved,
-        }),
+        Ok((metadata, resolved)) => {
+            let identifier =
+                match super::common::identifier_for_symlink(objects, symlink_path, &entry.identifier, kind).await {
+                    Ok(id) => id,
+                    Err(e) => {
+                        log::debug!("Failed to reconstruct identifier for '{}': {}", entry.identifier, e);
+                        return ProfileEntryResolution::broken(entry, Some(symlink_path.to_path_buf()), e.to_string());
+                    }
+                };
+            ProfileEntryResolution::Resolved(ResolvedProfileEntry {
+                identifier,
+                mode: entry.mode,
+                content_path: symlink_path.to_path_buf(),
+                metadata,
+                resolved,
+            })
+        }
         Err(e) => {
             log::debug!("Failed to resolve symlink entry '{}': {}", entry.identifier, e);
             ProfileEntryResolution::broken(entry, Some(symlink_path.to_path_buf()), e.to_string())

--- a/crates/ocx_lib/src/package_manager/tasks/pull.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/pull.rs
@@ -327,14 +327,14 @@ async fn setup_owned(
 
     // Build resolved package and enrich temp dir.
     // Order invariant: setup_dependencies returns results in declaration order.
-    let resolved = ResolvedPackage::new(pinned.clone()).with_dependencies(
+    let resolved = ResolvedPackage::new().with_dependencies(
         metadata
             .dependencies()
             .iter()
             .zip(dependencies.iter())
-            .map(|(decl, info)| (info.resolved.clone(), decl.visibility)),
+            .map(|(decl, info)| (info.identifier.clone(), info.resolved.clone(), decl.visibility)),
     );
-    post_download_actions(&pkg, &resolved).await?;
+    post_download_actions(&pkg, pinned, &resolved).await?;
 
     // Create remaining forward-ref symlinks in temp dir BEFORE move — targets
     // are absolute paths already in their respective stores. This ensures the
@@ -437,6 +437,7 @@ async fn setup_dependencies(
 /// - Writes the `digest` file for recovery of the full digest from the truncated CAS path.
 async fn post_download_actions(
     pkg: &file_structure::PackageDir,
+    pinned: &oci::PinnedIdentifier,
     resolved: &ResolvedPackage,
 ) -> Result<(), PackageErrorKind> {
     resolved
@@ -450,7 +451,7 @@ async fn post_download_actions(
         .await
         .map_err(PackageErrorKind::Internal)?;
 
-    file_structure::write_digest_file(&pkg.digest_file(), &resolved.identifier.digest())
+    file_structure::write_digest_file(&pkg.digest_file(), &pinned.digest())
         .await
         .map_err(PackageErrorKind::Internal)?;
 

--- a/crates/ocx_lib/src/package_manager/tasks/resolve.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/resolve.rs
@@ -111,7 +111,7 @@ impl PackageManager {
                 super::common::export_env(&content, &dep_metadata, &mut entries)?;
             }
             // Then the root package itself.
-            if check_exported(&pkg.resolved.identifier, &mut seen_digests, &mut seen_repos)? {
+            if check_exported(&pkg.identifier, &mut seen_digests, &mut seen_repos)? {
                 super::common::export_env(&pkg.content, &pkg.metadata, &mut entries)?;
             }
         }
@@ -134,7 +134,7 @@ impl PackageManager {
                     check_exported(&dep.identifier, &mut seen_digests, &mut seen_repos)?;
                 }
             }
-            check_exported(&pkg.resolved.identifier, &mut seen_digests, &mut seen_repos)?;
+            check_exported(&pkg.identifier, &mut seen_digests, &mut seen_repos)?;
         }
         Ok(seen_digests)
     }

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -77,6 +77,10 @@ tasks:
   check:
     cmd: cargo check
 
+  run:
+    desc: Build and run ocx (pass args after --)
+    cmd: cargo run --release --bin ocx -- {{.CLI_ARGS}}
+
   default:
     deps:
       - task: rust:format:check

--- a/test/tests/test_cross_repo_dedup.py
+++ b/test/tests/test_cross_repo_dedup.py
@@ -1,0 +1,109 @@
+"""Regression for ocx-sh/ocx#40 — cross-repo content-addressed dedup.
+
+Two repositories on the same registry may point at byte-identical manifest
+content (e.g. ``tools/cmake`` and ``mirrors/cmake``). The package store
+shards by registry + digest only, so both installs share a single on-disk
+directory. Before the fix, ``resolve.json`` stored the full pinned
+identifier of *whichever installer wrote the directory first*, and later
+commands (``find``, ``deps``) reported that stale repository name when
+queried via the second installer's path.
+
+The fix drops the redundant root identifier from ``resolve.json`` and
+reconstructs it from the caller's query identifier instead.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+from src import OcxRunner, current_platform
+
+
+def test_cross_repo_dedup_preserves_query_repository(
+    ocx: OcxRunner, tmp_path: Path,
+):
+    tag = "3.28"
+    plat = current_platform()
+    marker = f"xrepo-{uuid4().hex[:8]}"
+    # Unique repo prefixes so parallel test runs don't collide on the shared
+    # registry; both repos must use byte-identical content+metadata so the
+    # manifest digest is the same and the package store collapses the two
+    # installs into one directory.
+    uid = uuid4().hex[:8]
+    tools_repo = f"tools_{uid}/cmake"
+    mirrors_repo = f"mirrors_{uid}/cmake"
+
+    # --- Build one bundle + metadata, push to two repositories -----------
+    pkg_dir = tmp_path / "pkg"
+    bin_dir = pkg_dir / "bin"
+    bin_dir.mkdir(parents=True)
+    hello = bin_dir / "hello"
+    if sys.platform == "win32":
+        hello = hello.with_suffix(".bat")
+        hello.write_text(f"@echo {marker}\n")
+    else:
+        hello.write_text(f"#!/bin/sh\necho {marker}\n")
+        hello.chmod(hello.stat().st_mode | stat.S_IEXEC)
+
+    metadata = tmp_path / "metadata.json"
+    metadata.write_text(
+        json.dumps(
+            {
+                "type": "bundle",
+                "version": 1,
+                "env": [
+                    {
+                        "key": "PATH",
+                        "type": "path",
+                        "required": True,
+                        "value": "${installPath}/bin",
+                    },
+                ],
+            }
+        )
+    )
+    bundle = tmp_path / "bundle.tar.xz"
+    ocx.plain("package", "create", "-m", str(metadata), "-o", str(bundle), str(pkg_dir))
+
+    def push(repo: str) -> None:
+        fq = f"{ocx.registry}/{repo}:{tag}"
+        ocx.plain("package", "push", "-n", "-p", plat, "-m", str(metadata), fq, str(bundle))
+        ocx.plain("index", "update", f"{repo}:{tag}")
+
+    push(tools_repo)
+    push(mirrors_repo)
+
+    tools_short = f"{tools_repo}:{tag}"
+    mirrors_short = f"{mirrors_repo}:{tag}"
+
+    # --- First installer wins cross-repo dedup ---------------------------
+    ocx.json("install", tools_short)
+    # Second installer reuses the shared content-addressed package dir.
+    ocx.json("install", mirrors_short)
+
+    # --- find should report the repository the user queried --------------
+    find_result = ocx.json("find", mirrors_short)
+    assert mirrors_short in find_result, (
+        f"find should key result by queried identifier, got keys {list(find_result)}"
+    )
+
+    # --- deps --flat entry for the root should carry the queried repo ---
+    flat = ocx.json("deps", "--flat", mirrors_short)
+    entries = flat["entries"]
+    assert entries, f"expected at least one entry in deps --flat output, got {flat!r}"
+
+    def entry_repo(ident: str) -> str:
+        # String identifier of shape "{registry}/{repo}:{tag}@{digest}"
+        head = ident.split("@", 1)[0]
+        if ":" in head.rsplit("/", 1)[-1]:
+            head = head.rsplit(":", 1)[0]
+        return head.split("/", 1)[1] if "/" in head else head
+
+    assert any(entry_repo(e["identifier"]) == mirrors_repo for e in entries), (
+        f"deps --flat for {mirrors_short} should contain an entry with repo "
+        f"{mirrors_repo!r}, got entries={entries!r}"
+    )

--- a/test/tests/test_dependencies.py
+++ b/test/tests/test_dependencies.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
@@ -1304,20 +1303,17 @@ def test_diamond_intermediate_deps_forward_refs(
 def _find_object_dir(ocx: OcxRunner, reg_slug: str, repo: str) -> Path:
     """Find the single package directory for a given repo in the package store.
 
-    Package dirs are sharded by digest only: ``packages/{reg}/{algo}/{prefix}/{suffix}/``.
-    We identify the package by checking each object's ``resolve.json`` for the repo name.
+    Package dirs are sharded by registry + digest only (no repo in the path),
+    so ``find`` is the authoritative way to resolve a repo name to a content
+    path. For transitive deps (not installed directly and thus without an
+    install symlink) we fall back to the bare repo name so ``ocx find``
+    resolves via the local index.
     """
-    store_dir = Path(ocx.ocx_home) / "packages" / reg_slug
-    obj_dirs = []
-    for content_path in store_dir.rglob("content"):
-        if content_path.is_dir():
-            resolve_path = content_path.parent / "resolve.json"
-            if resolve_path.exists():
-                data = json.loads(resolve_path.read_text())
-                if repo in data.get("identifier", ""):
-                    obj_dirs.append(content_path.parent)
-    assert len(obj_dirs) == 1, f"expected 1 package dir for {repo}, got {len(obj_dirs)}"
-    return obj_dirs[0]
+    find_result = ocx.json("find", repo)
+    key = next(iter(find_result))
+    content_path = Path(find_result[key]).resolve()
+    assert content_path.name == "content", f"unexpected find target: {content_path}"
+    return content_path.parent
 
 
 def _list_dep_targets(obj_dir: Path) -> list[Path]:

--- a/test/tests/test_shell_profile.py
+++ b/test/tests/test_shell_profile.py
@@ -785,6 +785,35 @@ def test_profile_load_follows_select(
     # The current symlink now points to v2's content
 
 
+def test_profile_list_current_mode_drops_stale_tag_after_select(
+    ocx: OcxRunner, published_two_versions: tuple[PackageInfo, PackageInfo]
+):
+    """Regression: current-mode entry originally added as v1 must not report
+    `v1@<digest-of-v2>` after `ocx select v2`. The reconstructed identifier
+    for a current symlink must strip the caller's tag so the reported
+    identifier does not mix a stale tag with a newer digest."""
+    v1, v2 = published_two_versions
+    ocx.json("install", "-s", v1.short)
+    ocx.json("install", v2.short)
+    ocx.json("shell", "profile", "add", "--current", v1.short)
+    ocx.json("select", v2.short)
+
+    result = ocx.json("shell", "profile", "list")
+    assert len(result) == 1
+    entry = result[0]
+    assert entry["mode"] == "current"
+    assert entry["status"] == "active"
+
+    package = entry["package"]
+    # Must not contain the stale v1 tag — that would be a hybrid identifier
+    # `pkg:v1@<digest-of-v2>` which doesn't correspond to any real install.
+    assert f":{v1.tag}" not in package, (
+        f"current-mode entry still reports stale tag '{v1.tag}': {package}"
+    )
+    # Must carry a digest so downstream consumers can pin the actually-selected content.
+    assert "@sha256:" in package, f"expected digest in reported identifier: {package}"
+
+
 def test_profile_load_empty_profile(ocx: OcxRunner):
     """No entries → comment-only output for all shells, exit 0"""
     for shell in ("bash", "zsh", "fish", "powershell"):

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -292,14 +292,18 @@ cmake_root=$(ocx find --candidate --format json cmake:3.28 | jq -r '.["cmake:3.2
 #### `catalog` {#index-catalog}
 
 ```bash
-ocx index catalog [OPTIONS]
+ocx index catalog [OPTIONS] [REGISTRY...]
 ```
 
-Lists all packages available in the index. Uses the local index by default; pass [`--remote`](#arg-remote) to query the registry directly.
+Lists all packages available in the index. Uses the local index by default; pass [`--remote`](#arg-remote) to query the registry directly. Repository names are always prefixed with their registry in the output (e.g., `ocx.sh/cmake`).
+
+**Arguments**
+
+- `[REGISTRY...]`: Registries to query. Accepts zero or more registry hostnames. Defaults to `OCX_DEFAULT_REGISTRY` (or `ocx.sh`) when omitted.
 
 **Options**
 
-- `--with-tags`: Include available tags for each package. Slower — requires fetching additional information for each package.
+- `--tags`: Include available tags for each package. Slower — requires fetching additional information for each package.
 
 #### `list` {#index-list}
 


### PR DESCRIPTION
## Summary

- Remove `ResolvedPackage.identifier` — shared package directories across repos no longer inherit whichever installer wrote first, fixing wrong-repo reports in `ocx find` and silent lookup misses in `ocx deps`.
- Introduce `common::identifier_for_symlink` for the two symlink-lookup sites; it pairs the caller's `Identifier` with the digest read from the package dir's `digest` file.
- `identifier_for_symlink` takes a `SymlinkKind`: `current` strips the caller's tag so we never report hybrid identifiers like `pkg:1.0@<digest-of-2.0>` after `ocx select` moves the current symlink. Candidate symlinks preserve the tag (tag and digest agree by construction).
- `resolve.json` is deliberately breaking — `#[serde(deny_unknown_fields)]` rejects the old shape per the breaking-compat stance for the next version.

Fixes #40.

## Test plan

- [x] `task verify` — 951 unit tests + 232 acceptance tests green
- [x] New `test_cross_repo_dedup.py` — pushes one bundle to two repos, installs both, asserts `find` and `deps --flat` report the queried repository
- [x] New `test_profile_list_current_mode_drops_stale_tag_after_select` — regression for the current-mode identifier reconstruction (fails pre-fix with `pkg:1.0.0@<digest-of-v2>`)
- [x] Existing `test_profile_load_follows_select` still passes (candidate-mode coverage unaffected)