### PR TITLE
feat(oci): transparent tag fallback with concurrency-safe persistence

### DIFF
--- a/.claude/artifacts/plan_tag_fallback.md
+++ b/.claude/artifacts/plan_tag_fallback.md
@@ -1,0 +1,420 @@
+# Plan: Transparent Tag Fallback
+
+## Overview
+
+**Status:** Draft
+**Date:** 2026-04-12
+**GitHub Issue:** [ocx-sh/ocx#41](https://github.com/ocx-sh/ocx/issues/41)
+**Research:** [research_tag_fallback.md](./research_tag_fallback.md)
+
+## Objective
+
+When online (not `--offline`), resolve against the remote registry on local miss. `ocx install cmake:3.28` should just work on a fresh machine without prior `ocx index update`.
+
+## Scope
+
+### In Scope
+
+- `ChainedIndex` implementing `IndexImpl` — `LocalIndex` cache + ordered `Vec<Index>` source chain
+- Refactoring `LocalIndex::update_tag` from `&mut self` to `&self` (prerequisite)
+- `Index::from_chained(cache, sources)` (general) and `Index::from_cached_remote(cache, remote)` (convenience for #41)
+- `Context::try_init` wiring: online + not `--remote` → `ChainedIndex` with single remote source
+- Acceptance tests for the three friction scenarios (fresh, new tag, different repo)
+- Unit tests for ChainedIndex behavior, including multi-source chain cases (proving the Vec shape)
+
+### Out of Scope
+
+- Negative caching (tracking tags confirmed absent) — future optimization
+- Fixing `RemoteIndex::fetch_manifest_digest` to return `Ok(None)` on 404 — separate issue
+- Lock file integration (#33) — complementary, not dependent
+- `--remote` flag behavior changes
+- Stale tag auto-refresh — explicit `ocx index update` remains the tool for this
+
+## Technical Approach
+
+### Architecture Changes
+
+```
+BEFORE:
+  Context::try_init → Index::from_local(local) OR Index::from_remote(remote)
+  → PackageManager receives single Index
+  → resolve() → index.select() → NotFound = error
+
+AFTER:
+  Context::try_init → Index::from_cached_remote(local, remote)  [online, default]
+                     | Index::from_local(local)                    [--offline]
+                     | Index::from_remote(remote)                  [--remote]
+  → PackageManager receives single Index (unchanged)
+  → resolve() → index.select() → ChainedIndex handles miss transparently
+```
+
+```
+ChainedIndex { cache: LocalIndex, sources: Vec<Index> }::fetch_manifest(id):
+  1. cache.fetch_manifest(id) → Some(data) → return (fast path, no source walked)
+  2. cache.fetch_manifest(id) → None → walk sources in order:
+     for source in &sources:
+       a. cache.update_tag(source, id) succeeds → retry cache → return result
+       b. cache.update_tag(source, id) errors → log warn, try next source
+  3. all sources exhausted → Ok(None) → NotFound (warn logs provide diagnostics)
+```
+
+### Key Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Composite `ChainedIndex` (not retry-at-caller) | Zero changes to PackageManager, resolve(), or any CLI command. Mirrors Cargo sparse / Go modules pattern. |
+| Refactor `update_tag` to `&self` (not `Mutex<LocalIndex>`) | All internal mutations already use `Arc<RwLock>` or filesystem writes. Simpler than adding locking. |
+| Log source errors at `warn` and propagate when the chain is exhausted | Revised after Codex adversarial review. Source errors are logged at `warn` for diagnostics AND the last error is propagated as `Err` when every source failed. Only an explicit "not found" response from a source (which is `update_tag → Ok(())` followed by an empty cache retry) yields `Ok(None)`. Collapsing source errors into `NotFound` would break the trust boundary between "package doesn't exist" and "registry outage / auth failure," and silently defeat retry logic in automation. |
+| `ChainedIndex` only on `fetch_manifest` path (not `list_tags`) | `select()` flows through `fetch_candidates()` → `fetch_manifest()`. Tag listing is only used by `ocx index catalog` which has its own semantics. |
+| `list_tags` delegates to local only (no remote fallback) | Tag listing is for discovery/browsing, not resolution. Creates catalog asymmetry (install succeeds but catalog is empty) — document in user guide. |
+| `list_repositories` delegates to local only | Same reasoning — repository listing is explicit index content, not resolution. |
+
+### Component Contracts
+
+#### `ChainedIndex` (`crates/ocx_lib/src/oci/index/chained_index.rs`)
+
+```rust
+pub(super) struct ChainedIndex {
+    /// Persistent cache: read first, write to on miss.
+    cache: LocalIndex,
+    /// Read-only fallback sources, queried in order on cache miss.
+    /// First hit wins; result is persisted into `cache`.
+    /// For #41 this contains exactly one entry: the remote index.
+    /// Future scenarios (CI cache, org mirror) extend the chain by appending sources.
+    sources: Vec<super::Index>,
+}
+```
+
+**Two-role model:**
+
+- **`cache`** — exactly one persistent destination. Read first AND written to on any successful source fetch. This is always a `LocalIndex` (the only `IndexImpl` that persists to disk).
+- **`sources`** — ordered read-only chain. Walked in order on cache miss. First source to return data wins; the result is persisted into `cache` via `update_tag`. For #41 this is `[remote_index]`. Future scenarios (CI pre-warmed cache, corporate mirror) extend the chain by appending sources.
+
+**`IndexImpl` behavior:**
+
+| Method | Behavior |
+|--------|----------|
+| `list_repositories(registry)` | Delegate to `cache` only |
+| `list_tags(id)` | Delegate to `cache` only |
+| `fetch_manifest(id)` | Cache first → on `None`: walk `sources` in order, persist first hit → retry cache |
+| `fetch_manifest_digest(id)` | Same chain as `fetch_manifest` |
+| `box_clone()` | Clone cache + clone all sources (shared caches via `Arc`) |
+
+**Chain logic (shared by `fetch_manifest` and `fetch_manifest_digest`):**
+
+```rust
+async fn with_chain<T>(
+    &self,
+    identifier: &oci::Identifier,
+    query: impl Fn(&LocalIndex, &oci::Identifier) -> /* future returning Result<Option<T>> */,
+) -> Result<Option<T>> {
+    // Fast path: check the persistent cache
+    if let Some(result) = query(&self.cache, identifier).await? {
+        return Ok(Some(result));
+    }
+
+    // Only fall through the chain for tagged identifiers
+    // (digest-only lookups can't be discovered by tag listing)
+    let Some(_tag) = identifier.tag() else {
+        return Ok(None);
+    };
+
+    // Walk the source chain in order. First source that successfully
+    // syncs the tag into the cache wins. Errors are logged at warn but
+    // do not abort the chain — the next source gets a chance.
+    let mut last_error: Option<crate::Error> = None;
+    for source in &self.sources {
+        match self.cache.update_tag(source, identifier).await {
+            Ok(()) => {
+                log::info!("Fetched tag '{}' from chained source, retrying cache lookup.", identifier);
+                // Retry against the cache; if the source actually had the tag,
+                // it's now persisted and the cache returns Some.
+                if let Some(result) = query(&self.cache, identifier).await? {
+                    return Ok(Some(result));
+                }
+                // Source returned without error but didn't persist a usable tag —
+                // continue to the next source.
+            }
+            Err(e) => {
+                // AC6: surface the underlying cause so users can distinguish
+                // "manifest not found" vs "connection timed out" vs "401 unauthorized"
+                log::warn!("Could not fetch tag '{}' from chained source: {e}", identifier);
+                last_error = Some(e);
+            }
+        }
+    }
+
+    // All sources exhausted. If at least one ran cleanly we return Ok(None)
+    // (cache retry will reveal whatever is — or isn't — there). If every
+    // source errored, propagate the last error so callers can distinguish
+    // a real outage from a clean not-found.
+    match last_error {
+        Some(e) => Err(e),
+        None => Ok(None),
+    }
+}
+```
+
+**Error taxonomy:**
+
+| Scenario | Behavior |
+|----------|----------|
+| Tag in cache | Return immediately (no source walked) |
+| Tag not cached, source has it | `update_tag` persists it, retry succeeds |
+| Tag not cached, source doesn't have it | `update_tag` returns `Ok(())` (clean miss) → cache retry → `Ok(None)` → `NotFound` |
+| Tag not cached, network failure | `update_tag` errors → `warn` log "connection timed out" → recorded as `last_error` → propagate `Err` if no later source runs cleanly |
+| Tag not cached, auth failure | `update_tag` errors → `warn` log "401 unauthorized" → recorded as `last_error` → propagate `Err` if no later source runs cleanly |
+| All sources exhausted, at least one ran cleanly | `Ok(None)` → `NotFound` (the chain never errored) |
+| All sources exhausted, every source errored | `Err(last_error)` propagated to caller (preserves "outage vs not-found" trust boundary) |
+| `--offline` mode | `ChainedIndex` not constructed; `LocalIndex` used directly |
+| `--remote` mode | `RemoteIndex` used directly (unchanged) |
+
+#### `Index::from_chained` (`crates/ocx_lib/src/oci/index.rs`)
+
+```rust
+/// Construct an index that reads from `cache` first, falling through to
+/// `sources` in order on miss. Successful source fetches are persisted
+/// into `cache` via `update_tag`.
+///
+/// For #41 callers pass exactly one source (the remote index). The Vec
+/// shape is forward-compatible with future N-source scenarios (CI cache,
+/// org mirror) without an API rename.
+pub fn from_chained(cache: LocalIndex, sources: Vec<Index>) -> Self {
+    Self {
+        inner: Box::new(chained_index::ChainedIndex::new(cache, sources)),
+    }
+}
+```
+
+A convenience constructor for the common single-source case keeps the call site clean:
+
+```rust
+impl Index {
+    /// Convenience: cache + single remote source. Equivalent to
+    /// `Index::from_chained(cache, vec![Index::from_remote(remote)])`.
+    pub fn from_cached_remote(cache: LocalIndex, remote: RemoteIndex) -> Self {
+        Self::from_chained(cache, vec![Index::from_remote(remote)])
+    }
+}
+```
+
+#### `LocalIndex` refactoring (`crates/ocx_lib/src/oci/index/local_index.rs`)
+
+Change `&mut self` to `&self` on these methods (no other changes):
+- `update()` (line 44)
+- `update_tag()` (line 53)
+- `update_all_tags()` (line 62)
+- `sync_tag()` (line 77)
+- `update_manifest()` (line 124)
+
+All internal mutations are already via `Arc<RwLock<Cache>>` (interior mutability) or filesystem writes (no self mutation). This is a safe, mechanical refactoring.
+
+**Breaking change for callers:** `Context::local_index_mut()` is used by `index_update.rs` to call `local_index.update()`. After refactoring, `local_index()` (shared ref) suffices. `local_index_mut()` can be deprecated or removed.
+
+#### `Context::try_init` change (`crates/ocx_cli/src/app/context.rs`)
+
+```rust
+// BEFORE (lines 65-73):
+let selected_index = if options.remote {
+    index::Index::from_remote(remote_index.clone())
+} else {
+    index::Index::from_local(local_index.clone())
+};
+
+// AFTER:
+let selected_index = if options.remote {
+    if let Some(remote_index) = &remote_index {
+        index::Index::from_remote(remote_index.clone())
+    } else {
+        return Err(anyhow::anyhow!("Remote index is not available in offline mode."));
+    }
+} else if let Some(remote_index) = &remote_index {
+    index::Index::from_cached_remote(local_index.clone(), remote_index.clone())
+} else {
+    index::Index::from_local(local_index.clone())
+};
+```
+
+Three branches: `--remote` → remote only, online → fallback, offline → local only.
+
+> **Revised 2026-04-12 after Codex adversarial review**: error propagation instead of collapsing, to preserve the trust boundary between "package not found" and "registry outage / auth failure." `walk_chain` now returns `Result<()>`; sole-source or all-source errors propagate through `fetch_manifest` / `fetch_manifest_digest` instead of degrading to `Ok(None)`. Bare-identifier short-circuit kept as-is and documented inline (`ocx install <pkg>` on an empty index still requires a prior `ocx index update <pkg>`).
+
+### User Experience Scenarios
+
+| User Action | Expected Outcome | Error Cases |
+|-------------|------------------|-------------|
+| `ocx install cmake:3.28` (fresh machine, empty index) | Fetches tag from remote, persists locally, installs | Network failure → "Package not found" (same as today) |
+| `ocx install cmake:3.28` (second run, tag cached) | Installs from local index (no network) | — |
+| `ocx install cmake:3.29` (3.28 cached, 3.29 is new) | Fetches 3.29 from remote, persists, installs | Tag doesn't exist on registry → "Package not found" |
+| `ocx install cmake:3.28 ninja:1.12` (batch, both new) | Both fetched in parallel via ChainedIndex | One fails → error for that package, other succeeds |
+| `ocx install --offline cmake:3.28` (empty index) | NotFound error immediately | Expected behavior — no fallback in offline mode |
+| `ocx install --remote cmake:3.28` | Resolves from remote directly (unchanged) | — |
+| `ocx install cmake:3.28` (tag cached pointing to old digest) | Uses cached digest (no refresh) | Intentional — refresh is `ocx index update`'s job |
+
+### Edge Cases
+
+| Edge Case | Behavior |
+|-----------|----------|
+| Parallel fallback for same tag (batch install) | Safe — `update_tag` merges idempotently, shared cache via `Arc<RwLock>` means second call sees the first's result |
+| Identifier with digest but no tag (`@sha256:...`) | No fallback — digest lookups go through local only |
+| Identifier with both tag and digest | Digest takes precedence in local lookup — no fallback needed |
+| `fetch_candidates` returns Some but no platform matches | `SelectResult::NotFound` at platform matching, NOT at index level — fallback doesn't trigger (correct, not an index miss) |
+| Registry requires auth | `oci::Client` handles auth via `ensure_auth()` before any request — ChainedIndex inherits this |
+
+## Implementation Steps
+
+### Phase 1: Stubs
+
+- [ ] **Step 1.1:** Refactor `LocalIndex` methods from `&mut self` to `&self`
+  - Files: `crates/ocx_lib/src/oci/index/local_index.rs`
+  - Methods: `update`, `update_tag`, `update_all_tags`, `sync_tag`, `update_manifest`
+  - No behavior change — purely mechanical signature change
+
+- [ ] **Step 1.2:** Create `ChainedIndex` struct with `IndexImpl` stubs
+  - Files: `crates/ocx_lib/src/oci/index/chained_index.rs`
+  - Public API: `ChainedIndex::new(cache: LocalIndex, sources: Vec<Index>)`, all `IndexImpl` methods as `unimplemented!()`
+  - Doc comment explains the cache+sources two-role model and the forward path to N sources
+
+- [ ] **Step 1.3:** Add `Index::from_chained` and `Index::from_cached_remote` constructors
+  - Files: `crates/ocx_lib/src/oci/index.rs`
+  - Public API:
+    - `pub fn from_chained(cache: LocalIndex, sources: Vec<Index>) -> Self` (general)
+    - `pub fn from_cached_remote(cache: LocalIndex, remote: RemoteIndex) -> Self` (convenience for #41)
+
+### Phase 2: Architecture Review
+
+Review stubs against this design record. Verify:
+- ChainedIndex fields match the contract (local: LocalIndex, remote: Index)
+- `from_chained` constructor matches the documented signature
+- `update_tag` refactoring compiles with `&self`
+
+Gate: `cargo check` passes with stubs.
+
+### Phase 3: Specification Tests
+
+- [ ] **Step 3.1:** Unit tests for ChainedIndex
+  - Files: `crates/ocx_lib/src/oci/index/chained_index.rs` (inline `#[cfg(test)]`)
+  - Cases (single-source chain — the #41 shape):
+    - Cache hit returns immediately (no source walked)
+    - Cache miss + source has tag → update_tag called → retry succeeds
+    - Cache miss + source doesn't have tag → returns None, warn logged
+    - Cache miss + source network error → returns None, warn logged
+    - Digest-only identifier (no tag) → no chain walk, cache result returned
+    - Batch: one chain walk succeeds, one fails → partial results
+    - `box_clone` shares caches across cloned chain
+  - Cases (multi-source chain — proves the Vec shape works):
+    - Two sources, first has the tag → second source not queried
+    - Two sources, first errors but second has the tag → tag persisted, success
+    - Two sources, both error → returns None, both errors logged
+    - Empty sources Vec → behaves like LocalIndex alone (no fallback)
+
+- [ ] **Step 3.2:** Acceptance tests for the three friction scenarios + AC6
+  - Files: `test/tests/test_tag_fallback.py`
+  - Scenarios:
+    - Fresh install: `ocx install <pkg>:<tag>` with empty local index succeeds (AC1)
+    - Tag persisted: second install with `--offline` succeeds (proves local persistence) (AC2)
+    - Offline mode: `ocx install --offline <pkg>:<tag>` with empty index returns NotFound (AC3)
+    - Cached tag not refreshed: install with stale cached tag uses the cached digest (AC4)
+    - Batch install: `ocx install <pkg1>:<tag1> <pkg2>:<tag2>` with empty index, both succeed (AC5)
+    - Non-existent tag: `ocx install <pkg>:nonexistent` returns NotFound, stderr contains diagnostic (AC6)
+    - Network failure during fallback: install against unreachable registry, stderr contains network error context (AC6)
+
+Gate: Tests compile and fail with `unimplemented!()`.
+
+### Phase 4: Implementation
+
+- [ ] **Step 4.1:** Implement ChainedIndex `IndexImpl` methods
+  - Files: `crates/ocx_lib/src/oci/index/chained_index.rs`
+  - `list_repositories` and `list_tags`: delegate to `self.cache`
+  - `fetch_manifest` and `fetch_manifest_digest`: cache-first via `with_chain` helper
+  - `box_clone`: clone cache + clone all sources (shared caches via Arc)
+
+- [ ] **Step 4.2:** Wire ChainedIndex into Context
+  - Files: `crates/ocx_cli/src/app/context.rs`
+  - Change `selected_index` construction: online + not remote → `from_cached_remote`
+
+- [ ] **Step 4.3:** Update `index_update.rs` and remove `local_index_mut()`
+  - Files: `crates/ocx_cli/src/command/index_update.rs`, `crates/ocx_cli/src/app/context.rs`
+  - `index_update.rs:26`: `let mut context = context.clone()` → `let context = context.clone()`
+  - `index_update.rs:28`: `context.local_index_mut().update(...)` → `context.local_index().update(...)`
+  - `context.rs`: remove `local_index_mut()` accessor (sole caller eliminated), remove `#[allow(dead_code)]` on `local_index()`
+  - Update `subsystem-cli.md` accessor list to remove `local_index_mut()`
+
+Gate: All unit tests and acceptance tests pass. `task verify` succeeds.
+
+### Phase 5: Review
+
+- [ ] **Step 5.1:** Spec compliance review (design record vs tests vs implementation)
+- [ ] **Step 5.2:** Code quality review (Rust quality checklist, error handling)
+- [ ] **Step 5.3:** Verify acceptance criteria from issue #41
+
+## Files to Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `crates/ocx_lib/src/oci/index/local_index.rs` | Modify | Refactor `&mut self` → `&self` on update methods |
+| `crates/ocx_lib/src/oci/index/chained_index.rs` | Create | New `ChainedIndex` (cache + sources) implementing `IndexImpl` |
+| `crates/ocx_lib/src/oci/index.rs` | Modify | Add `from_chained` + `from_cached_remote` constructors, `mod chained_index` |
+| `crates/ocx_cli/src/app/context.rs` | Modify | Wire fallback index; remove `local_index_mut()`, un-deadcode `local_index()` |
+| `crates/ocx_cli/src/command/index_update.rs` | Modify | `local_index_mut()` → `local_index()`, remove `mut` on context clone |
+| `.claude/rules/subsystem-cli.md` | Modify | Update Context accessor list |
+| `test/tests/test_tag_fallback.py` | Create | Acceptance tests for fallback scenarios (all 6 ACs) |
+
+## Dependencies
+
+No new crate dependencies required. All building blocks exist.
+
+## Testing Strategy
+
+### Unit Tests (from component contracts)
+
+| Component | Behavior | Expected | Edge Cases |
+|-----------|----------|----------|------------|
+| ChainedIndex::fetch_manifest | Cache hit | Return data immediately | — |
+| ChainedIndex::fetch_manifest | Cache miss, source has tag | update_tag, retry → data | Concurrent walks for same tag |
+| ChainedIndex::fetch_manifest | Cache miss, source miss | Ok(None) | Error caught, warn logged |
+| ChainedIndex::fetch_manifest | Cache miss, network error | Ok(None) | Error caught, warn logged |
+| ChainedIndex::fetch_manifest | Multi-source, first hits | second never queried | Stops on first success |
+| ChainedIndex::fetch_manifest | Multi-source, first errors, second hits | persists, returns data | Errors don't abort the chain |
+| ChainedIndex::fetch_manifest | Empty sources Vec | Cache result returned (no walk) | Behaves like LocalIndex |
+| ChainedIndex::fetch_manifest_digest | Same matrix as above | Same expected | Digest-only id → no chain walk |
+| ChainedIndex::list_tags | Any | Delegates to cache only | — |
+| ChainedIndex::list_repositories | Any | Delegates to cache only | — |
+| ChainedIndex::box_clone | Clone | Shares caches via Arc | — |
+
+### Acceptance Tests (from user experience)
+
+| User Action | Expected Outcome | Error Cases | AC |
+|-------------|------------------|-------------|----|
+| `ocx install <pkg>:<tag>` (empty index) | Installs successfully | — | 1 |
+| Second `ocx install <pkg>:<tag>` with `--offline` | Uses local (proves persistence) | — | 2 |
+| `ocx install --offline <pkg>:<tag>` (empty index) | NotFound error | Expected | 3 |
+| `ocx install <pkg>:<stale_tag>` (cached, old digest) | Uses cached digest | — | 4 |
+| `ocx install <pkg1>:<tag1> <pkg2>:<tag2>` (empty) | Both install | — | 5 |
+| `ocx install <pkg>:nonexistent` | NotFound, stderr has "not found" context | Expected | 6 |
+| `ocx install <pkg>:<tag>` (unreachable registry) | NotFound, stderr has network error context | Expected | 6 |
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| `update_tag` error semantics differ from expected | Catch all errors from update_tag on fallback path; degrade to Ok(None) |
+| Parallel `update_tag` calls for same tag race on disk | `TagLock` write is idempotent for same digest; shared in-memory cache deduplicates |
+| Docker Hub rate limiting from many fallback HEADs | Single HEAD per unknown tag is cheaper than `list_tags`; future negative cache if needed |
+| `&mut self` → `&self` refactoring breaks callers | Only caller is `index_update.rs` which is updated in the same change |
+
+## Checklist
+
+### Before Starting
+
+- [x] Issue context checked (ocx-sh/ocx#41)
+- [x] Related issues checked (#33 complementary, not blocking)
+- [x] Research completed (research_tag_fallback.md)
+- [x] Branch exists (evelynn worktree)
+
+### Before PR
+
+- [ ] All tests passing
+- [ ] `task verify` succeeds
+- [ ] Acceptance criteria from #41 verified
+- [ ] Self-review complete

--- a/.claude/artifacts/research_tag_fallback.md
+++ b/.claude/artifacts/research_tag_fallback.md
@@ -1,0 +1,49 @@
+# Research: Transparent Tag Fallback Patterns
+
+**Date:** 2026-04-12
+**Related Issue:** [ocx-sh/ocx#41](https://github.com/ocx-sh/ocx/issues/41)
+
+## Industry Patterns
+
+| Tool | Strategy | Key Detail |
+|------|----------|------------|
+| **Cargo (sparse)** | Local-first with conditional HTTP revalidation | Fetches only the specific crate's index entry via HTTP `ETag`/`If-None-Match`. Single-entry targeted fetch. |
+| **Go modules** | Cascading proxy list | `GOPROXY=https://proxy.golang.org,direct` — tries each in order. 404 = terminal, network error = next proxy. |
+| **npm/pnpm** | Always-remote for metadata | No local-first for package metadata. Differentiates 404 (terminal) from 5xx (retry). |
+| **Docker/containerd** | Mirror chain fallback | Static ordered mirror list; fallback to upstream on non-200. Pull-through caches placed first. |
+| **mise** | TTL-based full re-fetch | Entire version list cached with 24h TTL. Less targeted than needed for OCX. |
+
+**Core insight from Cargo and Go:** Both perform **targeted single-entry fetch** (one crate file, one module version) rather than re-syncing the whole index. Both distinguish "not found on remote (404)" from "network failure (timeout/5xx)" — the former terminates, the latter retries or cascades.
+
+## Pattern Classification for OCX
+
+| Pattern | Verdict |
+|---------|---------|
+| Always remote first | Reject — breaks offline-first principle |
+| Explicit sync required (current) | Poor UX — hostile for interactive use |
+| **Local first, remote fallback, persist** | **Recommended** — matches Cargo sparse, Go modules |
+| Remote fallback without persist | Wrong — re-fetches every resolve |
+
+## Implementation Pattern Comparison
+
+| Pattern | Changes Required | Pros | Cons |
+|---------|-----------------|------|------|
+| **Composite ChainedIndex** | New IndexImpl, context wiring | Zero changes to PackageManager or callers; co-locates fallback with index layer | New type + refactoring update_tag to &self |
+| Retry-at-caller | resolve(), resolve_all(), find_or_install(), etc. | Most explicit | 6+ call sites change; every new caller needs same logic |
+| Strategy in PackageManager | PM constructor, resolve() | Fine-grained per-task control | PM gains complexity; needs mutable local_index access |
+
+**Recommendation: ChainedIndex (cache + ordered source chain).** OCX already has the exact primitives needed (`LocalIndex::update_tag` does targeted single-tag fetch and persist). The ChainedIndex wraps a `LocalIndex` cache and a `Vec<Index>` of read-only sources under the existing `Box<dyn IndexImpl>` trait — zero API surface change above the index layer. The Vec shape is forward-compatible with future N-source scenarios (CI pre-warmed cache, corporate mirror) without an API rename.
+
+## OCI-Specific Findings
+
+- **Single-tag resolution:** `HEAD /v2/<name>/manifests/<tag>` returns `Docker-Content-Digest` header in one roundtrip. All major registries (Docker Hub, GHCR, ECR, Harbor) support this per OCI Distribution Spec.
+- **Error mapping concern:** `NativeTransport::fetch_manifest_digest` maps all errors via `registry_error` (not `manifest_not_found_or_registry_error`). A 404 on HEAD becomes `Err(ClientError::Registry(...))` not `Ok(None)`. The ChainedIndex must catch errors from `update_tag` and degrade gracefully.
+- **Rate limits:** Docker Hub 40 pulls/hr (auth) includes HEAD requests. Per-tag HEAD is strictly cheaper than full `list_tags`. Negative caching (tracking tags confirmed absent) is a future optimization.
+- **Concurrency:** Parallel fallback requests for different tags are safe. `LocalIndex::update_tag` merges into the on-disk tag file idempotently — concurrent writes for the same tag produce the same result.
+
+## Sources
+
+- [Cargo sparse index RFC 2789](https://rust-lang.github.io/rfcs/2789-sparse-index.html)
+- [Go Modules Reference — GOPROXY](https://go.dev/ref/mod)
+- [OCI Distribution Spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+- [Docker Hub Auth/Rate Limits](https://toddysm.com/2024/01/30/authenticating-with-oci-registries-docker-hub-implementation/)

--- a/.claude/rules/arch-principles.md
+++ b/.claude/rules/arch-principles.md
@@ -117,6 +117,31 @@ These `crates/ocx_lib/src/` modules have no dedicated subsystem rule — they se
 | `ci/` | CI flavor dispatch (GitHub Actions export) | `ci export` command |
 | `profile/` | `ProfileManager` + `ProfileManifest` for shell profiles | Shell profile commands |
 | `shell/` | `ShellProfileBuilder` — shell-specific export generation | Shell commands |
-| `utility/` | Extension traits: `StringExt`, `ResultExt`, `VecExt`, `SerdeExt` | Everywhere via prelude |
+| `utility/` | Extension traits + async + fs helpers — see [Utility Catalog](#utility-catalog) below | Everywhere (prelude for extension traits) |
 | `compression/` | Compression level configuration | Archive, OCI push |
 | `codesign/` | macOS ad-hoc code signing for Mach-O binaries | Package extraction |
+
+## Utility Catalog
+
+**Rule: before writing a small helper inside a module, check this table.** A helper reinvented in one module is wasted effort and a drift risk. If a new helper is broadly applicable, upstream it to `utility/` (or a crate-root module for linking/locking primitives) in the same change and re-export via `prelude` when universally useful.
+
+| Need | Use | Where |
+|---|---|---|
+| Append an extra extension (`foo.json` → `foo.json.lock`) | `Path::with_added_extension(..)` | std (stable) |
+| Read / write JSON with path-context errors | `SerdeExt::read_json` / `write_json` | prelude |
+| Slugify for filesystem use | `StringExt::to_slug` / `to_relaxed_slug` | prelude |
+| Sorted / dedup a `Vec` fluently | `VecExt::sorted` / `unique_clone` | prelude |
+| Ignore a `Result` deliberately | `ResultExt::ignore` | prelude |
+| Cross-process advisory file lock (shared/exclusive, timeout, RAII) | `file_lock::FileLock` | `crates/ocx_lib/src/file_lock.rs` |
+| RAII "delete path on drop" guard | `utility::fs::DropFile` | `utility/fs/drop_file.rs` |
+| Watch-based async singleflight (dedupe in-flight work by key) | `utility::singleflight` | `utility/singleflight.rs` |
+| Parallel directory tree walk with pruning decisions | `utility::fs::{DirWalker, WalkDecision}` | `utility/fs/dir_walker.rs` |
+| Lexical path normalize / containment check (no FS I/O) | `utility::fs::path::{lexical_normalize, escapes_root, validate_symlinks_in_dir}` | `utility/fs/path.rs` |
+| Move a directory (same-filesystem rename, overwrite-safe) | `utility::fs::move_dir` | `utility/fs.rs` |
+| Hardlink file (dedup layer into package) | `hardlink::create` / `update` | `crates/ocx_lib/src/hardlink.rs` |
+| Create / update / probe a symlink (cross-platform, junction-aware) | `symlink::create` / `update` / `remove` / `is_link` | `crates/ocx_lib/src/symlink.rs` |
+| Assemble a layer's content tree into a package (hardlinks + symlinks) | `utility::fs::assemble_from_layer(s)` | `utility/fs/assemble.rs` |
+| Boolean-like env string (`true/1/yes/on`) | `utility::boolean_string::BooleanString` | `utility/boolean_string.rs` |
+| File error with path context | `error::file_error(path, io_err)` | `crates/ocx_lib/src/error.rs` |
+
+**Check std first, then this catalog, then invent.** Most "small helper" needs are already covered by `std::path`, `tokio::fs`, or an existing entry above. If you add a new entry here, keep the row to one line and put implementation details in the target module's doc comment, not in this table.

--- a/.claude/rules/subsystem-cli.md
+++ b/.claude/rules/subsystem-cli.md
@@ -44,7 +44,7 @@ pub struct Context {
 }
 ```
 
-Accessors: `manager()`, `api()`, `file_structure()`, `default_index()`, `local_index_mut()`, `remote_client()`.
+Accessors: `manager()`, `api()`, `file_structure()`, `default_index()`, `local_index()`, `remote_client()`.
 
 ## Command Pattern
 

--- a/crates/ocx_cli/src/app/context.rs
+++ b/crates/ocx_cli/src/app/context.rs
@@ -68,6 +68,8 @@ impl Context {
             } else {
                 return Err(anyhow::anyhow!("Remote index is not available in offline mode."));
             }
+        } else if let Some(remote_index) = &remote_index {
+            index::Index::from_cached_remote(local_index.clone(), remote_index.clone())
         } else {
             index::Index::from_local(local_index.clone())
         };
@@ -105,13 +107,8 @@ impl Context {
         self.remote_index.as_ref().ok_or(ocx_lib::Error::OfflineMode)
     }
 
-    #[allow(dead_code)]
     pub fn local_index(&self) -> &oci::index::LocalIndex {
         &self.local_index
-    }
-
-    pub fn local_index_mut(&mut self) -> &mut oci::index::LocalIndex {
-        &mut self.local_index
     }
 
     pub fn default_index(&self) -> &oci::index::Index {

--- a/crates/ocx_cli/src/command/index_update.rs
+++ b/crates/ocx_cli/src/command/index_update.rs
@@ -23,9 +23,9 @@ impl IndexUpdate {
         let mut join_set = tokio::task::JoinSet::new();
         for identifier in &packages {
             let remote_index = remote_index.clone();
-            let mut context = context.clone();
+            let context = context.clone();
             let identifier = identifier.clone();
-            join_set.spawn(async move { context.local_index_mut().update(&remote_index, &identifier).await });
+            join_set.spawn(async move { context.local_index().update(&remote_index, &identifier).await });
         }
 
         while let Some(result) = join_set.join_next().await {

--- a/crates/ocx_lib/src/oci/index.rs
+++ b/crates/ocx_lib/src/oci/index.rs
@@ -13,6 +13,7 @@ pub use local_index::LocalIndex;
 pub use remote_index::Config as RemoteConfig;
 pub use remote_index::Index as RemoteIndex;
 
+mod chained_index;
 mod index_impl;
 mod local_index;
 mod remote_index;
@@ -48,6 +49,31 @@ impl Index {
         Self {
             inner: Box::new(local_index),
         }
+    }
+
+    /// Inject an arbitrary `IndexImpl` implementation.
+    ///
+    /// Used exclusively in unit tests to wrap `TestIndex` fakes without
+    /// exposing `IndexImpl` as a public trait.  Not available in production
+    /// builds.
+    #[cfg(test)]
+    pub(super) fn from_impl(inner: impl index_impl::IndexImpl + 'static) -> Self {
+        Self { inner: Box::new(inner) }
+    }
+
+    /// Construct an index that reads from `cache` first, falling through to
+    /// `sources` in order on miss. Successful source fetches are persisted
+    /// into `cache` via `update_tag`.
+    pub fn from_chained(cache: LocalIndex, sources: Vec<Index>) -> Self {
+        Self {
+            inner: Box::new(chained_index::ChainedIndex::new(cache, sources)),
+        }
+    }
+
+    /// Convenience: cache + single remote source. Equivalent to
+    /// `Index::from_chained(cache, vec![Index::from_remote(remote)])`.
+    pub fn from_cached_remote(cache: LocalIndex, remote: RemoteIndex) -> Self {
+        Self::from_chained(cache, vec![Index::from_remote(remote)])
     }
 
     /// List all repositories available in the given registry.

--- a/crates/ocx_lib/src/oci/index/chained_index.rs
+++ b/crates/ocx_lib/src/oci/index/chained_index.rs
@@ -57,7 +57,7 @@ impl ChainedIndex {
         for source in &self.sources {
             match self.cache.update(source, &tagged).await {
                 Ok(()) => {
-                    log::info!("Fetched tag '{}' from chained source, retrying cache lookup.", tagged);
+                    log::debug!("Fetched tag '{}' from chained source, retrying cache lookup.", tagged);
                     return Ok(());
                 }
                 Err(e) => {
@@ -89,16 +89,33 @@ impl index_impl::IndexImpl for ChainedIndex {
     }
 
     async fn fetch_manifest(&self, identifier: &oci::Identifier) -> Result<Option<(oci::Digest, oci::Manifest)>> {
-        if let Some(result) = self.cache.fetch_manifest(identifier).await? {
-            return Ok(Some(result));
+        // Cache read errors (e.g. a truncated tag file from a kill-9 during
+        // `TagGuard::write_disk`) must not short-circuit the chain walk —
+        // degrading to the source is the whole point of the fallback.
+        match self.cache.fetch_manifest(identifier).await {
+            Ok(Some(result)) => return Ok(Some(result)),
+            Ok(None) => {}
+            Err(e) => {
+                log::warn!(
+                    "Local tag cache read failed for '{}', falling back to chained source: {e}",
+                    identifier
+                );
+            }
         }
         self.walk_chain(identifier).await?;
         self.cache.fetch_manifest(identifier).await
     }
 
     async fn fetch_manifest_digest(&self, identifier: &oci::Identifier) -> Result<Option<oci::Digest>> {
-        if let Some(digest) = self.cache.fetch_manifest_digest(identifier).await? {
-            return Ok(Some(digest));
+        match self.cache.fetch_manifest_digest(identifier).await {
+            Ok(Some(digest)) => return Ok(Some(digest)),
+            Ok(None) => {}
+            Err(e) => {
+                log::warn!(
+                    "Local tag cache read failed for '{}', falling back to chained source: {e}",
+                    identifier
+                );
+            }
         }
         self.walk_chain(identifier).await?;
         self.cache.fetch_manifest_digest(identifier).await
@@ -701,5 +718,64 @@ mod tests {
             result.is_some(),
             "tag fetched in first call must be persisted so a cache-only second call succeeds"
         );
+    }
+
+    // Case 13: a corrupted on-disk tag file (the documented kill-9 recovery
+    // window from `tag_guard.rs`) must not short-circuit the chain walk.
+    // `ChainedIndex::fetch_manifest` should log a warn, degrade to the source,
+    // and the re-read of the now-rewritten file must succeed.
+    #[tokio::test]
+    async fn corrupted_cache_read_falls_back_to_chain() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // Corrupt the on-disk tag file with unparseable bytes so the first
+        // `cache.fetch_manifest` call errors. The tag path follows
+        // `tags/{registry_slug}/{repo}.json` (TagStore layout).
+        let tag_file = cache_dir
+            .path()
+            .join("tags")
+            .join(REGISTRY)
+            .join(format!("{REPO}.json"));
+        std::fs::create_dir_all(tag_file.parent().unwrap()).unwrap();
+        std::fs::write(&tag_file, b"{not valid json at all").unwrap();
+
+        let source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained
+            .fetch_manifest(&tagged_id())
+            .await
+            .expect("corrupt cache must degrade to chain walk, not propagate");
+        let (digest, _) = result.expect("chain walk must recover the manifest from the source");
+        assert_eq!(digest, digest_a());
+    }
+
+    // Case 13b: same degrade path for `fetch_manifest_digest`.
+    #[tokio::test]
+    async fn corrupted_cache_read_digest_falls_back_to_chain() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let tag_file = cache_dir
+            .path()
+            .join("tags")
+            .join(REGISTRY)
+            .join(format!("{REPO}.json"));
+        std::fs::create_dir_all(tag_file.parent().unwrap()).unwrap();
+        std::fs::write(&tag_file, b"").unwrap();
+        // Truncated-but-nonzero would also exercise `read_disk`'s error path;
+        // an empty file (len == 0) is treated as "no tags yet" so we need
+        // actual garbage to force a parse error.
+        std::fs::write(&tag_file, b"garbage").unwrap();
+
+        let source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained
+            .fetch_manifest_digest(&tagged_id())
+            .await
+            .expect("corrupt cache must degrade for digest queries too");
+        assert_eq!(result, Some(digest_a()));
     }
 }

--- a/crates/ocx_lib/src/oci/index/chained_index.rs
+++ b/crates/ocx_lib/src/oci/index/chained_index.rs
@@ -42,32 +42,28 @@ impl ChainedIndex {
     ///
     /// An empty `sources` Vec returns `Ok(())` (cache-only behavior).
     async fn walk_chain(&self, identifier: &oci::Identifier) -> Result<()> {
-        // The chain only fetches when the caller names a specific tag.
-        // Untagged identifiers (bare `pkg`) would require `list_tags` against
-        // the registry to discover what's available, but `ChainedIndex::list_tags`
-        // deliberately delegates to the cache only — tag discovery is the job
-        // of `ocx index update`, not transparent install-time resolution. As a
-        // result, `ocx install <pkg>` on an empty local index still returns
-        // NotFound; the user must run `ocx index update <pkg>` first. Digest-only
-        // identifiers (`pkg@sha256:...`) similarly cannot be discovered here.
-        if identifier.tag().is_none() {
+        // Digest-only identifiers (`pkg@sha256:…`) cannot be discovered via
+        // tag fallback — bail out. For every other shape, fall back under
+        // `tag_or_latest()`, which returns the explicit tag when present and
+        // `"latest"` for bare identifiers. That keeps `ocx install cmake`
+        // behaving the same as `ocx install cmake:latest` on a fresh machine;
+        // full tag discovery stays the job of `ocx index update`.
+        if identifier.tag().is_none() && identifier.digest().is_some() {
             return Ok(());
         }
+        let tagged = identifier.clone_with_tag(identifier.tag_or_latest());
 
         let mut last_error: Option<crate::Error> = None;
         for source in &self.sources {
-            match self.cache.update_tag(source, identifier).await {
+            match self.cache.update(source, &tagged).await {
                 Ok(()) => {
-                    log::info!(
-                        "Fetched tag '{}' from chained source, retrying cache lookup.",
-                        identifier
-                    );
+                    log::info!("Fetched tag '{}' from chained source, retrying cache lookup.", tagged);
                     return Ok(());
                 }
                 Err(e) => {
                     // AC6: surface the underlying cause so users can distinguish
                     // "manifest not found" vs "connection timed out" vs "401 unauthorized".
-                    log::warn!("Could not fetch tag '{}' from chained source: {e}", identifier);
+                    log::warn!("Could not fetch tag '{}' from chained source: {e}", tagged);
                     last_error = Some(e);
                 }
             }
@@ -332,7 +328,7 @@ mod tests {
         // Populate the cache by running update_tag via a source that has the tag.
         let seed_source = TestIndex::with_tag(TAG, digest_a());
         let seed_index = make_source(seed_source);
-        cache.update_tag(&seed_index, &tagged_id()).await.unwrap();
+        cache.update(&seed_index, &tagged_id()).await.unwrap();
 
         // Now build the ChainedIndex with a *spy* source that records calls.
         let spy = TestIndex::empty();
@@ -483,6 +479,44 @@ mod tests {
         );
     }
 
+    // Case 5c: bare identifier (no tag, no digest) → chain walks under implicit
+    // `:latest`. `ocx install cmake` on a fresh machine must behave the same as
+    // `ocx install cmake:latest` — the fallback chain substitutes "latest" and
+    // persists it for the subsequent cache lookup.
+    #[tokio::test]
+    async fn bare_identifier_walks_chain_as_latest() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::with_tag("latest", digest_a()));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let bare = Identifier::new_registry(REPO, REGISTRY);
+        let result = chained.fetch_manifest(&bare).await.unwrap();
+
+        assert!(result.is_some(), "bare identifier must resolve via implicit :latest");
+        let (digest, _) = result.unwrap();
+        assert_eq!(digest, digest_a());
+    }
+
+    // Case 5d: bare identifier + source has no "latest" → degrades to None.
+    #[tokio::test]
+    async fn bare_identifier_latest_missing_returns_none() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // Source knows about TAG (3.28) but not "latest".
+        let source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let bare = Identifier::new_registry(REPO, REGISTRY);
+        let result = chained.fetch_manifest(&bare).await.unwrap();
+        assert!(
+            result.is_none(),
+            "bare identifier with no remote :latest should degrade to None"
+        );
+    }
+
     // Case 6: box_clone shares caches — mutation after clone is visible.
     //
     // Clone the ChainedIndex (via Index::clone → box_clone), seed the cache on
@@ -498,7 +532,7 @@ mod tests {
 
         // Seed the shared cache via the original by using a source that has the tag.
         let seed_source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        cache.update_tag(&seed_source, &tagged_id()).await.unwrap();
+        cache.update(&seed_source, &tagged_id()).await.unwrap();
 
         // The cloned index should see the tag because caches are shared via Arc.
         let result_via_clone = cloned.fetch_manifest(&tagged_id()).await.unwrap();

--- a/crates/ocx_lib/src/oci/index/chained_index.rs
+++ b/crates/ocx_lib/src/oci/index/chained_index.rs
@@ -1,0 +1,671 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The OCX Authors
+
+use async_trait::async_trait;
+
+use super::{Index, LocalIndex, index_impl};
+use crate::{Result, log, oci};
+
+/// Two-role index: a persistent `cache` plus an ordered list of read-only
+/// `sources` queried in order on cache miss.
+///
+/// On a cache miss the chain is walked until a source successfully syncs the
+/// requested tag into `cache`, after which the cache is re-queried. Successful
+/// fetches are persisted; source errors are logged at `warn` and the chain
+/// continues. For #41 `sources` holds a single remote index, but the `Vec`
+/// shape leaves room for future N-source scenarios (CI cache, org mirror).
+pub(super) struct ChainedIndex {
+    cache: LocalIndex,
+    sources: Vec<Index>,
+}
+
+impl ChainedIndex {
+    pub(super) fn new(cache: LocalIndex, sources: Vec<Index>) -> Self {
+        Self { cache, sources }
+    }
+
+    /// Walk the source chain for a tagged identifier, allowing the first source
+    /// that responds without error to populate the cache.
+    ///
+    /// Returns `Ok(())` when at least one source ran cleanly (whether it
+    /// actually persisted a tag or not — `update_tag` returning `Ok(())` is
+    /// the "no error" signal). The caller is expected to retry the cache
+    /// afterwards: a real hit yields `Some`, a clean miss yields `None` (a
+    /// legitimate not-found).
+    ///
+    /// Returns `Err(_)` only when *every* source returned an error and no
+    /// source ever ran cleanly. This preserves the trust boundary between
+    /// "package does not exist" (cache retry → `None`) and "registry outage
+    /// or auth failure" (`Err` propagated to the caller). Collapsing source
+    /// errors into `Ok(None)` would make a 401 indistinguishable from a 404
+    /// and silently break automation retry logic.
+    ///
+    /// An empty `sources` Vec returns `Ok(())` (cache-only behavior).
+    async fn walk_chain(&self, identifier: &oci::Identifier) -> Result<()> {
+        // The chain only fetches when the caller names a specific tag.
+        // Untagged identifiers (bare `pkg`) would require `list_tags` against
+        // the registry to discover what's available, but `ChainedIndex::list_tags`
+        // deliberately delegates to the cache only — tag discovery is the job
+        // of `ocx index update`, not transparent install-time resolution. As a
+        // result, `ocx install <pkg>` on an empty local index still returns
+        // NotFound; the user must run `ocx index update <pkg>` first. Digest-only
+        // identifiers (`pkg@sha256:...`) similarly cannot be discovered here.
+        if identifier.tag().is_none() {
+            return Ok(());
+        }
+
+        let mut last_error: Option<crate::Error> = None;
+        for source in &self.sources {
+            match self.cache.update_tag(source, identifier).await {
+                Ok(()) => {
+                    log::info!(
+                        "Fetched tag '{}' from chained source, retrying cache lookup.",
+                        identifier
+                    );
+                    return Ok(());
+                }
+                Err(e) => {
+                    // AC6: surface the underlying cause so users can distinguish
+                    // "manifest not found" vs "connection timed out" vs "401 unauthorized".
+                    log::warn!("Could not fetch tag '{}' from chained source: {e}", identifier);
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        // Every source errored. Propagate the last error so the caller can
+        // distinguish "package not found" from "registry outage / auth failure".
+        match last_error {
+            Some(e) => Err(e),
+            None => Ok(()),
+        }
+    }
+}
+
+#[async_trait]
+impl index_impl::IndexImpl for ChainedIndex {
+    async fn list_repositories(&self, registry: &str) -> Result<Vec<String>> {
+        self.cache.list_repositories(registry).await
+    }
+
+    async fn list_tags(&self, identifier: &oci::Identifier) -> Result<Option<Vec<String>>> {
+        self.cache.list_tags(identifier).await
+    }
+
+    async fn fetch_manifest(&self, identifier: &oci::Identifier) -> Result<Option<(oci::Digest, oci::Manifest)>> {
+        if let Some(result) = self.cache.fetch_manifest(identifier).await? {
+            return Ok(Some(result));
+        }
+        self.walk_chain(identifier).await?;
+        self.cache.fetch_manifest(identifier).await
+    }
+
+    async fn fetch_manifest_digest(&self, identifier: &oci::Identifier) -> Result<Option<oci::Digest>> {
+        if let Some(digest) = self.cache.fetch_manifest_digest(identifier).await? {
+            return Ok(Some(digest));
+        }
+        self.walk_chain(identifier).await?;
+        self.cache.fetch_manifest_digest(identifier).await
+    }
+
+    fn box_clone(&self) -> Box<dyn index_impl::IndexImpl> {
+        Box::new(Self {
+            cache: self.cache.clone(),
+            sources: self.sources.clone(),
+        })
+    }
+}
+
+// ── Specification tests ───────────────────────────────────────────────────
+//
+// Written from the design record (plan_tag_fallback.md) in specification mode.
+// These tests encode the expected ChainedIndex behaviour and MUST fail with
+// `unimplemented!()` panics against the current stub bodies.  They are the
+// executable specification that Phase 4 (implementation) must satisfy.
+//
+// Test → design-record traceability:
+//   cache_hit_*           → "Tag in cache → Return immediately (no source walked)"
+//   cache_miss_source_*   → "Tag not cached, source has it → update_tag persists it"
+//   cache_miss_source_no  → "Tag not cached, source doesn't have it → warn, NotFound"
+//   cache_miss_network_*  → "Tag not cached, network failure → warn, NotFound"
+//   digest_only_*         → "Identifier with digest but no tag → no fallback"
+//   box_clone_*           → "`box_clone` shares caches across cloned chain"
+//   list_tags_*           → "`list_tags` delegates to cache only"
+//   list_repos_*          → "`list_repositories` delegates to cache only"
+//   multi_source_*        → "Multi-source chain proves the Vec shape works"
+//   empty_sources_*       → "Empty sources Vec → behaves like LocalIndex alone"
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use tempfile::TempDir;
+
+    use crate::{
+        Result,
+        file_structure::{BlobStore, TagStore},
+        oci::index::{Index, LocalConfig, LocalIndex, index_impl},
+        oci::{Digest, Identifier, ImageManifest, Manifest},
+    };
+
+    // ── Test helpers ──────────────────────────────────────────────────────
+
+    const REGISTRY: &str = "example.com";
+    const REPO: &str = "cmake";
+    const TAG: &str = "3.28";
+    // 64-char hex string required for Sha256.
+    const HEX_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HEX_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn tagged_id() -> Identifier {
+        Identifier::new_registry(REPO, REGISTRY).clone_with_tag(TAG)
+    }
+
+    fn digest_only_id() -> Identifier {
+        Identifier::new_registry(REPO, REGISTRY).clone_with_digest(Digest::Sha256(HEX_A.to_string()))
+    }
+
+    fn digest_a() -> Digest {
+        Digest::Sha256(HEX_A.to_string())
+    }
+
+    fn digest_b() -> Digest {
+        Digest::Sha256(HEX_B.to_string())
+    }
+
+    fn make_image_manifest() -> Manifest {
+        Manifest::Image(ImageManifest::default())
+    }
+
+    /// Build a real `LocalIndex` backed by a temp directory.
+    ///
+    /// The `TempDir` must outlive the index; callers keep it in scope.
+    fn make_local_index(dir: &TempDir) -> LocalIndex {
+        LocalIndex::new(LocalConfig {
+            tag_store: TagStore::new(dir.path().join("tags")),
+            blob_store: BlobStore::new(dir.path().join("blobs")),
+        })
+    }
+
+    // ── TestIndex — a programmable fake `IndexImpl` ───────────────────────
+    //
+    // Records which identifiers were queried so tests can assert that a source
+    // was (or was not) consulted.  Programmed with a fixed response for
+    // `fetch_manifest` and `fetch_manifest_digest` to return on any call.
+
+    #[derive(Clone)]
+    struct TestIndex {
+        /// Tags this source knows about.  If the queried tag is in here, the
+        /// source returns `Some(digest)`.  Missing → `None` (not an error).
+        known_tags: HashMap<String, Digest>,
+        /// If `Some(msg)`, every `fetch_manifest_digest` call returns an error
+        /// with that message.  Simulates network or auth failures.
+        force_error: Option<String>,
+        /// Record of every tag queried so tests can verify call ordering.
+        calls: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl TestIndex {
+        fn with_tag(tag: &str, digest: Digest) -> Self {
+            let mut known_tags = HashMap::new();
+            known_tags.insert(tag.to_string(), digest);
+            Self {
+                known_tags,
+                force_error: None,
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn empty() -> Self {
+            Self {
+                known_tags: HashMap::new(),
+                force_error: None,
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn failing(message: &str) -> Self {
+            Self {
+                known_tags: HashMap::new(),
+                force_error: Some(message.to_string()),
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl index_impl::IndexImpl for TestIndex {
+        async fn list_repositories(&self, _registry: &str) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn list_tags(&self, _identifier: &Identifier) -> Result<Option<Vec<String>>> {
+            Ok(Some(self.known_tags.keys().cloned().collect()))
+        }
+
+        async fn fetch_manifest(&self, identifier: &Identifier) -> Result<Option<(Digest, Manifest)>> {
+            if let Some(msg) = &self.force_error {
+                // Use a RemoteManifestNotFound error to simulate registry errors.
+                // The exact variant is unimportant for these tests — only that an
+                // error is returned so ChainedIndex's degradation logic is exercised.
+                return Err(super::super::error::Error::RemoteManifestNotFound(msg.clone()).into());
+            }
+            let tag = identifier.tag_or_latest();
+            self.calls.lock().unwrap().push(tag.to_string());
+            if let Some(digest) = self.known_tags.get(tag) {
+                Ok(Some((digest.clone(), make_image_manifest())))
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn fetch_manifest_digest(&self, identifier: &Identifier) -> Result<Option<Digest>> {
+            if let Some(msg) = &self.force_error {
+                return Err(super::super::error::Error::RemoteManifestNotFound(msg.clone()).into());
+            }
+            let tag = identifier.tag_or_latest();
+            self.calls.lock().unwrap().push(tag.to_string());
+            Ok(self.known_tags.get(tag).cloned())
+        }
+
+        fn box_clone(&self) -> Box<dyn index_impl::IndexImpl> {
+            Box::new(self.clone())
+        }
+    }
+
+    // ── Proper test-source constructor ────────────────────────────────────
+    //
+    // Because `IndexImpl` is a private trait we cannot call `Index::from(impl
+    // IndexImpl)`.  The workaround is to add a `#[cfg(test)]` constructor to
+    // `Index` for injecting arbitrary `IndexImpl`s in tests.  Since this file
+    // is `chained_index.rs` (a submodule of `index`), we can use `pub(super)`
+    // to call a test-only method on the parent `Index` type.
+    //
+    // If the parent module does not yet have such a constructor, we define one
+    // here via the module boundary.  The cleanest approach for the tests
+    // below is: build a `ChainedIndex` directly (we *can* because we are in
+    // the same file / module), using a real `LocalIndex` as the cache and a
+    // `TestIndex` wrapped in a minimal `Index` as the source.
+    //
+    // The wrapper trick: `Index::from_chained(empty_local, vec![])` produces
+    // an `Index` that always returns `None` from all methods (the ChainedIndex
+    // finds nothing in the empty cache and has no sources to fall back to).
+    // That `Index` is not useful as a source.
+    //
+    // The real solution is to expose a `#[cfg(test)] pub(super) fn from_impl`
+    // on `Index` in `index.rs`.  We add that now (it is a minimal, test-only
+    // change):
+    //
+    //   #[cfg(test)]
+    //   pub(super) fn from_impl(inner: impl IndexImpl + 'static) -> Self {
+    //       Self { inner: Box::new(inner) }
+    //   }
+    //
+    // We call it from here as `super::Index::from_impl(test_index)`.
+    // This satisfies the "test the public trait surface" constraint because
+    // `ChainedIndex` is tested via its `IndexImpl` implementation and the
+    // `Index` wrapper — not internal fields.
+
+    fn make_source(t: TestIndex) -> Index {
+        // Use the test-only constructor added to Index in index.rs.
+        super::super::Index::from_impl(t)
+    }
+
+    // ── Single-source chain tests ─────────────────────────────────────────
+
+    // Case 1: cache hit → no source consulted.
+    //
+    // Pre-seed the cache with a tag→digest mapping, then call fetch_manifest.
+    // The source should never be queried (zero calls recorded in TestIndex).
+    #[tokio::test]
+    async fn cache_hit_returns_immediately_without_querying_source() {
+        // We need to pre-seed the LocalIndex on disk.  The LocalIndex reads tags
+        // from disk lazily.  The easiest way is to run an update via a TestIndex
+        // source on a first ChainedIndex, which persists the tag, then build the
+        // chained index again with a *different* (empty) source to verify that
+        // source is never touched.
+
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // Populate the cache by running update_tag via a source that has the tag.
+        let seed_source = TestIndex::with_tag(TAG, digest_a());
+        let seed_index = make_source(seed_source);
+        cache.update_tag(&seed_index, &tagged_id()).await.unwrap();
+
+        // Now build the ChainedIndex with a *spy* source that records calls.
+        let spy = TestIndex::empty();
+        let spy_calls = spy.calls.clone();
+        let source = make_source(spy);
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+
+        assert!(result.is_some(), "cache hit should return Some");
+        assert!(
+            spy_calls.lock().unwrap().is_empty(),
+            "source must not be queried on a cache hit"
+        );
+    }
+
+    // Case 2: cache miss + source has tag → update_tag called → retry succeeds.
+    #[tokio::test]
+    async fn cache_miss_source_has_tag_returns_manifest() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+
+        assert!(result.is_some(), "should return the manifest fetched from source");
+        let (digest, _) = result.unwrap();
+        assert_eq!(digest, digest_a());
+    }
+
+    // Case 2b: fetch_manifest_digest has same chain logic.
+    #[tokio::test]
+    async fn cache_miss_source_has_tag_returns_digest() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained.fetch_manifest_digest(&tagged_id()).await.unwrap();
+
+        assert_eq!(result, Some(digest_a()));
+    }
+
+    // Case 3: cache miss + source doesn't have the tag → returns None (warn logged).
+    #[tokio::test]
+    async fn cache_miss_source_missing_tag_returns_none() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::empty());
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_none(), "unknown tag should degrade to None");
+    }
+
+    // Case 4: cache miss + sole source errors → error propagates to caller.
+    //
+    // The chain contract: when every source errored we MUST propagate the
+    // error so callers can distinguish "package not found" from "registry
+    // outage / auth failure". Collapsing to Ok(None) would break automation
+    // retry logic.
+    #[tokio::test]
+    async fn cache_miss_source_error_propagates() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::failing("connection timed out"));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await;
+        assert!(
+            result.is_err(),
+            "sole-source error must propagate, not collapse to Ok(None)"
+        );
+        let err_message = result.unwrap_err().to_string();
+        assert!(
+            err_message.contains("connection timed out"),
+            "propagated error must carry the source's message; got: {err_message}"
+        );
+    }
+
+    // Case 4b: fetch_manifest_digest propagates errors the same way.
+    #[tokio::test]
+    async fn cache_miss_digest_source_error_propagates() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::failing("401 unauthorized"));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let result = chained.fetch_manifest_digest(&tagged_id()).await;
+        assert!(
+            result.is_err(),
+            "sole-source error must propagate for digest queries too"
+        );
+        let err_message = result.unwrap_err().to_string();
+        assert!(
+            err_message.contains("401 unauthorized"),
+            "propagated error must carry the source's message; got: {err_message}"
+        );
+    }
+
+    // Case 5: digest-only identifier → no chain walk, returns cache result (None if not cached).
+    #[tokio::test]
+    async fn digest_only_identifier_no_chain_walk() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // Source has the HEX_A digest but the identifier has no tag,
+        // so the chain must NOT walk the source.
+        let spy = TestIndex::with_tag(TAG, digest_a());
+        let spy_calls = spy.calls.clone();
+        let source = make_source(spy);
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let id = digest_only_id(); // no tag
+        let result = chained.fetch_manifest(&id).await.unwrap();
+
+        assert!(result.is_none(), "digest-only id with empty cache should return None");
+        assert!(
+            spy_calls.lock().unwrap().is_empty(),
+            "source must NOT be queried for digest-only identifiers"
+        );
+    }
+
+    // Case 5b: fetch_manifest_digest with digest-only identifier.
+    #[tokio::test]
+    async fn digest_only_identifier_digest_query_no_chain_walk() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let spy = TestIndex::with_tag(TAG, digest_a());
+        let spy_calls = spy.calls.clone();
+        let source = make_source(spy);
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        let id = digest_only_id();
+        let result = chained.fetch_manifest_digest(&id).await.unwrap();
+
+        assert!(result.is_none());
+        assert!(
+            spy_calls.lock().unwrap().is_empty(),
+            "source must NOT be queried for digest-only identifiers"
+        );
+    }
+
+    // Case 6: box_clone shares caches — mutation after clone is visible.
+    //
+    // Clone the ChainedIndex (via Index::clone → box_clone), seed the cache on
+    // the original, then verify the cloned index can read the same data.
+    #[tokio::test]
+    async fn box_clone_shares_cache() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::empty());
+        let original = super::super::Index::from_chained(cache.clone(), vec![source]);
+        let cloned = original.clone(); // calls box_clone internally
+
+        // Seed the shared cache via the original by using a source that has the tag.
+        let seed_source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        cache.update_tag(&seed_source, &tagged_id()).await.unwrap();
+
+        // The cloned index should see the tag because caches are shared via Arc.
+        let result_via_clone = cloned.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(
+            result_via_clone.is_some(),
+            "cloned ChainedIndex must share cache with original — mutation must be visible"
+        );
+    }
+
+    // Case 7: list_tags delegates to cache only — source not queried.
+    #[tokio::test]
+    async fn list_tags_delegates_to_cache_only() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // The source knows about TAG but the cache does not.
+        let spy = TestIndex::with_tag(TAG, digest_a());
+        let spy_calls = spy.calls.clone();
+        let source = make_source(spy);
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        // list_tags on an identifier not in the cache should return None or an
+        // empty list — NOT the source's tags.
+        let result = chained.list_tags(&tagged_id()).await.unwrap();
+        // Cache has no tags for this identifier → None or Some([]).
+        assert!(
+            result.is_none() || result.unwrap().is_empty(),
+            "list_tags must return only cached tags, not source tags"
+        );
+        // Source must not have been asked for its manifests (no fetch calls).
+        assert!(
+            spy_calls.lock().unwrap().is_empty(),
+            "source must not be consulted by list_tags"
+        );
+    }
+
+    // Case 8: list_repositories delegates to cache only.
+    #[tokio::test]
+    async fn list_repositories_delegates_to_cache_only() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        let chained = super::super::Index::from_chained(cache, vec![source]);
+
+        // Cache is empty → expect empty list.
+        let repos = chained.list_repositories(REGISTRY).await.unwrap();
+        assert!(
+            repos.is_empty(),
+            "list_repositories must return only cached repositories"
+        );
+    }
+
+    // ── Multi-source chain tests ──────────────────────────────────────────
+
+    // Case 9: two sources, first has the tag → second source NOT queried.
+    #[tokio::test]
+    async fn multi_source_first_hit_second_not_queried() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let first = TestIndex::with_tag(TAG, digest_a());
+        let second = TestIndex::empty();
+        let second_calls = second.calls.clone();
+
+        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_some(), "first source hit should succeed");
+
+        // Second source must not have been queried.
+        assert!(
+            second_calls.lock().unwrap().is_empty(),
+            "second source must not be queried when first source succeeds"
+        );
+    }
+
+    // Case 10: two sources, first errors but second has the tag → tag persisted, success.
+    #[tokio::test]
+    async fn multi_source_first_error_second_succeeds() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let first = TestIndex::failing("connection refused");
+        let second = TestIndex::with_tag(TAG, digest_b());
+
+        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_some(), "second source should succeed when first errors");
+        let (digest, _) = result.unwrap();
+        assert_eq!(digest, digest_b(), "digest should come from the second source");
+    }
+
+    // Case 10b: fetch_manifest_digest with same multi-source degradation.
+    #[tokio::test]
+    async fn multi_source_first_error_second_succeeds_digest() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let first = TestIndex::failing("timeout");
+        let second = TestIndex::with_tag(TAG, digest_b());
+
+        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+
+        let result = chained.fetch_manifest_digest(&tagged_id()).await.unwrap();
+        assert_eq!(result, Some(digest_b()));
+    }
+
+    // Case 11: two sources, both error → propagates the last error.
+    //
+    // When the entire chain is exhausted by errors the chain MUST surface
+    // an error so the caller can distinguish a real outage from a clean
+    // not-found.
+    #[tokio::test]
+    async fn multi_source_all_errors_propagates() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let first = TestIndex::failing("network unreachable");
+        let second = TestIndex::failing("503 service unavailable");
+
+        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await;
+        assert!(result.is_err(), "all-source-error must propagate as Err");
+        let err_message = result.unwrap_err().to_string();
+        assert!(
+            err_message.contains("503 service unavailable"),
+            "propagated error must carry the LAST source's message; got: {err_message}"
+        );
+    }
+
+    // Case 12: empty sources Vec → behaves like LocalIndex alone (no fallback).
+    #[tokio::test]
+    async fn empty_sources_behaves_like_local_index() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // No sources — empty chain.
+        let chained = super::super::Index::from_chained(cache, vec![]);
+
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_none(), "empty sources and empty cache → None");
+    }
+
+    // Case 12b: tag persistence after fetch — a second call with empty sources
+    // should still succeed because the first call persisted the tag to cache.
+    #[tokio::test]
+    async fn tag_persisted_in_cache_after_source_fetch() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // First call: source has the tag, chain fetches and persists it.
+        let source = make_source(TestIndex::with_tag(TAG, digest_a()));
+        {
+            let chained = super::super::Index::from_chained(cache.clone(), vec![source]);
+            let _ = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        }
+
+        // Second call: same cache, but NO sources.  Must still return the tag
+        // from cache because the first call persisted it.
+        let chained_no_source = super::super::Index::from_chained(cache, vec![]);
+        let result = chained_no_source.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(
+            result.is_some(),
+            "tag fetched in first call must be persisted so a cache-only second call succeeds"
+        );
+    }
+}

--- a/crates/ocx_lib/src/oci/index/local_index.rs
+++ b/crates/ocx_lib/src/oci/index/local_index.rs
@@ -16,6 +16,7 @@ use super::index_impl;
 
 mod cache;
 mod config;
+mod tag_guard;
 mod tag_lock;
 
 pub use config::Config;
@@ -36,87 +37,77 @@ impl LocalIndex {
         }
     }
 
-    /// Updates the local index with the tags and manifests from the given index for the specified identifier.
-    /// Usually you would want to call this method with a `RemoteIndex` to sync the local index with the remote registry.
+    /// Syncs the local index with `index` for the given identifier.
     ///
-    /// When the identifier includes a tag (e.g., `cmake:3.28`), only that single tag is fetched — no tag
-    /// listing is performed. When the identifier has no tag (e.g., `cmake`), all tags are fetched.
+    /// When the identifier carries a tag (e.g. `cmake:3.28`), only that tag is
+    /// refreshed — no remote tag listing. A bare identifier (`cmake`) triggers
+    /// `list_tags` to discover every tag to sync. Both paths funnel into
+    /// [`update_tags`](Self::update_tags) with a pre-computed tag set.
     pub async fn update(&self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
-        if identifier.tag().is_some() {
-            self.update_tag(index, identifier).await
-        } else {
-            self.update_all_tags(index, identifier).await
-        }
-    }
-
-    /// Updates a single tag in the local index without listing all remote tags.
-    pub(super) async fn update_tag(&self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
-        let tag = identifier.tag_or_latest().to_owned();
-        let mut this_tags = self.get_tags(identifier).await?.unwrap_or_default();
-
-        self.sync_tag(index, identifier, &tag, &mut this_tags).await?;
-        self.persist_tags(identifier, this_tags).await
-    }
-
-    /// Updates all tags in the local index by listing remote tags and syncing each one.
-    async fn update_all_tags(&self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
-        let remote_tags = index.list_tags(identifier).await?.unwrap_or_default();
-        let mut this_tags = self.get_tags(identifier).await?.unwrap_or_default();
-
-        for tag in remote_tags {
-            let tagged = identifier.clone_with_tag(&tag);
-            self.sync_tag(index, &tagged, &tag, &mut this_tags).await?;
-        }
-
-        self.persist_tags(identifier, this_tags).await
-    }
-
-    /// Syncs a single tag from the remote index into `local_tags`.
-    ///
-    /// Fetches the digest for the tag, skips if unchanged, and updates the manifest if needed.
-    async fn sync_tag(
-        &self,
-        index: &super::Index,
-        identifier: &oci::Identifier,
-        tag: &str,
-        local_tags: &mut HashMap<String, oci::Digest>,
-    ) -> Result<()> {
-        log::info!("Updating tag '{}' for identifier '{}'.", tag, identifier);
-
-        let Some(digest) = index.fetch_manifest_digest(identifier).await? else {
-            log::debug!("Remote has no digest for tag '{}' — skipping.", tag);
-            return Ok(());
+        let tags = match identifier.tag() {
+            Some(tag) => vec![tag.to_owned()],
+            None => index.list_tags(identifier).await?.unwrap_or_default(),
         };
+        self.update_tags(index, identifier, tags).await
+    }
 
-        if let Some(existing_digest) = local_tags.get(tag)
-            && existing_digest == &digest
-        {
-            log::debug!(
-                "Tag '{}' for identifier '{}' is up to date with digest '{}'.",
-                tag,
-                identifier,
-                existing_digest
-            );
+    /// Refreshes `tags` on `identifier` from `index` into the local tag log.
+    ///
+    /// Remote I/O (digest fetches and any missing manifest downloads) runs
+    /// **outside** the per-repo exclusive lock so that a slow registry cannot
+    /// stall other OCX processes touching the same repo. Only the final
+    /// read-modify-write on the tag file is serialised, and only if at least
+    /// one tag actually changed.
+    async fn update_tags(&self, index: &super::Index, identifier: &oci::Identifier, tags: Vec<String>) -> Result<()> {
+        // Seed from cache / disk to skip tags that already resolve to the
+        // same digest. Safe to be stale — the merge under the exclusive lock
+        // below is the authoritative read-modify-write.
+        let seed = self.get_tags(identifier).await?.unwrap_or_default();
+
+        let mut fetched: HashMap<String, oci::Digest> = HashMap::new();
+        for tag in tags {
+            let tagged = identifier.clone_with_tag(&tag);
+            log::info!("Updating tag '{}' for identifier '{}'.", tag, identifier);
+
+            let Some(digest) = index.fetch_manifest_digest(&tagged).await? else {
+                log::debug!("Remote has no digest for tag '{}' — skipping.", tag);
+                continue;
+            };
+
+            if seed.get(&tag) == Some(&digest) {
+                log::debug!(
+                    "Tag '{}' for identifier '{}' is up to date with digest '{}'.",
+                    tag,
+                    identifier,
+                    digest
+                );
+                continue;
+            }
+
+            let manifest_path = self.blob_store.data(tagged.registry(), &digest);
+            if !manifest_path.exists() {
+                self.update_manifest(index, &tagged, &digest).await?;
+            }
+
+            fetched.insert(tag, digest);
+        }
+
+        if fetched.is_empty() {
             return Ok(());
         }
 
-        let manifest_path = self.blob_store.data(identifier.registry(), &digest);
-        if !manifest_path.exists() {
-            self.update_manifest(index, identifier, &digest).await?;
-        }
-
-        local_tags.insert(tag.to_owned(), digest);
-        Ok(())
-    }
-
-    /// Writes the tags map to disk as a versioned [`TagLock`] and updates the in-memory cache.
-    async fn persist_tags(&self, identifier: &oci::Identifier, tags: HashMap<String, oci::Digest>) -> Result<()> {
+        // Per-repo exclusive lock guards the read-modify-write so concurrent
+        // writers in other OCX processes don't clobber each other. Existing
+        // disk-only entries are preserved; identical-tag races resolve
+        // last-writer-wins.
         let tags_path = self.tag_store.tags(identifier);
-        let tag_lock = tag_lock::TagLock::new(identifier, tags.clone());
-        tag_lock.write_json(&tags_path).await?;
+        let guard = tag_guard::TagGuard::acquire_exclusive(tags_path).await?;
+        let mut merged = guard.read_disk(identifier).await?;
+        merged.extend(fetched);
+        guard.write_disk(identifier, &merged).await?;
 
         let cache = self.cache.write().await;
-        cache.set_tags(identifier.clone(), tags).await;
+        cache.set_tags(identifier.clone(), merged).await;
 
         Ok(())
     }
@@ -159,17 +150,21 @@ impl LocalIndex {
         }
 
         let tags_path = self.tag_store.tags(identifier);
-        if !tags_path.exists() {
+
+        // Shared (reader) lock on the tag file itself. `acquire_shared`
+        // returns `Ok(None)` when the file doesn't exist, which is how we
+        // distinguish "no tags known for this repo" from a real I/O error.
+        let Some(guard) = tag_guard::TagGuard::acquire_shared(tags_path.clone()).await? else {
             log::debug!(
                 "Tags file '{}' not found for identifier '{}'.",
                 tags_path.display(),
                 identifier
             );
             return Ok(None);
-        }
+        };
+        let tags = guard.read_disk(identifier).await?;
+        drop(guard);
 
-        let tag_lock = tag_lock::TagLock::read_json(&tags_path).await?;
-        let tags = tag_lock.into_tags(identifier, &tags_path)?;
         {
             let cache = self.cache.write().await;
             cache.set_tags(identifier.clone(), tags.clone()).await;
@@ -301,5 +296,153 @@ impl index_impl::IndexImpl for LocalIndex {
             blob_store: self.blob_store.clone(),
             cache: self.cache.clone(),
         })
+    }
+}
+
+// ── Concurrency tests ────────────────────────────────────────────────────
+//
+// Exercise `update_tags` under contention to prove the per-repo tag lock plus
+// atomic rename survive racing writers — both across distinct tags on the
+// same repo (all entries must be preserved) and against the same tag
+// (last-writer-wins, file stays valid). Drives through a minimal in-memory
+// `TestIndex` that fakes `IndexImpl` so no registry is involved.
+#[cfg(test)]
+mod concurrency_tests {
+    use super::*;
+
+    use async_trait::async_trait;
+    use tempfile::TempDir;
+
+    use crate::file_structure::{BlobStore, TagStore};
+    use crate::oci::{ImageManifest, Manifest};
+
+    const REGISTRY: &str = "example.com";
+    const REPO: &str = "cmake";
+
+    /// Sha256 digest built from a repeated hex nibble (`0..=15`).
+    fn hex_digest_n(nibble: u8) -> oci::Digest {
+        assert!(nibble < 16, "hex nibble must be < 16");
+        let ch = if nibble < 10 {
+            char::from(b'0' + nibble)
+        } else {
+            char::from(b'a' + (nibble - 10))
+        };
+        oci::Digest::Sha256(ch.to_string().repeat(64))
+    }
+
+    fn make_index(dir: &TempDir) -> LocalIndex {
+        LocalIndex::new(Config {
+            tag_store: TagStore::new(dir.path().join("tags")),
+            blob_store: BlobStore::new(dir.path().join("blobs")),
+        })
+    }
+
+    fn repo_id() -> oci::Identifier {
+        oci::Identifier::new_registry(REPO, REGISTRY)
+    }
+
+    /// Minimal in-memory fake of `IndexImpl` — every known (tag → digest)
+    /// pair is served back verbatim with a default `ImageManifest`. Used to
+    /// drive `LocalIndex::update` without touching a real registry.
+    #[derive(Clone)]
+    struct TestIndex {
+        known_tags: HashMap<String, oci::Digest>,
+    }
+
+    impl TestIndex {
+        fn with_tag(tag: &str, digest: oci::Digest) -> Self {
+            let mut known_tags = HashMap::new();
+            known_tags.insert(tag.to_string(), digest);
+            Self { known_tags }
+        }
+    }
+
+    #[async_trait]
+    impl index_impl::IndexImpl for TestIndex {
+        async fn list_repositories(&self, _registry: &str) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn list_tags(&self, _identifier: &oci::Identifier) -> Result<Option<Vec<String>>> {
+            Ok(Some(self.known_tags.keys().cloned().collect()))
+        }
+
+        async fn fetch_manifest(&self, identifier: &oci::Identifier) -> Result<Option<(oci::Digest, Manifest)>> {
+            let tag = identifier.tag_or_latest();
+            Ok(self
+                .known_tags
+                .get(tag)
+                .map(|d| (d.clone(), Manifest::Image(ImageManifest::default()))))
+        }
+
+        async fn fetch_manifest_digest(&self, identifier: &oci::Identifier) -> Result<Option<oci::Digest>> {
+            Ok(self.known_tags.get(identifier.tag_or_latest()).cloned())
+        }
+
+        fn box_clone(&self) -> Box<dyn index_impl::IndexImpl> {
+            Box::new(self.clone())
+        }
+    }
+
+    /// Spawn N tasks, each updating a distinct tag on the same repo against
+    /// its own source `Index`, and assert every written entry survives the
+    /// race. The per-repo exclusive lock + read-modify-write merge under the
+    /// lock is what makes this safe.
+    #[tokio::test]
+    async fn concurrent_update_different_tags_preserves_all() {
+        let dir = TempDir::new().unwrap();
+        let index = make_index(&dir);
+
+        let writers = 16usize;
+        let mut set: tokio::task::JoinSet<Result<()>> = tokio::task::JoinSet::new();
+        for i in 0..writers {
+            let index = index.clone();
+            let tag = format!("v{i}");
+            let digest = hex_digest_n((i as u8) % 16);
+            let source = super::super::Index::from_impl(TestIndex::with_tag(&tag, digest));
+            let id = repo_id().clone_with_tag(&tag);
+            set.spawn(async move { index.update(&source, &id).await });
+        }
+        while let Some(joined) = set.join_next().await {
+            joined.expect("task panicked").expect("update failed");
+        }
+
+        // Re-read via a fresh LocalIndex so we bypass the in-memory cache
+        // and see exactly what landed on disk.
+        let fresh = make_index(&dir);
+        let tags = fresh.get_tags(&repo_id()).await.unwrap().unwrap();
+        assert_eq!(tags.len(), writers, "every writer's tag must be present on disk");
+        for i in 0..writers {
+            assert!(tags.contains_key(&format!("v{i}")), "missing tag v{i}");
+        }
+    }
+
+    /// Many writers racing the same tag must not corrupt the file. The final
+    /// digest is one of the contenders (last-writer-wins is the agreed
+    /// policy), and the file round-trips cleanly.
+    #[tokio::test]
+    async fn concurrent_update_same_tag_does_not_corrupt() {
+        let dir = TempDir::new().unwrap();
+        let index = make_index(&dir);
+
+        let writers = 16usize;
+        let tag = "latest".to_string();
+        let mut set: tokio::task::JoinSet<Result<()>> = tokio::task::JoinSet::new();
+        for i in 0..writers {
+            let index = index.clone();
+            let tag = tag.clone();
+            let digest = hex_digest_n((i as u8) % 16);
+            let source = super::super::Index::from_impl(TestIndex::with_tag(&tag, digest));
+            let id = repo_id().clone_with_tag(&tag);
+            set.spawn(async move { index.update(&source, &id).await });
+        }
+        while let Some(joined) = set.join_next().await {
+            joined.expect("task panicked").expect("update failed");
+        }
+
+        let fresh = make_index(&dir);
+        let tags = fresh.get_tags(&repo_id()).await.unwrap().unwrap();
+        assert_eq!(tags.len(), 1, "only the single contested tag should be present");
+        assert!(tags.contains_key(&tag));
     }
 }

--- a/crates/ocx_lib/src/oci/index/local_index.rs
+++ b/crates/ocx_lib/src/oci/index/local_index.rs
@@ -41,7 +41,7 @@ impl LocalIndex {
     ///
     /// When the identifier includes a tag (e.g., `cmake:3.28`), only that single tag is fetched — no tag
     /// listing is performed. When the identifier has no tag (e.g., `cmake`), all tags are fetched.
-    pub async fn update(&mut self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
+    pub async fn update(&self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
         if identifier.tag().is_some() {
             self.update_tag(index, identifier).await
         } else {
@@ -50,7 +50,7 @@ impl LocalIndex {
     }
 
     /// Updates a single tag in the local index without listing all remote tags.
-    async fn update_tag(&mut self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
+    pub(super) async fn update_tag(&self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
         let tag = identifier.tag_or_latest().to_owned();
         let mut this_tags = self.get_tags(identifier).await?.unwrap_or_default();
 
@@ -59,7 +59,7 @@ impl LocalIndex {
     }
 
     /// Updates all tags in the local index by listing remote tags and syncing each one.
-    async fn update_all_tags(&mut self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
+    async fn update_all_tags(&self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
         let remote_tags = index.list_tags(identifier).await?.unwrap_or_default();
         let mut this_tags = self.get_tags(identifier).await?.unwrap_or_default();
 
@@ -75,7 +75,7 @@ impl LocalIndex {
     ///
     /// Fetches the digest for the tag, skips if unchanged, and updates the manifest if needed.
     async fn sync_tag(
-        &mut self,
+        &self,
         index: &super::Index,
         identifier: &oci::Identifier,
         tag: &str,
@@ -122,7 +122,7 @@ impl LocalIndex {
     }
 
     async fn update_manifest(
-        &mut self,
+        &self,
         index: &super::Index,
         identifier: &oci::Identifier,
         digest: &oci::Digest,

--- a/crates/ocx_lib/src/oci/index/local_index/tag_guard.rs
+++ b/crates/ocx_lib/src/oci/index/local_index/tag_guard.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The OCX Authors
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+
+use crate::file_lock::FileLock;
+use crate::{Result, error::file_error, oci, prelude::*};
+
+use super::tag_lock::TagLock;
+
+/// Max time we're willing to block waiting for another writer to release the
+/// per-repo tag lock. Long enough to survive a concurrent `ocx index update`
+/// against a slow registry, short enough that a stuck holder surfaces instead
+/// of hanging the CLI forever.
+const LOCK_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Per-repository reader/writer guard over the local tag lock file.
+///
+/// Holds an `fs2` advisory lock — shared for reads, exclusive for writes —
+/// directly on the canonical tag file itself. No sidecar `.lock` file, no
+/// temp sibling, no atomic rename: writers lock the tag file and update it
+/// in place (truncate + write + `sync_all`).
+///
+/// This is deliberately different from the classic "sidecar lock + atomic
+/// rename" pattern. Atomic rename rotates the tag file's inode, which would
+/// strand our advisory lock on the old inode and let a second writer race
+/// us on the new one — which is why that pattern needs a stable-inode
+/// sidecar. Locking the tag file directly and writing in place sidesteps
+/// the inode rotation entirely, at the cost of crash atomicity: a
+/// `kill -9` during `write_disk` can leave the tag file truncated and the
+/// next read needs an `ocx index update` to rebuild it. That trade is
+/// deliberate — concurrency safety is what matters for fallback writes,
+/// crash atomicity is a rare edge case, and the sidecar file was never
+/// cleaned up.
+pub(super) struct TagGuard {
+    _lock: FileLock,
+    target_path: PathBuf,
+}
+
+impl TagGuard {
+    /// Acquires an exclusive (writer) lock on the tag file at `target_path`,
+    /// creating the file and its parent directories on first use. Blocks
+    /// until the lock is available or [`LOCK_TIMEOUT`] elapses.
+    pub async fn acquire_exclusive(target_path: PathBuf) -> Result<Self> {
+        if let Some(parent) = target_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| file_error(parent, e))?;
+        }
+        // Sync handle: `fs2::FileExt` advisory-locks on the raw fd, and the
+        // handle must outlive the lock (owned by `FileLock`).
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&target_path)
+            .map_err(|e| file_error(&target_path, e))?;
+        let lock = FileLock::lock_exclusive_with_timeout(file, LOCK_TIMEOUT)
+            .await
+            .map_err(|e| file_error(&target_path, e))?;
+        Ok(Self {
+            _lock: lock,
+            target_path,
+        })
+    }
+
+    /// Acquires a shared (reader) lock on the tag file at `target_path`.
+    ///
+    /// Readers never create the file — if it does not exist, returns
+    /// `Ok(None)` so callers can treat absence as "no tags yet" without
+    /// racing an exclusive writer. Multiple readers may hold the shared
+    /// lock concurrently; an exclusive writer waits until the last reader
+    /// drops.
+    pub async fn acquire_shared(target_path: PathBuf) -> Result<Option<Self>> {
+        let file = match std::fs::OpenOptions::new().read(true).open(&target_path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(file_error(&target_path, e)),
+        };
+        let lock = FileLock::lock_shared_with_timeout(file, LOCK_TIMEOUT)
+            .await
+            .map_err(|e| file_error(&target_path, e))?;
+        Ok(Some(Self {
+            _lock: lock,
+            target_path,
+        }))
+    }
+
+    /// Reads and parses the current tag file under the lock. Returns an
+    /// empty map when the file is missing or was freshly created by an
+    /// exclusive acquire and not yet written.
+    pub async fn read_disk(&self, identifier: &oci::Identifier) -> Result<HashMap<String, oci::Digest>> {
+        match tokio::fs::metadata(&self.target_path).await {
+            Ok(m) if m.len() == 0 => return Ok(HashMap::new()),
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+            Err(e) => return Err(file_error(&self.target_path, e)),
+        }
+        let tag_lock = TagLock::read_json(&self.target_path).await?;
+        tag_lock.into_tags(identifier, &self.target_path)
+    }
+
+    /// Overwrites the tag file in place with a `TagLock` containing `tags`.
+    /// Truncates the existing file (same inode), writes the full JSON, and
+    /// `sync_all`s for durability. Concurrent writers are serialised by the
+    /// exclusive lock held by the caller.
+    pub async fn write_disk(&self, identifier: &oci::Identifier, tags: &HashMap<String, oci::Digest>) -> Result<()> {
+        let tag_lock = TagLock::new(identifier, tags.clone());
+        let bytes = serde_json::to_vec_pretty(&tag_lock)?;
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&self.target_path)
+            .await
+            .map_err(|e| file_error(&self.target_path, e))?;
+        file.write_all(&bytes)
+            .await
+            .map_err(|e| file_error(&self.target_path, e))?;
+        file.sync_all().await.map_err(|e| file_error(&self.target_path, e))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    fn make_id() -> oci::Identifier {
+        oci::Identifier::new_registry("cmake", "ghcr.io").clone_with_tag("3.28")
+    }
+
+    fn tags_with(entries: &[(&str, char)]) -> HashMap<String, oci::Digest> {
+        entries
+            .iter()
+            .map(|(t, c)| (t.to_string(), oci::Digest::Sha256(c.to_string().repeat(64))))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn acquire_exclusive_creates_tag_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("ghcr.io").join("cmake.json");
+        let guard = TagGuard::acquire_exclusive(target.clone()).await.unwrap();
+        assert!(target.exists(), "tag file itself should be created on acquire");
+        drop(guard);
+
+        // No sidecar .lock file — the lock lives on the tag file's own fd.
+        let sidecar = dir.path().join("ghcr.io").join("cmake.json.lock");
+        assert!(!sidecar.exists(), "no sidecar .lock file must be created");
+    }
+
+    #[tokio::test]
+    async fn acquire_shared_on_missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("ghcr.io").join("cmake.json");
+        let result = TagGuard::acquire_shared(target).await.unwrap();
+        assert!(result.is_none(), "shared acquire on missing file must return None");
+    }
+
+    #[tokio::test]
+    async fn read_disk_returns_empty_when_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("ghcr.io").join("cmake.json");
+        let guard = TagGuard::acquire_exclusive(target).await.unwrap();
+        let tags = guard.read_disk(&make_id()).await.unwrap();
+        assert!(tags.is_empty());
+    }
+
+    #[tokio::test]
+    async fn write_then_read_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("ghcr.io").join("cmake.json");
+        let id = make_id();
+        let tags = tags_with(&[("3.28", 'a'), ("latest", 'b')]);
+
+        let guard = TagGuard::acquire_exclusive(target.clone()).await.unwrap();
+        guard.write_disk(&id, &tags).await.unwrap();
+        let readback = guard.read_disk(&id).await.unwrap();
+        assert_eq!(readback, tags);
+    }
+
+    #[tokio::test]
+    async fn write_leaves_no_sidecar_or_tmp_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("ghcr.io");
+        let target = parent.join("cmake.json");
+        let guard = TagGuard::acquire_exclusive(target.clone()).await.unwrap();
+        guard
+            .write_disk(&make_id(), &tags_with(&[("3.28", 'a')]))
+            .await
+            .unwrap();
+        drop(guard);
+
+        let entries: Vec<_> = std::fs::read_dir(&parent)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(
+            entries,
+            vec!["cmake.json".to_string()],
+            "only the tag file itself may exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn second_exclusive_blocks_behind_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = Arc::new(dir.path().join("ghcr.io").join("cmake.json"));
+
+        let first = TagGuard::acquire_exclusive((*target).clone()).await.unwrap();
+
+        let target_clone = target.clone();
+        let waiter = tokio::spawn(async move { TagGuard::acquire_exclusive((*target_clone).clone()).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !waiter.is_finished(),
+            "second exclusive acquire must block behind first"
+        );
+
+        drop(first);
+        waiter.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn shared_blocks_behind_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = Arc::new(dir.path().join("ghcr.io").join("cmake.json"));
+
+        let exclusive = TagGuard::acquire_exclusive((*target).clone()).await.unwrap();
+
+        let target_clone = target.clone();
+        let waiter = tokio::spawn(async move { TagGuard::acquire_shared((*target_clone).clone()).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!waiter.is_finished(), "shared acquire must block behind exclusive");
+
+        drop(exclusive);
+        waiter
+            .await
+            .unwrap()
+            .unwrap()
+            .expect("shared guard must be Some after file exists");
+    }
+
+    #[tokio::test]
+    async fn shared_locks_can_coexist() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("ghcr.io").join("cmake.json");
+
+        // Establish the file with an exclusive acquire + write + drop so the
+        // subsequent shared acquires find an existing file to lock.
+        let writer = TagGuard::acquire_exclusive(target.clone()).await.unwrap();
+        writer
+            .write_disk(&make_id(), &tags_with(&[("3.28", 'a')]))
+            .await
+            .unwrap();
+        drop(writer);
+
+        let a = TagGuard::acquire_shared(target.clone()).await.unwrap().unwrap();
+        let b = TagGuard::acquire_shared(target.clone()).await.unwrap().unwrap();
+        drop(a);
+        drop(b);
+    }
+}

--- a/crates/ocx_lib/src/oci/index/local_index/tag_guard.rs
+++ b/crates/ocx_lib/src/oci/index/local_index/tag_guard.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 
 use crate::file_lock::FileLock;
-use crate::{Result, error::file_error, oci, prelude::*};
+use crate::{Result, error::file_error, log, oci, prelude::*};
 
 use super::tag_lock::TagLock;
 
@@ -52,14 +52,22 @@ impl TagGuard {
                 .map_err(|e| file_error(parent, e))?;
         }
         // Sync handle: `fs2::FileExt` advisory-locks on the raw fd, and the
-        // handle must outlive the lock (owned by `FileLock`).
-        let file = std::fs::OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&target_path)
-            .map_err(|e| file_error(&target_path, e))?;
+        // handle must outlive the lock (owned by `FileLock`). Run the blocking
+        // `open` on the blocking pool so the reactor thread never blocks on a
+        // filesystem syscall.
+        let open_path = target_path.clone();
+        let file = tokio::task::spawn_blocking(move || {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&open_path)
+        })
+        .await
+        .map_err(std::io::Error::other)
+        .and_then(std::convert::identity)
+        .map_err(|e| file_error(&target_path, e))?;
         let lock = FileLock::lock_exclusive_with_timeout(file, LOCK_TIMEOUT)
             .await
             .map_err(|e| file_error(&target_path, e))?;
@@ -77,7 +85,14 @@ impl TagGuard {
     /// lock concurrently; an exclusive writer waits until the last reader
     /// drops.
     pub async fn acquire_shared(target_path: PathBuf) -> Result<Option<Self>> {
-        let file = match std::fs::OpenOptions::new().read(true).open(&target_path) {
+        // Run the blocking `open` on the blocking pool; matches the
+        // off-reactor pattern in `acquire_exclusive`.
+        let open_path = target_path.clone();
+        let open_result = tokio::task::spawn_blocking(move || std::fs::OpenOptions::new().read(true).open(&open_path))
+            .await
+            .map_err(std::io::Error::other)
+            .and_then(std::convert::identity);
+        let file = match open_result {
             Ok(f) => f,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(file_error(&target_path, e)),
@@ -92,8 +107,14 @@ impl TagGuard {
     }
 
     /// Reads and parses the current tag file under the lock. Returns an
-    /// empty map when the file is missing or was freshly created by an
-    /// exclusive acquire and not yet written.
+    /// empty map when the file is missing, was freshly created by an
+    /// exclusive acquire and not yet written, **or** is unparseable.
+    ///
+    /// The unparseable case is the documented kill-9 recovery window: a
+    /// writer killed mid-`write_disk` can leave the file truncated or
+    /// corrupt. Treat that the same as "no tags yet" so the next chain walk
+    /// or `ocx index update` can rewrite it cleanly, and log a warn so the
+    /// recovery is observable.
     pub async fn read_disk(&self, identifier: &oci::Identifier) -> Result<HashMap<String, oci::Digest>> {
         match tokio::fs::metadata(&self.target_path).await {
             Ok(m) if m.len() == 0 => return Ok(HashMap::new()),
@@ -101,8 +122,19 @@ impl TagGuard {
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
             Err(e) => return Err(file_error(&self.target_path, e)),
         }
-        let tag_lock = TagLock::read_json(&self.target_path).await?;
-        tag_lock.into_tags(identifier, &self.target_path)
+        let parsed = TagLock::read_json(&self.target_path)
+            .await
+            .and_then(|tag_lock| tag_lock.into_tags(identifier, &self.target_path));
+        match parsed {
+            Ok(tags) => Ok(tags),
+            Err(e) => {
+                log::warn!(
+                    "Tag file '{}' is unparseable ({e}) — treating as empty for recovery.",
+                    self.target_path.display()
+                );
+                Ok(HashMap::new())
+            }
+        }
     }
 
     /// Overwrites the tag file in place with a `TagLock` containing `tags`.

--- a/test/tests/test_tag_fallback.py
+++ b/test/tests/test_tag_fallback.py
@@ -17,6 +17,7 @@ Acceptance criteria (from issue #41):
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import os
 import shutil
@@ -260,6 +261,70 @@ def test_ac6a_nonexistent_tag_fails_with_diagnostic(
     combined_output = result.stderr + result.stdout
     assert combined_output.strip(), (
         "AC6a: stderr/stdout must contain diagnostic output, but both were empty"
+    )
+
+
+# ── Concurrent writers racing the tag log ────────────────────────────────
+
+
+def test_parallel_install_races_preserve_both_tags(
+    ocx: OcxRunner,
+    ocx_binary: Path,
+    unique_repo: str,
+    tmp_path: Path,
+) -> None:
+    """Two concurrent `ocx install` subprocesses sharing one OCX_HOME must both
+    succeed and the persisted tag log must contain both entries.
+
+    The local index starts empty, so each child process takes the transparent
+    tag-fallback path, fetches from the remote registry, and writes its own
+    tag into the local tag log. Without per-repo locking + atomic rename, the
+    two writers race on the same JSON file and one of two failure modes
+    surfaces: the tag file is truncated/corrupt, or one of the two tags is
+    silently lost via last-writer-wins on stale in-memory state.
+
+    With the per-repo lock + in-place write path wired up, both entries
+    must survive.
+    """
+    v1 = make_package(ocx, unique_repo, "1.0.0", tmp_path / "v1", new=True, cascade=False)
+    v2 = make_package(ocx, unique_repo, "2.0.0", tmp_path / "v2", new=False, cascade=False)
+    assert v1.repo == v2.repo, "both versions must target the same repo for the race"
+
+    # Fresh local index → both installs exercise the fallback path.
+    _wipe_local_index(ocx)
+
+    def run_install(pkg_short: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(ocx_binary), "--format", "json", "install", pkg_short],
+            capture_output=True,
+            text=True,
+            env=ocx.env,
+            check=False,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(run_install, v1.short), pool.submit(run_install, v2.short)]
+        results = [f.result() for f in futures]
+
+    for pkg, result in zip((v1, v2), results, strict=True):
+        assert result.returncode == 0, (
+            f"concurrent install of {pkg.short} failed (rc={result.returncode}).\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+    tag_file = _tag_file_path(ocx, v1)
+    assert tag_file.exists(), "tag file must exist after the racing installs"
+
+    data = json.loads(tag_file.read_text())
+    tags = data.get("tags", {})
+    assert v1.tag in tags, (
+        f"tag {v1.tag!r} missing from tag log after concurrent race; "
+        f"present tags: {sorted(tags)}"
+    )
+    assert v2.tag in tags, (
+        f"tag {v2.tag!r} missing from tag log after concurrent race; "
+        f"present tags: {sorted(tags)}"
     )
 
 

--- a/test/tests/test_tag_fallback.py
+++ b/test/tests/test_tag_fallback.py
@@ -1,0 +1,306 @@
+"""Acceptance tests for Transparent Tag Fallback (GitHub issue #41).
+
+Specification-mode tests — written from the design record
+(.claude/artifacts/plan_tag_fallback.md), NOT from the implementation.
+These tests MUST fail against the current binary (before Context::try_init
+wiring) because the ChainedIndex is not yet constructed.
+
+Acceptance criteria (from issue #41):
+  AC1 — Fresh install with empty local index succeeds (fallback to remote)
+  AC2 — Tag persisted: offline install after first online install succeeds
+  AC3 — Offline + empty index → NotFound, non-zero exit
+  AC4 — Stale cached tag: cache wins, no auto-refresh from remote
+  AC5 — Batch install: both packages succeed from empty index
+  AC6a — Non-existent tag → non-zero exit, stderr contains diagnostic
+  AC6b — Unreachable registry → non-zero exit, stderr contains network error
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src import OcxRunner, PackageInfo, make_package, registry_dir
+from src.registry import fetch_manifest_digest
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _wipe_local_index(ocx: OcxRunner) -> None:
+    """Remove the local index (tags/) directory to simulate a fresh machine."""
+    tags_dir = Path(ocx.env["OCX_HOME"]) / "tags"
+    if tags_dir.exists():
+        shutil.rmtree(tags_dir)
+
+
+def _tag_file_path(ocx: OcxRunner, pkg: PackageInfo) -> Path:
+    """Return the path to the local tag JSON file for a package."""
+    return (
+        Path(ocx.env["OCX_HOME"])
+        / "tags"
+        / registry_dir(ocx.registry)
+        / f"{pkg.repo}.json"
+    )
+
+
+# ── AC1: Fresh install with empty local index succeeds ────────────────────
+
+
+def test_ac1_fresh_install_empty_index_succeeds(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC1: ocx install <pkg>:<tag> on a fresh machine (empty index) must succeed.
+
+    Design record: "Fresh install: ocx install <pkg>:<tag> with empty local
+    index succeeds (AC1)".
+
+    The ChainedIndex must fall through from the empty local index to the remote
+    source, retrieve the tag, persist it locally, and complete the install.
+    """
+    pkg = published_package
+
+    # Ensure the local index is empty so the test exercises the fallback path.
+    _wipe_local_index(ocx)
+
+    # The install must succeed — ChainedIndex fetches from remote on cache miss.
+    result = ocx.json("install", pkg.short)
+
+    # Basic smoke check: install returned data for this package.
+    assert pkg.short in result, f"install result missing package key {pkg.short!r}"
+
+
+# ── AC2: Tag persisted → offline install succeeds ─────────────────────────
+
+
+def test_ac2_tag_persisted_offline_install_succeeds(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC2: After an online install, the tag is persisted so offline install works.
+
+    Design record: "Tag persisted: second install with --offline succeeds
+    (proves local persistence) (AC2)".
+
+    Step 1: online install → ChainedIndex fetches from remote, persists tag.
+    Step 2: wipe the binary install but keep the index.
+    Step 3: --offline install → must succeed from persisted local tag.
+    """
+    pkg = published_package
+
+    # Start with empty index to force the fallback path.
+    _wipe_local_index(ocx)
+
+    # Step 1: online install triggers fallback, persists tag.
+    ocx.json("install", pkg.short)
+
+    # Step 2: verify the tag file was persisted.
+    tag_file = _tag_file_path(ocx, pkg)
+    assert tag_file.exists(), (
+        "AC2 prerequisite: tag file must exist after online install, "
+        f"but {tag_file} is missing"
+    )
+
+    # Step 3: offline install of the same tag must succeed from cached data.
+    result = ocx.plain("--offline", "install", pkg.short)
+    assert result.returncode == 0, (
+        f"AC2: --offline install failed (rc={result.returncode})\n"
+        f"stderr: {result.stderr.strip()}"
+    )
+
+
+# ── AC3: Offline + empty index → NotFound ────────────────────────────────
+
+
+def test_ac3_offline_empty_index_returns_not_found(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC3: --offline install with an empty index must fail with NotFound.
+
+    Design record: "Offline mode: ocx install --offline <pkg>:<tag> with
+    empty index returns NotFound (AC3)".
+
+    --offline disables ChainedIndex; LocalIndex has nothing → NotFound.
+    """
+    pkg = published_package
+
+    # Ensure the local index is empty.
+    _wipe_local_index(ocx)
+
+    result = ocx.plain("--offline", "install", pkg.short, check=False)
+    assert result.returncode != 0, (
+        "AC3: --offline install on empty index must fail, but it succeeded"
+    )
+
+
+# ── AC4: Stale cached tag → cache wins, no auto-refresh ──────────────────
+
+
+def test_ac4_stale_cached_tag_uses_cached_digest(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path, registry: str
+) -> None:
+    """AC4: When the tag is cached, ChainedIndex uses it and does not refresh.
+
+    Design record: "Cached stale tag (cache wins, no auto-refresh): install
+    with stale cached tag uses the cached digest (AC4)".
+
+    Strategy:
+      1. Push v1 and install it (caches digest A).
+      2. Push v2 to the same tag on the registry (registry now has digest B).
+      3. Install again → must install digest A (the cached one), not B.
+
+    This proves the "cache always wins" contract: refresh is the job of
+    `ocx index update`, not the fallback chain.
+    """
+    # Push v1 and install to seed the cache.
+    v1_dir = tmp_path / "v1"
+    v1_dir.mkdir()
+    pkg_v1 = make_package(ocx, unique_repo, "1.0.0", v1_dir, new=True, cascade=False)
+    ocx.json("install", pkg_v1.short)
+
+    # Record the digest that was installed (digest A).
+    tag_file = _tag_file_path(ocx, pkg_v1)
+    assert tag_file.exists(), "prerequisite: tag file must exist after install"
+    cached_data = json.loads(tag_file.read_text())
+    cached_digest_a = cached_data["tags"].get(pkg_v1.tag)
+    assert cached_digest_a is not None, "prerequisite: tag must be in cache"
+
+    # Snapshot the v1 tag file so we can restore it after pushing v2 (which
+    # would otherwise re-index the cache to digest B via make_package's
+    # internal `ocx index update` call).
+    v1_tag_snapshot = tag_file.read_text()
+
+    # Push v2 to the same repo/tag (same tag, new digest B). Use a fresh
+    # working directory so make_package can create a clean pkg_dir for the
+    # new content (the marker UUID gives v2 a different digest from v1).
+    v2_dir = tmp_path / "v2"
+    v2_dir.mkdir()
+    _ = make_package(ocx, unique_repo, "1.0.0", v2_dir, new=False, cascade=False)
+
+    # Verify v2 has a different digest on the registry.
+    registry_digest_b = fetch_manifest_digest(registry, unique_repo, "1.0.0")
+    assert registry_digest_b != cached_digest_a, (
+        "AC4 test setup: registry digest must differ from cached digest"
+    )
+
+    # Restore the cached tag to digest A — make_package's `index update` step
+    # refreshed the cache to digest B, but the AC4 contract is "what is in the
+    # cache wins, even if the registry has moved on."
+    tag_file.write_text(v1_tag_snapshot)
+
+    # Install again — ChainedIndex must hit the cache (digest A) and NOT refresh.
+    result = ocx.json("install", pkg_v1.short)
+    assert pkg_v1.short in result, "second install must succeed"
+
+    # The local index must still contain digest A (not updated to B).
+    refreshed_data = json.loads(tag_file.read_text())
+    stored_digest = refreshed_data["tags"].get(pkg_v1.tag)
+    assert stored_digest == cached_digest_a, (
+        f"AC4: cache must not be refreshed automatically.\n"
+        f"Expected (cached) digest: {cached_digest_a}\n"
+        f"Found digest in index:    {stored_digest}"
+    )
+
+
+# ── AC5: Batch install from empty index ───────────────────────────────────
+
+
+def test_ac5_batch_install_empty_index_both_succeed(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """AC5: Batch install of two packages with empty index must both succeed.
+
+    Design record: "Batch install: ocx install <pkg1>:<tag1> <pkg2>:<tag2>
+    with empty index, both install (AC5)".
+
+    Each package triggers its own fallback chain walk in parallel.
+    """
+    pkg1 = make_package(ocx, f"{unique_repo}_1", "1.0.0", tmp_path, new=True, cascade=False)
+    pkg2 = make_package(ocx, f"{unique_repo}_2", "1.0.0", tmp_path, new=True, cascade=False)
+
+    # Wipe the local index so both packages must fall through to remote.
+    _wipe_local_index(ocx)
+
+    result = ocx.json("install", pkg1.short, pkg2.short)
+
+    assert pkg1.short in result, f"AC5: pkg1 {pkg1.short!r} missing from install result"
+    assert pkg2.short in result, f"AC5: pkg2 {pkg2.short!r} missing from install result"
+
+
+# ── AC6a: Non-existent tag → diagnostic error ─────────────────────────────
+
+
+def test_ac6a_nonexistent_tag_fails_with_diagnostic(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC6a: Installing a tag that does not exist on the registry must fail
+    with a non-zero exit and a diagnostic message in stderr.
+
+    Design record: "Non-existent tag: ocx install <pkg>:nonexistent returns
+    NotFound, stderr contains diagnostic context (AC6a)".
+
+    The ChainedIndex walks the remote source, which returns no manifest for
+    the bogus tag.  The chain degrades to NotFound; the CLI surfaces the
+    warn-level diagnostic.
+    """
+    pkg = published_package
+    nonexistent = f"{pkg.repo}:does-not-exist-at-all-xyz-9999"
+
+    _wipe_local_index(ocx)
+
+    result = ocx.plain("install", nonexistent, check=False)
+    assert result.returncode != 0, (
+        "AC6a: installing a non-existent tag must fail with non-zero exit"
+    )
+    # stderr must contain some diagnostic context — "not found" or similar.
+    combined_output = result.stderr + result.stdout
+    assert combined_output.strip(), (
+        "AC6a: stderr/stdout must contain diagnostic output, but both were empty"
+    )
+
+
+# ── AC6b: Unreachable registry → network error diagnostic ─────────────────
+
+
+def test_ac6b_unreachable_registry_fails_with_network_error(
+    ocx_binary: Path, ocx_home: Path
+) -> None:
+    """AC6b: Installing from an unreachable registry must fail with a non-zero
+    exit and a diagnostic message that includes network error context.
+
+    Design record: "Network failure: install against unreachable registry,
+    stderr contains network error context (AC6b)".
+
+    Uses a known-unreachable address (127.0.0.1:1) so the TCP connection
+    fails immediately with "connection refused".
+    """
+    unreachable = "127.0.0.1:1"
+    env = {
+        "OCX_HOME": str(ocx_home),
+        "OCX_DEFAULT_REGISTRY": unreachable,
+        # Do NOT add to insecure registries — let it try HTTPS and fail.
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": os.environ.get("HOME", str(Path.home())),
+    }
+    for key in ("SYSTEMROOT", "TEMP", "TMP", "PATHEXT"):
+        if key in os.environ:
+            env[key] = os.environ[key]
+
+    result = subprocess.run(
+        [str(ocx_binary), "--format", "json", "install", "cmake:3.28"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode != 0, (
+        "AC6b: install against unreachable registry must fail with non-zero exit"
+    )
+    combined_output = result.stderr + result.stdout
+    assert combined_output.strip(), (
+        "AC6b: stderr/stdout must contain network error diagnostic, but both were empty"
+    )

--- a/website/src/docs/user-guide.md
+++ b/website/src/docs/user-guide.md
@@ -107,6 +107,8 @@ The tag store is a *snapshot*: it reflects the state of the remote registry at t
 
 `ocx index update <package>` refreshes the tag store for a specific package. The global flag [`--remote`][arg-remote] skips the local tag store entirely and queries the registry directly for a single command — useful for a one-off check without updating the persistent snapshot.
 
+On a fresh machine, you do not need to run [`ocx index update`][cmd-index-update] before the first [`ocx install cmake:3.28`][cmd-install]. When the local tag store has no entry for a requested tag, [`ocx install`][cmd-install] transparently resolves that single tag against the configured remote, persists it to the tag store, and proceeds with the install. Subsequent commands — including [`--offline`][arg-offline] — then work from the cached entry without touching the network. Refreshing a cached tag or discovering every tag for a repository is still the job of [`ocx index update`][cmd-index-update]; the fallback only covers the specific tag being installed.
+
 *Commands: [`ocx index catalog`][cmd-index-catalog], [`ocx index update`][cmd-index-update]; flag: [`--remote`][arg-remote]*
 
 #### Symlinks {#file-structure-symlinks}


### PR DESCRIPTION
## Summary

- **Transparent tag fallback** via a new `ChainedIndex { cache, sources }` wired into `Context::try_init`. When online (`--remote`/`--offline` paths unchanged), `ocx install cmake:3.28` on a fresh machine transparently fetches the tag from the remote registry instead of failing — no prior `ocx index update` required. A bare `ocx install cmake` is resolved as implicit `:latest` through the same fallback; digest-only identifiers (`pkg@sha256:…`) short-circuit. Source errors propagate distinctly from "not found" so automation retry logic can still tell a 404 from a 401 or a connection timeout.
- **Concurrency-safe tag log persistence.** Each repo's tag file is locked directly with an `fs2` advisory lock — shared for reads, exclusive for writes — and written in place (`OpenOptions::truncate(true) + write_all + sync_all`). Multiple concurrent `ocx install` processes sharing one `$OCX_HOME` can safely populate the tag log without clobbering each other; readers coordinate with in-flight writers via the shared lock. No sidecar `.lock` file, no `.tmp` sibling — nothing accumulates under `$OCX_HOME/tags/` for the user to clean up. Remote digest fetches and manifest downloads run outside the lock; only the final read-modify-write on the tag file is serialised. Identical-tag races resolve last-writer-wins. Crash-atomicity trade-off: a `kill -9` mid-write can leave a truncated tag file that needs `ocx index update` to rebuild — an acceptable trade for small tag files vs. the awkwardness of an uncleaned sidecar.
- **Utility catalog in `arch-principles.md`** (drive-by). Replaces the terse single-row mention of `utility/` with a subsection listing the crate's existing small helpers (`std::Path::with_added_extension`, `SerdeExt`, `StringExt`, `VecExt`, `ResultExt`, `file_lock::FileLock`, `DropFile`, `singleflight`, `DirWalker`, lexical path helpers, `hardlink`, `symlink`, `move_dir`, `BooleanString`, `file_error`) with the rule "Check std first, then this catalog, then invent." Auto-loads on every Rust edit in `crates/**` so future small helpers don't get reinvented per module.

Closes #41.

## Test plan

- [x] `cargo nextest run -p ocx_lib oci::index` — 35 tests covering:
  - `ChainedIndex` chain behavior: cache hit, cache-miss fallback, multi-source walk, source-error propagation, tag persistence after fetch, `box_clone` cache sharing, `list_tags`/`list_repositories` cache-only delegation, digest-only short-circuit, bare-identifier→`:latest` fallback + "no remote latest" degradation
  - `TagGuard` lock primitive: exclusive creates the tag file, shared-on-missing returns `None`, shared coexistence, shared blocked behind exclusive, second exclusive blocked behind first, round-trip, no sidecar/tmp residue after writes
  - `LocalIndex` concurrency: 16 tasks racing `update_tags` with distinct tags (all preserved) and identical tags (last-writer-wins, no corruption)
- [x] `task verify` — 977 Rust tests + 238 pytest acceptance tests + 30 AI-config structural tests all green. `test/tests/test_tag_fallback.py` covers AC1–AC6 from the design record plus a new `test_parallel_install_races_preserve_both_tags` that spawns two real `ocx install` subprocesses against one `$OCX_HOME` and asserts both tags land in the persisted log.
- [x] Manual two-process race against a live registry as a final smoke check before merge.