### PR TITLE
feat(oci)!: chain refs resolution and --remote as CAS cache mode

### DIFF
--- a/.claude/artifacts/plan_resolution_chain_refs.md
+++ b/.claude/artifacts/plan_resolution_chain_refs.md
@@ -1,0 +1,730 @@
+---
+title: Capture Full OCI Resolution Chain in Package refs/blobs/
+issue: https://github.com/ocx-sh/ocx/issues/35
+scope: Medium (1-2 weeks)
+reversibility: Two-Way Door — pure correctness/consistency, no new on-disk format
+status: plan
+related:
+  - .claude/artifacts/adr_three_tier_cas_storage.md
+  - .claude/artifacts/plan_tag_fallback.md (ChainedIndex, landed as #41 via commits 89b0b90 / 5569658 / 68f341c)
+  - .claude/artifacts/research_tag_fallback.md
+  - .claude/artifacts/research_blob_retention_policy.md (prior-art for deferred #50)
+breaking_changes:
+  - `--remote` flag semantic: forces mutable lookups (tags, catalog) to source but still uses the chained cache for digest-addressed blob reads AND still persists fetched blobs into the cache via write-through
+  - `ocx index update` no longer pre-walks manifests; only locks tag→digest pointers
+  - `ocx --offline install <pkg>` after a bare `ocx index update <pkg>` now fails — users must run the first install online to populate the blob cache
+follow_ups:
+  - "#50 — policy-based retention for orphan blobs (shared $OCX_HOME CI scenarios)"
+---
+
+# Plan: Capture Full OCI Resolution Chain in Package `refs/blobs/`
+
+## Problem
+
+Three coupled gaps in the post-three-tier-CAS storage model:
+
+**Gap 1 — Incomplete `refs/blobs/` on installed packages.** `cache_manifest_blob` at `pull.rs:488-512` persists only the final platform manifest; `link_blobs_in_temp` at `pull.rs:762-774` links only that one blob into the package's `refs/blobs/`. Every intermediate image index or child platform manifest the resolver walked is a disk orphan — present in `blobs/` but not referenced by any package. `garbage_collection.rs:48` contains a hardcoded `**tier != CasTier::Blob` skip (with the test `unreachable_blobs_skipped_by_clean` at line 200 citing this issue) to protect these orphans from `ocx clean`, because collecting them would break offline re-resolve.
+
+**Gap 2 — Persistence and retention conflated.** `LocalIndex::update_manifest` at `local_index.rs:115-142` is the systematic write-path for manifest blobs. It is triggered from two distinct flows that *look* the same from the store's perspective but have very different user intent:
+
+- `ChainedIndex::walk_chain` during install (cache miss, legitimate write-through)
+- `ocx index update` CLI command (explicit user-level tag freeze — pre-walks the manifest chain eagerly as a side effect)
+
+The second flow creates long-lived orphans in `blobs/` that nothing references until a later install *might* link them. In the post-#35 world where the hardcoded blob skip is gone, those orphans become visible to `ocx clean` on the next run, creating a confusing "why did my index update blobs just disappear" story. The right answer is to narrow `ocx index update` to its actual job — locking tag→digest pointers — and let install-time ChainedIndex persistence cover the legitimate write-through case.
+
+**Gap 3 — Latent bug in `update_tags` skip logic.** `local_index.rs:77-85` short-circuits the entire tag refresh when `seed.get(&tag) == Some(&digest)`, which is correct for the tag file but ALSO skips the `update_manifest` call that would re-fetch a missing manifest blob. Today unreachable because nothing deletes blobs. Post-#35, once `ocx clean` can collect orphan blobs, a user who deletes `blobs/` (or whose blob was never persisted in the first place) would hit: tag file says `3.28 → sha256:abc`, manifest file missing, `fetch_manifest` returns `None`, `walk_chain` sees seed match and skips, infinite resolve loop returns `None`. Must be fixed as part of this feature — either by decoupling the checks in `update_tags` or (my preference) by moving orchestration into `ChainedIndex` where "tag cached, manifest missing" becomes a concrete state the walk can address.
+
+**Gap 4 — `--remote` is a type switch, not a behaviour hint.** `context.rs:65-75` has three branches: `--remote` → `Index::from_remote(remote_index)` (no cache, no write-through), default online → `Index::from_cached_remote(local, remote)` (ChainedIndex with write-through), `--offline` → `Index::from_local(local)` (no fallback). In a content-addressed world, digest-addressed reads return identical bytes whether cache or source — the only meaningful axis is whether mutable lookups (tags, catalog) should bypass the cache. The `--remote` branch loses write-through entirely, which means a user running `ocx --remote install cmake:3.28` gets no blob caching at all, even for digest-addressed fetches. That's wrong in principle and becomes more wrong after #35 because the pull pipeline's `link_blobs_batch` call would find nothing persisted to link against.
+
+## Design Revisions (applied 2026-04-13)
+
+Five corrections on review of the original plan — the shape below supersedes any conflicting detail in later sections:
+
+1. **`BlobStore::acquire_write` / `acquire_read` are public** and take a `&oci::PinnedIdentifier` (registry + digest already paired), not `(registry, digest)` positional args. `BlobGuard` is `pub`, not `pub(in crate::file_structure)`. Rationale: widely-scoped visibility qualifiers are a code smell; per `quality-rust.md` public vs private is the only valid split.
+2. **`ReferenceManager::link_blobs_batch` is renamed to `link_blobs`** and is the *only* blob-link entry point. Any single-blob use case passes a one-element slice. Old `link_blobs_in_temp` is deleted entirely.
+3. **No `pub(super)` / `pub(in …)` anywhere in this change.** Every new item is either `pub` (crate-module boundary) or private to its own module. If visibility needs a middle tier, the module hierarchy is wrong and gets fixed.
+4. **No public `lock_tags` primitive.** `LocalIndex` owns tag writes atomically via a single private writer. `ocx index update <pkg>` becomes a high-level method on `Index` (or `LocalIndex`) — something like `refresh_tags(identifier, source: &Index) -> Result<()>` — that fetches from source + writes atomically, with no intermediate primitive exposed to callers. The old `update_tags` / `update_manifest` duplication is removed by consolidating into this single entry, not by adding a second one.
+5. **`chain_walk` is deleted.** Chain accumulation becomes a byproduct of `PackageManager::resolve` itself. `resolve` returns a new `ResolvedChain { pinned: PinnedIdentifier, chain: Vec<(String, Digest)>, final_manifest: ImageManifest }` instead of bare `PinnedIdentifier`. The two existing resolve callers (`pull.rs:177`, `find.rs:41`) consume the chain as part of their existing resolve call. The chain is accumulated inside `Index::fetch_candidates` (or `select`) where the tag → image-index → platform-manifest walk already happens. `IndexImpl` trait stays unchanged; only the `Index` wrapper's `select`/`fetch_candidates` return shape is enriched (or a sibling method is added). No separate module, no public `walk_chain` function, no third task module.
+
+All subsequent sections of this plan should be read through these corrections. Where the older text below disagrees, these revisions win.
+
+## Scope
+
+### Fix
+
+Unified ChainedIndex + two-layer responsibility model with chain capture as a byproduct of resolution.
+
+- **Layer 1 — ChainedIndex (automatic write-through):** owns "is the blob on disk?" `walk_chain` is rewritten to explicitly fetch the tag digest and manifest chain from the source, persist both via new low-level LocalIndex primitives, and handle "tag cached / manifest missing" as a concrete state. Each successful `fetch_manifest` call guarantees the returned digest is backed by an on-disk blob. Intra-process `singleflight` dedup (same pattern already used for layer extraction in `pull.rs`) prevents duplicate concurrent fetches.
+- **Layer 2 — ChainWalker (package manager helper):** owns "which blobs did we walk?" New `package_manager/tasks/chain_walk.rs` with `walk_chain` helper that calls `Index::fetch_manifest` twice at most (top-level → platform child) and accumulates `(registry, digest)` pairs into a `ChainWalk` struct. Self-contained traversal logic; the `IndexImpl` trait signature stays unchanged.
+- **Layer 3 — pull / find callers (reachability via `refs/blobs/`):** owns "is the chain held against GC?" Takes the walker's `Vec<(String, Digest)>` and calls `ReferenceManager::link_blobs_batch` — a new method on the existing `ReferenceManager` at `crates/ocx_lib/src/reference_manager.rs` — for an idempotent forward-ref upsert.
+
+Separation rationale. Trace accumulation is not resolution; it's traversal bookkeeping. Keeping it out of `IndexImpl` makes the trait simple, keeps the walker alongside other task helpers, and means ChainedIndex's job is just "answer `fetch_manifest(id)` correctly and persist what you fetched."
+
+Fail-safe. If Layer 1 writes a blob but Layer 3 never runs (crash between walk and link), the blob is orphaned. Once the hardcoded GC skip is removed, the next `ocx clean` collects it. No correctness hazard, just a retry cost on re-install.
+
+### In scope
+
+**Storage primitive (new):**
+- `BlobGuard` in a new file `crates/ocx_lib/src/file_structure/blob_store/blob_guard.rs`, directly modelled on `TagGuard` at `crates/ocx_lib/src/oci/index/local_index/tag_guard.rs`. Shared-for-reads / exclusive-for-writes `fs2` advisory lock on the blob's `data` file itself. No sidecar file. Crash trade: kill-9 mid-write leaves a truncated file; reader sees `Manifest::read_json` parse error; caller treats as cache miss and re-fetches.
+- `BlobStore::acquire_write(registry, digest)` and `acquire_read(registry, digest)` wrappers that construct the CAS path (`self.path(registry, digest).join("data")`), ensure parent dirs exist, and call `BlobGuard::acquire_exclusive` / `acquire_shared`. A successful locked write also writes the sibling `digest` marker file via `file_structure::write_digest_file`.
+
+**Index layer — LocalIndex:**
+- Add primitive `pub(super) persist_manifest_chain(source: &Index, identifier: &Identifier, digest: &Digest)`: fetches the manifest from `source`, locks + writes to the blob store via `BlobGuard`, recurses for `ImageIndex` children (same algorithm as today's `update_manifest` but with locking and explicit recursion). Used only by `ChainedIndex::walk_chain`.
+- Add primitive `pub lock_tags(identifier: &Identifier, fetched: HashMap<String, Digest>)`: exclusive `TagGuard`, read-modify-write merge of `fetched` into the existing on-disk tag map, cache update. Factored out of today's `update_tags:95-112` tail.
+- `get_manifest` at `local_index.rs:176-218` gains `BlobStore::acquire_read` around the manifest read. On parse failure (truncated `data` from kill-9), log warn and return `Ok(None)` — treat as cache miss for graceful recovery.
+- **Delete** `LocalIndex::update` (`:46-52`), `update_tags` (`:61-113`), `update_manifest` (`:115-142`). Their responsibilities move to ChainedIndex (orchestration + walk-chain logic) and `ocx index update` CLI (tag locking). The latent bug at `:77-85` vanishes because the rewrite has no "skip manifest if seed matches" short-circuit — the tag and manifest paths are independent.
+
+**Index layer — ChainedIndex:**
+- Rewrite `walk_chain` at `chained_index.rs:44-78` to own the full orchestration:
+  1. Short-circuit digest-only identifiers (unchanged).
+  2. Normalise to `tagged = identifier.clone_with_tag(identifier.tag_or_latest())`.
+  3. For each source in `self.sources`: fetch the manifest digest; if not present in the cache's blob store OR the cache's tag file, call `cache.persist_manifest_chain(source, &tagged, &digest)` then `cache.lock_tags(&tagged, {tag: digest})`. On first successful source, return. On all-sources-fail, propagate the last error.
+  4. Wrap the per-identifier work in `utility::singleflight` keyed by `(registry_slug, resolved_identifier_string)` so two concurrent tasks in one process share the result.
+- Add `mode: ChainMode` field (new enum, see below). `list_repositories`, `list_tags`, and `fetch_manifest_digest`-on-tag check the mode before consulting the cache; `Default` and `Offline` behave as today, `Remote` skips the cache read for mutable lookups and falls straight through to the source path.
+- `fetch_manifest` and `fetch_manifest_digest` on digest-addressed identifiers ignore the mode (always cache-first with write-through), because digest-addressed content is immutable by construction and the cache can never be wrong about it.
+
+**Index layer — public `Index` wrapper and context wiring:**
+- New `ChainMode` enum in `crates/ocx_lib/src/oci/index.rs` (or a sibling file), `#[non_exhaustive]`:
+  ```rust
+  pub enum ChainMode { Default, Remote, Offline }
+  ```
+- `Index::from_chained` gains a `mode: ChainMode` parameter. `Index::from_cached_remote` becomes sugar for `from_chained(local, vec![from_remote(remote)], ChainMode::Default)`.
+- **Delete** `Index::from_local`. Only used in one place (`context.rs:74` for the `--offline` branch) — replaced by `from_chained(local, vec![], ChainMode::Offline)`.
+- **Keep** `Index::from_remote`. Still the right primitive for constructing a single remote source wrapper; used by `ocx index update` CLI (the narrowed version) to pass a source into `lock_tags`.
+- `Context::try_init` at `crates/ocx_cli/src/app/context.rs:65-75` collapses to one `Index::from_chained(...)` call site where the mode is derived from `options.offline` and `options.remote`. The three-branch `if/else if/else` at 65-75 is replaced with a single `ChainMode` match and one constructor call. The `remote_index: Option<RemoteIndex>` field and its accessors stay — `ocx index update` still uses them directly.
+
+**CLI layer — `ocx index update`:**
+- `crates/ocx_cli/src/command/index_update.rs:18-40` currently calls `context.local_index().update(&remote_index, &identifier)`. Rewrite to: for each tag the user requested, `remote_index.fetch_manifest_digest(&tagged)`, accumulate into a `HashMap<String, Digest>`, then call `local_index.lock_tags(&identifier, fetched)`. No manifest walk. No `blobs/` writes.
+- Preserve the tagged-vs-bare semantics documented at `subsystem-cli-commands.md:136`: tagged identifier = that tag's digest only, bare identifier = all tags via `remote_index.list_tags`.
+
+**Package-manager layer — new `chain_walk` helper:**
+- New file `crates/ocx_lib/src/package_manager/tasks/chain_walk.rs` with `pub(super) struct ChainWalk` and `pub(super) async fn walk_chain(index: &Index, identifier: &Identifier, platform: &Platform) -> Result<ChainWalk, PackageErrorKind>`. See the type sketch below.
+- Walker behaviour: fetch the identifier → push `(registry, top_digest)` to the chain. If top manifest is `Manifest::Image`, done. If `Manifest::ImageIndex`, select the platform child via the existing `fetch_candidates` / `select` machinery (or inline the manifest-descriptor filter), fetch the child, push `(registry, child_digest)`. Return `ChainWalk { chain, final_digest, final_manifest: ImageManifest }`. Reject nested image indexes with a clear error.
+
+**Reference manager — new `link_blobs_batch`:**
+- Add method to `ReferenceManager` at `crates/ocx_lib/src/reference_manager.rs`: `pub fn link_blobs_batch(&self, content_path: &Path, chain: &[(String, oci::Digest)]) -> Result<()>`. Implementation: for each `(registry, digest)`, compute `target = self.file_structure.blobs.data(registry, digest)` and `ref_name = cas_ref_name(digest)`, construct `link_path = self.file_structure.packages.refs_blobs_dir_for_content(content_path)? .join(ref_name)`. Read any existing symlink at `link_path` — if present and matches `target`, no-op; else `symlink::update`. On `EEXIST` from a racing peer, re-read and verify target matches; if yes, treat as success; if no (impossible by construction because ref_name is digest-derived), propagate the error.
+- `link_blobs_in_temp` at `pull.rs:762-774` is deleted. Its one caller at `pull.rs:354` becomes a call to `ReferenceManager::link_blobs_batch`.
+
+**Pull pipeline:**
+- Delete `cache_manifest_blob` at `pull.rs:488-512`. Its single caller at `pull.rs:293` becomes a call to `walk_chain`, whose result is passed to `link_blobs_batch` at the `pull.rs:354` site. The pull flow now: resolve → `walk_chain` (which goes through ChainedIndex which auto-persists) → use `walk.final_manifest` for layer extraction → `link_blobs_batch(&pkg.content(), &walk.chain)` → rename temp to packages.
+- Subtle: `cache_manifest_blob` today writes the final-manifest blob AND its `digest` marker file as a side effect of pull — but this work is now done inside ChainedIndex during `walk_chain`. No pull-side persistence remains.
+
+**Find family (`find`, `find_symlink`, `find_or_install`):**
+- On every successful resolve of an already-installed package, call `walk_chain(...)` → `ReferenceManager::link_blobs_batch(&package.content(), &walk.chain)`. This covers the "different chain" case where a package was installed via one tag and is later resolved via another. `link_blobs_batch` is idempotent; if the chain is already current, zero symlinks are written.
+
+**GC:**
+- Delete the `tier != CasTier::Blob` filter at `garbage_collection.rs:48`. Rename / rewrite the test `unreachable_blobs_skipped_by_clean` at `:200` to `unreachable_blob_is_collected` asserting the positive.
+
+**Docs:**
+- `website/src/docs/user-guide.md` — index section, `--remote` semantics.
+- `website/src/docs/reference/command-line.md` — `--remote` entry.
+- `website/src/docs/reference/environment.md` — `OCX_REMOTE` entry.
+- `website/src/docs/getting-started.md` — any `--remote` usage examples still work (semantic narrowing is user-invisible for installs; only the "no cache touched" claim goes away).
+- `.claude/rules/subsystem-oci.md` — LocalIndex primitives (`persist_manifest_chain`, `lock_tags`); `ChainMode`; `walk_chain` orchestration.
+- `.claude/rules/subsystem-file-structure.md` — `BlobGuard` in the module map; GC Safety section (blobs are first-class BFS entries).
+- `.claude/rules/subsystem-package-manager.md` — new `chain_walk` task helper.
+- `.claude/rules/arch-principles.md` Utility Catalog — add `BlobGuard` row next to the existing `FileLock` entry.
+- `CHANGELOG.md` — two breaking-change lines for `--remote` and `ocx index update`.
+
+### Out of scope
+
+- Policy-based retention (TTL / size-cap / pinning) — #50.
+- OCI referrers (signatures, SBOMs) — separate lifecycle, not required for re-resolve.
+- Byte-exact manifest persistence. Today's `manifest.write_json` re-serialises a parsed `Manifest`, which is not byte-identical to the registry response — digest verification on read would fail if it were ever added. Pre-existing gap. Future tracking item if byte-exact persistence becomes a hard requirement.
+- Proactive migration of existing installed packages' refs. New installs get full chains immediately; existing installs top up on the first `find` against them. Users who want to force the migration can `ocx find <pkg>` each installed package after upgrade.
+- `ocx prefetch` command — deferred to whenever an explicit pre-fetch need emerges.
+
+## Acceptance Criteria
+
+1. After `ocx install <pkg>`, the package's `refs/blobs/` contains a forward-ref for every OCI blob the resolver read (image index + platform manifest at minimum).
+2. After `ocx find <pkg>` via a tag path that walks blobs not yet linked to the existing package, those blobs are appended to `refs/blobs/` — no duplicate entries, no changed targets, idempotent on re-run.
+3. `ocx clean` does not delete any blob reachable via any installed package's `refs/blobs/`.
+4. `ocx clean` does delete blobs not reachable from any installed package (e.g., orphans left by a crashed install, or the old chain after `uninstall --purge`).
+5. Offline re-resolve of an installed package succeeds for any tag path the package has ever been resolved via.
+6. The hardcoded `tier != CasTier::Blob` exemption at `garbage_collection.rs:48` is removed.
+7. `ocx index update <pkg>` writes only to `$OCX_HOME/tags/`, never to `$OCX_HOME/blobs/`. Verified by walking `blobs/` before and after and asserting it is unchanged.
+8. `ocx --remote install <pkg>` persists the resolution chain into `blobs/` and links it into `refs/blobs/`. `--remote` no longer disables the cache write-through.
+9. `ocx --remote index list <pkg>` still refreshes tag data from the source on every invocation.
+10. `ocx --offline install <pkg>` after a bare `ocx index update <pkg>` fails with a clear error naming the missing manifest digest.
+11. Two concurrent `ocx install` processes against the same `$OCX_HOME` both complete successfully, neither corrupts blob files, both produce full `refs/blobs/`.
+12. After any successful install, no sidecar `.lock`, `.log`, or `.tmp` files remain anywhere under `$OCX_HOME/blobs/`.
+13. The `update_tags` latent bug is fixed: deleting a manifest `data` file from `blobs/` (leaving the tag file in place) and then running `ocx install <pkg>` re-fetches the manifest and completes successfully (not infinite-loop or `NotFound`).
+
+## Architecture
+
+> **SUPERSEDED** — see [Design Revisions](#design-revisions-applied-2026-04-13). The three-layer model collapses to two (ChainedIndex + callers); `chain_walk` is deleted and chain accumulation is a byproduct of `PackageManager::resolve`. The sketches below are retained for historical context but are no longer the build target.
+
+### Three-layer responsibility model
+
+```
+┌──────── Layer 3: callers (pull / find / find_symlink / find_or_install) ────────┐
+│                                                                                 │
+│  let walk = chain_walk::walk_chain(index, id, platform).await?;                 │
+│  reference_manager.link_blobs_batch(&package.content(), &walk.chain)?;          │
+│  // use walk.final_digest / walk.final_manifest for downstream pull work        │
+│                                                                                 │
+└───────────────────────────────────▲─────────────────────────────────────────────┘
+                                    │ ChainWalk { chain, final_digest, final_manifest }
+┌───────────────────────────────────┴─────────────────────────────────────────────┐
+│       Layer 2: ChainWalker — package_manager/tasks/chain_walk.rs (new)          │
+│                                                                                 │
+│  walk_chain(index, id, platform):                                               │
+│    let (top_d, top_m) = index.fetch_manifest(id).await?;                        │
+│    chain.push((id.registry(), top_d.clone()));                                  │
+│    match top_m {                                                                │
+│      Manifest::Image(img) => return (chain, top_d, img),                        │
+│      Manifest::ImageIndex(idx) => {                                             │
+│        let child_id = id.clone_with_digest(select_platform(&idx, platform)?);  │
+│        let (child_d, child_m) = index.fetch_manifest(&child_id).await?;         │
+│        chain.push((child_id.registry(), child_d.clone()));                      │
+│        return (chain, child_d, child_m.into_image_manifest()?);                 │
+│      }                                                                          │
+│    }                                                                            │
+│                                                                                 │
+└───────────────────────────────────▲─────────────────────────────────────────────┘
+                                    │ Index::fetch_manifest — trait unchanged
+┌───────────────────────────────────┴─────────────────────────────────────────────┐
+│             Layer 1: ChainedIndex — automatic write-through                     │
+│                                                                                 │
+│  fetch_manifest(id):                                                            │
+│    if let Some(hit) = self.cache.fetch_manifest(id).await? { return Ok(hit); }  │
+│    if self.mode == ChainMode::Offline { return Ok(None); }                      │
+│    singleflight.run((registry, id_key), async {                                 │
+│      for source in &self.sources {                                              │
+│        let Some(digest) = source.fetch_manifest_digest(&tagged).await? else { continue; };│
+│        self.cache.persist_manifest_chain(source, &tagged, &digest).await?;     │
+│        self.cache.lock_tags(&tagged, {tag → digest}).await?;                    │
+│        return Ok(());                                                           │
+│      }                                                                          │
+│      Err(last_error_from_sources)                                              │
+│    }).await?;                                                                   │
+│    self.cache.fetch_manifest(id).await                                          │
+│                                                                                 │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Key invariants:
+
+1. **`IndexImpl::fetch_manifest` is self-contained.** Same signature, no trace. Resolving an identifier returns `Result<Option<(Digest, Manifest)>>`, nothing more.
+2. **Every digest in a `ChainWalk` is guaranteed on disk.** Every `fetch_manifest` call the walker makes goes through ChainedIndex, which either found the blob in cache or persisted it via `persist_manifest_chain` before returning.
+3. **`link_blobs_batch` never creates dangling symlinks.** Its input is a `ChainWalk::chain` whose entries are all backed by real `blobs/.../data` files at call time.
+
+### `ChainMode`
+
+```rust
+// crates/ocx_lib/src/oci/index.rs
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ChainMode {
+    /// Cache-first for all lookups. Write-through on cache-miss source fetches.
+    /// Used for default (no flag) online operation.
+    Default,
+    /// Mutable lookups (tags, catalog) bypass cache and go straight to source.
+    /// Digest-addressed (immutable) lookups still use cache + write-through.
+    /// Used for --remote.
+    Remote,
+    /// Cache only. Source list is empty or consulted never. Cache misses
+    /// return `None` from `fetch_manifest`. Used for --offline.
+    Offline,
+}
+```
+
+### `BlobGuard` — mirror of `TagGuard`
+
+New file `crates/ocx_lib/src/file_structure/blob_store/blob_guard.rs`:
+
+```rust
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+
+use crate::file_lock::FileLock;
+use crate::{Result, error::file_error, prelude::*};
+
+const LOCK_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Per-blob reader/writer guard over a content-addressed `data` file.
+///
+/// Holds an `fs2` advisory lock — shared for reads, exclusive for writes —
+/// directly on the `data` file itself. No sidecar `.lock`, no temp sibling,
+/// no atomic rename: writers lock the file and update it in place
+/// (truncate + write + `sync_all`).
+///
+/// Modelled exactly on `TagGuard`. Crash trade: kill-9 mid-write can leave
+/// the `data` file truncated; the next `Manifest::read_json` attempt will
+/// fail to parse, `LocalIndex::get_manifest` logs at warn and returns
+/// `None`, and `ChainedIndex::walk_chain` re-fetches the blob via
+/// `persist_manifest_chain`. Safe because blob content is immutable by
+/// digest — any re-fetch produces identical bytes.
+pub(in crate::file_structure) struct BlobGuard {
+    _lock: FileLock,
+    target_path: PathBuf,
+}
+
+impl BlobGuard {
+    pub async fn acquire_exclusive(target_path: PathBuf) -> Result<Self> { /* spawn_blocking open + fs2 exclusive, 60s timeout */ }
+    pub async fn acquire_shared(target_path: PathBuf) -> Result<Option<Self>> { /* None if file missing */ }
+    pub async fn write_bytes(&self, bytes: &[u8]) -> Result<()> { /* truncate(true) + write_all + sync_all */ }
+    pub async fn read_bytes(&self) -> Result<Vec<u8>> { /* read_to_end */ }
+}
+```
+
+Exposed from `BlobStore` via wrapper methods:
+
+```rust
+impl BlobStore {
+    /// Acquire an exclusive lock on the blob `data` file for the given
+    /// registry + digest, creating parent directories. Writers must hold
+    /// this guard while calling `write_bytes`.
+    pub async fn acquire_write(&self, registry: &str, digest: &oci::Digest) -> Result<BlobGuard> { /* ... */ }
+
+    /// Acquire a shared lock on the blob `data` file. Returns `None` if
+    /// the file does not exist.
+    pub async fn acquire_read(&self, registry: &str, digest: &oci::Digest) -> Result<Option<BlobGuard>> { /* ... */ }
+}
+```
+
+**SUPERSEDED** — `BlobGuard` is `pub` and re-exported from `file_structure` (see revision §1). `BlobStore::acquire_write` / `acquire_read` take `&PinnedIdentifier` (not `(registry, digest)`) and are `pub`.
+
+### ~~`ChainWalk` and the walker~~ (SUPERSEDED — see revision §5)
+
+The block below is historical. `chain_walk` is deleted; `PackageManager::resolve` returns a `ResolvedChain { pinned, chain, final_manifest }` that subsumes the walker.
+
+### `ChainWalk` and the walker (historical)
+
+```rust
+// crates/ocx_lib/src/package_manager/tasks/chain_walk.rs
+use crate::oci;
+use super::super::error::PackageErrorKind;
+
+pub(super) struct ChainWalk {
+    /// (registry, digest) pairs in walk order. First entry is the top-level
+    /// manifest (image or image index); for image indexes, the second entry
+    /// is the platform-selected child manifest. Every entry is backed by a
+    /// real blob file at `file_structure.blobs.data(registry, digest)` on
+    /// disk at the moment this struct is returned.
+    pub chain: Vec<(String, oci::Digest)>,
+    pub final_digest: oci::Digest,
+    pub final_manifest: oci::ImageManifest,
+}
+
+pub(super) async fn walk_chain(
+    index: &oci::index::Index,
+    identifier: &oci::Identifier,
+    platform: &oci::Platform,
+) -> Result<ChainWalk, PackageErrorKind>;
+```
+
+Visibility: `pub(super)` — visible to sibling task modules under `package_manager/tasks/`, not exposed publicly.
+
+### ~~New `LocalIndex` primitives~~ (SUPERSEDED — see revision §4)
+
+After revision §4, `LocalIndex` exposes a single high-level primitive:
+
+```rust
+impl LocalIndex {
+    /// Atomic tag refresh: fetches from `source` and writes under the
+    /// existing `TagGuard` in one call. No intermediate `persist_manifest_chain`
+    /// or `lock_tags` surface is exposed.
+    pub async fn refresh_tags(
+        &self,
+        identifier: &oci::Identifier,
+        source: &super::Index,
+    ) -> Result<()>;
+}
+```
+
+Manifest persistence during a `ChainedIndex::fetch_manifest` cache miss
+becomes a private detail of the chained index; no separate public API.
+
+### New `LocalIndex` primitives (historical)
+
+```rust
+impl LocalIndex {
+    /// Fetches the manifest for `identifier` from `source` and persists it
+    /// (and, for image indexes, every child manifest) into the blob store
+    /// under per-file `BlobGuard` exclusive locks.
+    ///
+    /// Callers must pre-resolve `digest` via `source.fetch_manifest_digest`
+    /// so this method does not double-dispatch the manifest lookup.
+    ///
+    /// Caller contract: on `Ok(())`, every digest in the persisted chain
+    /// has a readable `data` file at the expected CAS-sharded path.
+    pub(super) async fn persist_manifest_chain(
+        &self,
+        source: &super::Index,
+        identifier: &oci::Identifier,
+        digest: &oci::Digest,
+    ) -> Result<()>;
+
+    /// Merges `fetched` into the on-disk tag file under an exclusive
+    /// `TagGuard`. Preserves existing disk entries not present in
+    /// `fetched`. Updates the in-memory cache to reflect the merged state.
+    ///
+    /// This is the only public tag write path after the refactor. Used by
+    /// `ChainedIndex::walk_chain` (single-tag writes) and by the `ocx
+    /// index update` CLI command (batched writes).
+    pub async fn lock_tags(
+        &self,
+        identifier: &oci::Identifier,
+        fetched: std::collections::HashMap<String, oci::Digest>,
+    ) -> Result<()>;
+}
+```
+
+### `ReferenceManager::link_blobs` (renamed — see revision §2)
+
+```rust
+impl ReferenceManager {
+    /// Idempotently upserts a `refs/blobs/` forward-ref for every entry in
+    /// `chain`. The link name is derived from the digest via `cas_ref_name`
+    /// so concurrent peers producing the same chain produce identical
+    /// symlinks — races resolve to the correct state.
+    ///
+    /// Caller contract: every `(registry, digest)` in `chain` must already
+    /// be backed by an on-disk `blobs/{registry}/.../data` file. Violation
+    /// produces `Error::InternalFile` at link time.
+    pub fn link_blobs(
+        &self,
+        content_path: &std::path::Path,
+        chain: &[(String, oci::Digest)],
+    ) -> Result<()>;
+}
+```
+
+### Concurrency safety — four hazards
+
+**H1 — intra-process duplicate fetches.** Two async tasks in one process both want the same manifest on cache miss. Mitigation: ChainedIndex wraps the source-walk branch in `utility::singleflight` (see `arch-principles.md` Utility Catalog) keyed by `(registry_slug, resolved_id_string)`. Same pattern already used for layer extraction in `pull.rs:590-611` and for dependency setup. First task fetches + persists; peers wait on the watch channel and re-read from cache.
+
+**H2 — inter-process blob writes.** Two `ocx` invocations writing the same blob concurrently. Mitigation: `BlobGuard` exclusive `fs2` lock on the `data` file itself — directly modelled on `TagGuard`. Crash trade documented above. No sidecar file.
+
+**H3 — inter-process `refs/blobs/` upsert races.** Two finds upserting refs on the same installed package concurrently. Mitigation: `link_blobs` is idempotent per entry (read existing symlink, compare target, no-op if correct). On `EEXIST` from a racing peer on `symlink::create`, re-read and verify the target matches; if yes, treat as success. Targets are deterministic from the digest-derived `cas_ref_name`, so "same digest, different target" is structurally impossible.
+
+**H4 — `ocx clean` concurrent with install / find.** Out of scope. Inherits the existing convention from `garbage_collection.rs:94`: *"No guard against concurrent installs. Do not run `clean` while other OCX operations are in progress."* Documented in the user guide under `ocx clean`.
+
+**No-sidecar policy.** `BlobGuard` locks the target `data` file directly. `TagGuard` locks the target tag file directly. `TempStore` has a sibling `.lock` only because it needs atomic `temp/ → packages/` rename (which would rotate the inode); that sidecar is auto-deleted on `Drop`. Any future lock location must follow one of these two patterns — direct-lock or auto-cleaned-sibling — never a dangling sidecar. Enforced structurally by acceptance test AC12.
+
+### Integration points
+
+| Site | File:line (merged main) | Change |
+|---|---|---|
+| New primitive | `crates/ocx_lib/src/file_structure/blob_store/blob_guard.rs` (new) | Create `BlobGuard`, modelled on `tag_guard.rs` |
+| BlobStore wrappers | `crates/ocx_lib/src/file_structure/blob_store.rs` | Add `acquire_write` / `acquire_read`; write sibling `digest` file after successful `write_bytes` |
+| New type | `crates/ocx_lib/src/oci/index.rs` (or sibling) | `ChainMode` enum |
+| `Index` wrapper | `crates/ocx_lib/src/oci/index.rs:41-77` | Add `mode` parameter to `from_chained` / `from_cached_remote`; delete `from_local` (line 48-52). Keep `from_remote` (used by `index update` CLI) |
+| `LocalIndex` primitive | `crates/ocx_lib/src/oci/index/local_index.rs` | Add single `refresh_tags(identifier, source)` entry point (revision §4). `get_manifest:176-218` gains `BlobStore::acquire_read` + graceful parse-failure recovery |
+| `LocalIndex` deletions | `crates/ocx_lib/src/oci/index/local_index.rs:46-52, 61-113, 115-142` | Delete `update`, `update_tags`, `update_manifest` |
+| `ChainedIndex` | `crates/ocx_lib/src/oci/index/chained_index.rs:22-79` | Add `mode: ChainMode` field; rewrite `fetch_manifest`'s cache-miss path to persist fetched manifest + children via `BlobStore::acquire_write` and call `cache.refresh_tags` atomically; wrap per-identifier work in `singleflight` |
+| `ChainedIndex` modes | `crates/ocx_lib/src/oci/index/chained_index.rs:82-130` | `list_repositories`, `list_tags`, `fetch_manifest_digest`-on-tag check `self.mode`; `Remote` skips cache read for mutable lookups; `Offline` short-circuits source walk |
+| `Context::try_init` | `crates/ocx_cli/src/app/context.rs:65-75` | Collapse three-branch `if/else if/else` into one `ChainMode` match + one `Index::from_chained(...)` call |
+| `CLI ocx index update` | `crates/ocx_cli/src/command/index_update.rs:18-40` | Rewrite to call `local_index.refresh_tags(&identifier, remote_wrapped_as_index)` — single atomic call, no manifest walk (revision §4) |
+| Resolve return shape | `crates/ocx_lib/src/package_manager/tasks/resolve.rs` | `PackageManager::resolve` returns `ResolvedChain { pinned, chain, final_manifest }` (revision §5); chain accumulation is a byproduct of the existing `select` path, no separate `chain_walk` module |
+| New ref method | `crates/ocx_lib/src/reference_manager.rs` | Add `link_blobs` method — idempotent upsert via `symlink::update`, `EEXIST` tolerated (revision §2) |
+| Pull pipeline | `crates/ocx_lib/src/package_manager/tasks/pull.rs:293, 354, 488-512, 762-774` | Replace `cache_manifest_blob` + `link_blobs_in_temp` with `ReferenceManager::link_blobs` over `ResolvedChain::chain`. Delete the two free functions |
+| Find | `crates/ocx_lib/src/package_manager/tasks/find.rs` | After successful resolve of an already-installed package, `ReferenceManager::link_blobs` over `ResolvedChain::chain` against the existing package's `content/` |
+| Find-symlink | `crates/ocx_lib/src/package_manager/tasks/find_symlink.rs` | Same |
+| Find-or-install | `crates/ocx_lib/src/package_manager/tasks/find_or_install.rs` | On the already-installed branch: `ReferenceManager::link_blobs` over `ResolvedChain::chain`. On the install branch: pull pipeline already covers it |
+| GC skip removal | `crates/ocx_lib/src/package_manager/tasks/garbage_collection.rs:48` | Delete `**tier != CasTier::Blob &&` from the filter |
+| GC test inversion | `crates/ocx_lib/src/package_manager/tasks/garbage_collection.rs:200-204` | `unreachable_blobs_skipped_by_clean` → `unreachable_blob_is_collected`, assert positive |
+| Subsystem rule | `.claude/rules/subsystem-oci.md` | Document `refresh_tags`, `ChainMode`, `singleflight` in `ChainedIndex::fetch_manifest` cache-miss path (revision §4) |
+| Subsystem rule | `.claude/rules/subsystem-file-structure.md` | `BlobGuard` (pub) in module map; GC Safety section updated |
+| Subsystem rule | `.claude/rules/subsystem-package-manager.md` | `PackageManager::resolve` returns `ResolvedChain` (revision §5) — no `chain_walk` module |
+| Arch rule | `.claude/rules/arch-principles.md` Utility Catalog | Row for `BlobGuard` alongside `FileLock` |
+| User docs | `website/src/docs/user-guide.md`, `reference/command-line.md`, `reference/environment.md`, `getting-started.md` | `--remote` semantic change, `ocx index update` narrowing, offline install requirement |
+| CHANGELOG | `CHANGELOG.md` | Two breaking-change entries |
+
+### Error / edge cases
+
+| Condition | Behaviour |
+|---|---|
+| `walk_chain` input has nested image index (image index pointing at another image index) | Return `PackageErrorKind::Internal` with a clear error — not a supported OCI shape, rejected early |
+| `walk_chain` input is digest-only, identifier points at an `ImageIndex` | Fetch the index, `select_platform` picks a child, fetch the child. Same code path as tag-based, because `Index::fetch_manifest` returns the manifest for whatever identifier you pass |
+| `persist_manifest_chain` succeeds for parent index but fails for a child | Parent blob is persisted but child blob is not; `walk_chain` re-tries on next invocation. Parent blob is orphaned until the retry or until `ocx clean` collects it. Acceptable retry cost |
+| `BlobGuard::acquire_exclusive` times out (60 s) | Returns `Error::InternalFile(path, TimedOut)`. Surface to user with a clear message — another process is holding the lock |
+| `get_manifest` parse failure on truncated `data` file (post-kill-9) | Log warn, return `Ok(None)`. `ChainedIndex` sees cache miss, falls through to `walk_chain` which re-fetches |
+| `link_blobs_batch` encounters a chain entry whose blob file is missing | Returns `Error::InternalFile(missing_path, NotFound)`. Violates the walker's invariant — hard error |
+| `ocx index update` in `--offline` mode | Error at CLI entry (today's behaviour — `remote_index()` returns `Err(OfflineMode)`). Unchanged |
+| Concurrent `ocx install foo` + `ocx install bar` sharing an image index blob | Both go through ChainedIndex; `singleflight` deduplicates the fetch if identifiers happen to collide, otherwise `BlobGuard` serialises the file write. Either way final state is correct |
+
+## User Experience Scenarios
+
+### UX1 — Fresh install captures full chain
+
+```
+$ ocx install cmake:3.28
+# ChainedIndex walks tag → image index (sha256:idx) → platform manifest (sha256:M).
+# Both blobs are persisted to ~/.ocx/blobs/ocx.sh/... and linked into
+# the package's refs/blobs/.
+
+$ ls ~/.ocx/packages/ocx.sh/sha256/.../refs/blobs/
+<cas_ref_name(idx)>
+<cas_ref_name(M)>
+```
+
+### UX2 — `find` via different tag appends refs
+
+```
+$ ocx install cmake:latest      # chain {idxA, M}
+$ ocx find cmake:3.28           # walks {idxB, M} — same M, different image index
+# refs/blobs/ now contains {idxA, idxB, M}. No dup M. idxB appended idempotently.
+```
+
+### UX3 — `--remote` forces tag lookup but still caches blobs
+
+```
+$ ocx install cmake:3.28           # cache miss on tag → walk_chain → persist + link
+$ ocx --remote install cmake:3.28  # forces remote tag re-fetch; digest matches cached M;
+                                   # blob cache hit; zero blob download
+$ ocx --remote install cmake:latest
+                                   # remote tag lookup returns new digest; walk_chain
+                                   # persists the new chain + links refs/blobs/
+```
+
+### UX4 — `ocx index update` writes only tags
+
+```
+$ ocx index update cmake
+# Writes ~/.ocx/tags/ocx.sh/cmake.json with the latest tag→digest map.
+# Writes NOTHING under ~/.ocx/blobs/.
+
+$ ocx --offline install cmake:3.28
+Error: manifest sha256:M not in local cache. Run `ocx install cmake:3.28` online to populate the blob cache.
+```
+
+### UX5 — Orphan cleanup after failed install
+
+```
+$ ocx install cmake:3.28        # network fails mid-chain; image index blob is persisted
+                                # but install aborts before link_blobs_batch runs
+$ ocx clean
+Removed 1 unreferenced blob.
+$ ocx install cmake:3.28        # retry re-downloads the chain, succeeds
+```
+
+### UX6 — Offline re-resolve survives clean
+
+```
+$ ocx install cmake:3.28        # full chain persisted + linked
+$ ocx --offline find cmake:3.28 # succeeds, reads from cache
+$ ocx clean                     # zero collections; everything reachable via refs/blobs/
+$ ocx --offline find cmake:3.28 # still succeeds
+```
+
+### UX7 — Latent-bug fix: missing manifest after tag lock
+
+```
+$ ocx index update cmake        # locks cmake:3.28 → sha256:M in tags/
+$ rm -rf ~/.ocx/blobs/          # user nukes the blob store (or GC collected it)
+$ ocx install cmake:3.28        # tag file says M, manifest missing — walk_chain
+                                # re-fetches via source, persists, installs successfully
+```
+
+## Testing Strategy
+
+### Unit tests — `file_structure/blob_store/blob_guard.rs` (new)
+
+Mirror `tag_guard.rs` tests line-for-line structurally:
+
+1. `acquire_exclusive_creates_blob_file_and_parent_dirs`
+2. `acquire_shared_on_missing_file_returns_none`
+3. `acquire_shared_returns_some_when_present`
+4. `shared_locks_can_coexist`
+5. `shared_blocks_behind_exclusive`
+6. `second_exclusive_blocks_behind_first`
+7. `write_bytes_truncates_and_syncs`
+8. `read_bytes_round_trips_written_content`
+9. `no_sidecar_lock_file_created_after_acquire_write_drop`
+10. `kill_9_simulation_leaves_file_readable_but_manifest_parse_fails` (writes partial JSON, asserts `Manifest::read_json` errors)
+
+### Unit tests — `file_structure/blob_store.rs` (revision §1 — `&PinnedIdentifier` API)
+
+11. `acquire_write_writes_sibling_digest_marker_file` (via `BlobStore::acquire_write(&pinned)`)
+12. `acquire_write_then_acquire_read_returns_bytes`
+13. `concurrent_acquire_write_on_same_digest_serialises` (8 tasks race; final file is correct)
+
+### Unit tests — `oci/index/local_index.rs` (revision §4 — retargeted at `refresh_tags` + ChainedIndex write-through)
+
+14. `refresh_tags_merges_new_tags_with_existing_disk_entries`
+15. `refresh_tags_preserves_tags_not_in_source`
+16. `refresh_tags_concurrent_callers_both_visible_on_disk`
+17. `chained_fetch_manifest_persists_image_blob_at_expected_cas_path`
+18. `chained_fetch_manifest_recurses_for_image_index_children`
+19. `chained_fetch_manifest_writes_sibling_digest_marker_for_every_blob`
+20. `get_manifest_on_truncated_blob_file_returns_none_and_logs_warn`
+21. `latent_bug_fix_missing_manifest_triggers_refetch_via_chain` — integration-style: seed a tag file with a digest whose blob is absent; `fetch_manifest` via ChainedIndex must re-fetch and return `Some`
+
+### Unit tests — `oci/index/chained_index.rs`
+
+22. `default_mode_cache_hit_returns_without_touching_sources`
+23. `default_mode_cache_miss_walks_source_and_persists_chain_on_disk` — property: after call, `blob_store.data(registry, digest)` file exists for every chain entry
+24. `remote_mode_bypasses_cache_for_tag_lookup_but_still_persists_blobs`
+25. `remote_mode_digest_addressed_lookup_uses_cache`
+26. `offline_mode_cache_miss_returns_none_without_consulting_sources`
+27. `offline_mode_cache_hit_returns_from_disk`
+28. `singleflight_dedups_concurrent_identical_cache_miss_fetches` — 4 concurrent tasks on same identifier; exactly 1 source fetch recorded by test transport
+29. `singleflight_broadcasts_source_error_to_waiters`
+30. `list_tags_respects_chain_mode` — Default uses cache; Remote hits source and persists; Offline is cache-only
+31. `list_repositories_respects_chain_mode`
+32. `fetch_manifest_post_persist_is_guaranteed_on_disk` — property-style: for any mode, after a successful `fetch_manifest(id)` returning `Some((digest, _))`, `blob_store.data(registry, digest)` exists
+
+### Unit tests — `package_manager/tasks/resolve.rs` (revision §5 — replaces deleted `chain_walk.rs`)
+
+33. `resolve_single_image_returns_one_chain_entry`
+34. `resolve_image_index_returns_two_chain_entries`
+35. `resolve_rejects_nested_image_index`
+36. `resolve_result_every_entry_has_on_disk_blob_file` — property guarantee
+
+(Note: revised from the 6 chain_walk tests to 4 resolve tests. The
+"unsupported platform" and "fetch_manifest not found" cases are covered by
+the existing `select` path and its pre-existing tests — nothing new to
+assert at the revised `resolve` boundary.)
+
+### Unit tests — `reference_manager.rs` (revision §2 — renamed `link_blobs_batch` → `link_blobs`)
+
+37. `link_blobs_creates_symlinks_for_all_chain_entries`
+38. `link_blobs_idempotent_on_existing_correct_symlinks`
+39. `link_blobs_tolerates_eexist_when_target_matches`
+40. `link_blobs_updates_stale_symlink_target` (impossible by construction but test the recovery path)
+41. `link_blobs_missing_blob_file_returns_error`
+
+### Unit tests — `package_manager/tasks/garbage_collection.rs`
+
+44. `unreachable_blob_is_collected` (replaces `unreachable_blobs_skipped_by_clean`)
+45. `reachable_blob_via_refs_blobs_survives_gc`
+46. `purge_cascades_through_intermediate_chain_blobs` (existing `purge_cascades_through_blobs` at `:302` generalised to full chain)
+
+### Acceptance tests — `test/tests/test_resolution_chain_refs.py` (new)
+
+47. `test_install_creates_full_chain_refs` — AC1
+48. `test_find_via_different_tag_appends_refs` — AC2
+49. `test_clean_retains_reachable_blobs` — AC3
+50. `test_clean_collects_orphaned_chain_after_uninstall_purge` — AC4
+51. `test_offline_reresolve_survives_clean_after_full_chain_capture` — AC5
+52. `test_index_update_writes_only_tag_files_not_blobs` — AC7 (walks `blobs/` before and after)
+53. `test_remote_flag_install_persists_and_links_chain` — AC8
+54. `test_remote_flag_index_list_refreshes_tags_from_source` — AC9
+55. `test_offline_install_after_bare_index_update_fails_cleanly` — AC10
+56. `test_failed_install_leaves_collectable_orphans` — UX5
+57. `test_parallel_install_races_preserve_full_chain` — AC11, two real `ocx install` subprocesses against one `$OCX_HOME`
+58. `test_no_sidecar_lock_files_in_blobs_dir_after_install` — AC12, walks `$OCX_HOME/blobs/` and asserts no `.lock`, `.log`, `.tmp` files
+59. `test_missing_manifest_after_index_update_recovers_on_install` — AC13, UX7, the latent-bug fix
+60. `test_find_read_only_against_matching_chain_makes_no_writes` — fast-path proof
+
+## Executable Phases
+
+### Phase A — Prerequisite
+
+PR #45 is merged (commits 89b0b90 / 5569658 / 68f341c). `ChainedIndex`, `TagGuard`, and `Index::from_chained` / `from_cached_remote` already exist on `main`. This plan rewrites and extends them.
+
+### Phase B — Stub
+
+B.1 Create `file_structure/blob_store/blob_guard.rs` with `BlobGuard` struct + method stubs.
+B.2 Add `BlobStore::acquire_write` / `acquire_read` wrapper stubs in `blob_store.rs`.
+B.3 Add `ChainMode` enum in `oci/index.rs`. Thread an unused `mode` parameter through `from_chained` construction sites. Keep the compiler happy.
+B.4 Add `LocalIndex::persist_manifest_chain` and `LocalIndex::lock_tags` stubs alongside the existing methods (don't delete the existing methods yet — Phase E does that).
+B.5 Create `package_manager/tasks/chain_walk.rs` with `ChainWalk` struct and `walk_chain` stub.
+B.6 Add `ReferenceManager::link_blobs_batch` stub in `reference_manager.rs`.
+B.7 Touch `Context::try_init`, `command/index_update.rs`, `pull.rs`, `find.rs`, `find_symlink.rs`, `find_or_install.rs` with `// TODO(#35)` comments at the known call sites.
+
+Gate: `cargo check --workspace` passes. The `IndexImpl` trait is unchanged, so no ripple into test transports.
+
+### Phase C — Verify stubs
+
+`task rust:verify` clean.
+
+### Phase D — Specify tests
+
+Write all 60 tests against stubs. Each must fail with `unimplemented!()` or the expected "not yet wired" assertion. The existing `unreachable_blobs_skipped_by_clean` test (`garbage_collection.rs:200-204`) is renamed and inverted in this phase as part of test 44.
+
+Gate: `cargo nextest run -p ocx_lib` — new tests fail with `unimplemented!()`; pre-existing tests still green.
+
+### Phase E — Implement
+
+E.1 `BlobGuard` + `BlobStore::acquire_write` / `acquire_read` + sibling `digest` marker write (tests 1-13).
+
+E.2 `LocalIndex::persist_manifest_chain` using `BlobStore::acquire_write`, handling the `ImageIndex` recursion. `LocalIndex::lock_tags` factored from the existing `update_tags` tail (tests 14-19).
+
+E.3 `LocalIndex::get_manifest` gains `BlobStore::acquire_read` wrapping + graceful parse-failure recovery (tests 20-21).
+
+E.4 `ChainedIndex` rewrite: `mode: ChainMode` field, `walk_chain` owns orchestration, per-identifier `singleflight`, mode-aware routing for mutable-lookup methods (tests 22-32).
+
+E.5 Delete `LocalIndex::update`, `update_tags`, `update_manifest`. Compiler guides remaining callers to `persist_manifest_chain` + `lock_tags`. Delete `Index::from_local`.
+
+E.6 `Context::try_init` collapses to one `from_chained` call with `ChainMode` derived from flags. `CLI ocx index update` rewired to `fetch_manifest_digest` + `lock_tags` loop (test 52).
+
+E.7 `package_manager/tasks/chain_walk.rs` implementation (tests 33-38).
+
+E.8 `ReferenceManager::link_blobs_batch` (tests 39-43).
+
+E.9 Pull pipeline: replace `cache_manifest_blob` + `link_blobs_in_temp` with `walk_chain` + `link_blobs_batch`. Delete the two free functions (acceptance test 47).
+
+E.10 Find-family upserts (`find`, `find_symlink`, `find_or_install`) on the already-installed branch (acceptance tests 48, 60).
+
+E.11 Delete `garbage_collection.rs:48` skip; invert the test (tests 44-46; acceptance tests 49-50).
+
+E.12 Acceptance tests for `--remote`, `--offline`, parallel install, sidecar check, latent-bug fix (acceptance tests 51, 53-59).
+
+### Phase F — Review-fix loop
+
+Round 1 (parallel):
+
+- `worker-reviewer` spec-compliance — AC1-13 coverage; "every walker chain entry is on disk" invariant upheld across all modes; find-family writes are minimal and idempotent.
+- `worker-reviewer` rust-quality — `quality-rust.md` checklist. Special attention: no `MutexGuard` across `.await`; `fs2::FileExt` calls wrapped in `spawn_blocking` (matches `TagGuard`); `#[non_exhaustive]` on `ChainMode`; `thiserror` for new error variants if any.
+- `worker-reviewer` concurrency — `BlobGuard` parallels `TagGuard` faithfully; no sidecar files anywhere; `EEXIST` handling on symlinks correct; `singleflight` key scheme prevents same-identifier-different-tag collision; `ocx clean` concurrent-with-install convention inherited and documented.
+- `worker-architect` — three-layer separation clean; `IndexImpl` trait genuinely unchanged; the latent bug fix lands without reintroducing the "tag match skip" short-circuit; migration note for existing installed packages is accurate.
+
+Deferred-finding bar: any policy-retention suggestion is pushed to #50. Any byte-exact manifest persistence concern is out of scope.
+
+Optional: one Codex adversarial pass on the diff after convergence.
+
+### Phase G — Docs + commit
+
+- `website/src/docs/user-guide.md` — index section (remote semantics, offline install requirement).
+- `website/src/docs/reference/command-line.md` — `--remote` flag section.
+- `website/src/docs/reference/environment.md` — `OCX_REMOTE` section.
+- `website/src/docs/getting-started.md` — `--remote` example updates.
+- `.claude/rules/subsystem-oci.md` — `persist_manifest_chain`, `lock_tags`, `ChainMode`, `singleflight` in `walk_chain`.
+- `.claude/rules/subsystem-file-structure.md` — `BlobGuard` in module map; GC Safety section (blobs are first-class BFS entries).
+- `.claude/rules/subsystem-package-manager.md` — `chain_walk` task helper.
+- `.claude/rules/arch-principles.md` Utility Catalog — `BlobGuard` row.
+- `CHANGELOG.md` — breaking-change lines for `--remote` and `ocx index update`.
+
+Commits (conventional, split by concern):
+
+1. `feat(store): BlobGuard — fs2-locked direct writes to CAS blob files`
+2. `refactor(oci): LocalIndex exposes persist_manifest_chain + lock_tags primitives`
+3. `refactor(oci): ChainedIndex owns walk_chain orchestration with singleflight`
+4. `feat(oci): ChainMode unifies --remote / --offline / default handling`
+5. `refactor(cli): narrow ocx index update to tag-locking`
+6. `feat(package-manager): chain_walk helper for resolution chain traversal`
+7. `feat(store): ReferenceManager::link_blobs_batch idempotent refs/blobs/ upsert`
+8. `feat(store): link full resolution chain into package refs/blobs/`
+9. `feat(gc): collect unreferenced blobs now that chains are linked`
+10. `fix(oci): re-fetch manifest when tag is cached but blob is missing`
+11. `docs: --remote semantic change and index update narrowing`
+
+## Dependencies
+
+- **#27** — three-tier CAS (landed).
+- **#41 / PR #45** — ChainedIndex + TagGuard (landed as commits 89b0b90 / 5569658 / 68f341c). This plan rewrites parts of ChainedIndex and LocalIndex on top of that base.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Trait change accidentally introduced via `LocalIndex` public API | Low | `persist_manifest_chain` is `pub(super)`; `lock_tags` is `pub` but doesn't cross trait boundary. `IndexImpl` trait signature genuinely unchanged |
+| Existing installed packages ship without full chains; `clean` prunes their idx blobs on first run after upgrade | Medium | First `find` against each existing package upserts the chain. Document in release notes: "run `ocx find <pkg>` at least once per installed package before the first `clean` after upgrade". Alternative: ship a one-shot migration in Phase G — rejected because it spreads the cost across every command |
+| `--remote` behaviour change confuses users | Low | CLI reference + user guide updated in Phase G. Net-beneficial (write-through now applies) |
+| `ocx index update` narrowing breaks CI workflows that relied on eager manifest caching | Medium | CHANGELOG calls it out. Workaround: run `ocx install` once online. This IS a breaking change; the user has explicitly accepted breaking changes for v0.3 |
+| `ChainedIndex::walk_chain` rewrite introduces a subtle regression in the tag-fallback behaviour covered by PR #45's tests | Medium | PR #45 ships `test_tag_fallback.py` + extensive ChainedIndex unit tests in `chained_index.rs` tests module; Phase F runs both. Phase E.4 explicitly calls out running the existing tag-fallback tests as the regression guard |
+| `LocalIndex::update_manifest` removal breaks a caller I haven't found | Low | Compiler catches all call sites; any remaining usage redirects to `persist_manifest_chain` |
+| Kill-9 mid-write leaves a truncated blob and `Manifest::read_json` fails in an unexpected path | Low | Test 10 simulates partial writes; test 21 covers the full recovery round-trip through ChainedIndex |
+| Pre-existing non-byte-exact manifest persistence (`write_json` re-serialises) | Low | Out of scope; future tracking item if byte-exact persistence becomes required |
+| The `singleflight` key scheme collides for two different tags on the same repo | Low | Key is `(registry_slug, resolved_id_string)` — the resolved identifier string includes the tag. Test 28 guards this |
+
+## Out-of-Scope Follow-Ups
+
+- **#50** — policy-based retention for orphan blobs in shared-`$OCX_HOME` CI scenarios. Depends on this issue.
+- **Byte-exact manifest persistence** — `write_json` re-serialises parsed manifests; the stored bytes are not byte-identical to the registry response. No digest re-verification on read. File a tracking issue if this becomes a hard requirement.
+- **`ocx prefetch` command** — deferred to whenever an explicit pre-fetch need emerges.

--- a/.claude/artifacts/research_blob_retention_policy.md
+++ b/.claude/artifacts/research_blob_retention_policy.md
@@ -1,0 +1,197 @@
+---
+title: Blob / Cache Retention Policies for a Content-Addressed Binary Store
+date: 2026-04-13
+domain: storage | gc | infrastructure
+triggered_by: Issue #35 — originally framed as "policy-based retention". Scope was later split — #35 became a pure-reachability fix (see `plan_resolution_chain_refs.md`). This research applies to the deferred follow-up for policy-based retention (shared-$OCX_HOME CI scenarios, LRU/TTL/size-cap for already-unreferenced blobs).
+expires: 2027-04-13
+status: prior-art for deferred follow-up issue
+---
+
+# Research: Blob/Cache Retention Policies for a Content-Addressed Binary Store
+
+## Direct Answer
+
+OCX should adopt **hybrid max-age + size-cap + explicit pinning** tracked via a sidecar SQLite index (not filesystem atime). The two TTL-eligible blob categories (resolution-cache manifests and prefetched tarballs) share a size-cap budget and each have a distinct default TTL. Eviction runs at end-of-command, at most once per day, skipped in `--offline` mode. In-flight downloads are already protected by OCX's existing `TempStore` staging directory; the sidecar index must be written only after the `temp/ → blobs/` rename completes.
+
+## Prior Art Survey
+
+### Cargo — SQLite last-use tracking with max-age + size-cap (most directly relevant)
+
+Since Rust 1.75, Cargo maintains `~/.cargo/.global-cache` (SQLite) with six tables tracking last-access timestamps for all cache tiers. `DeferredGlobalLastUse` batches timestamp updates in memory and flushes them at command end. A `UPDATE_RESOLUTION` constant (300 seconds) prevents writes more frequent than once per 5 minutes per entry, keeping write overhead negligible. Eviction runs at most once per day (gated on `global_data.last_auto_gc`), skipped in `--offline`/`--frozen` mode. Age-based deletion uses `DELETE WHERE timestamp < threshold`. Size-based deletion orders by timestamp ascending and deletes oldest until under budget. The two modes compose: age runs first, then size-cap trims remaining entries. The design explicitly avoids atime because Docker volume mounts and network filesystems cannot be relied upon to update it.
+
+Default TTLs: rebuilt-from-source artifacts at 1 month, downloaded blobs at 3 months.
+
+Sources: [Cargo Cache Cleaning](https://blog.rust-lang.org/2023/12/11/cargo-cache-cleaning/), [global_cache_tracker.rs](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/global_cache_tracker.rs).
+
+### containerd — lease TTLs with reachability GC, no size-based eviction
+
+Containerd uses label-based mark-sweep. Leases protect blobs via `containerd.io/gc.ref.content.*` labels. Default lease TTL is 24 hours — if the client process dies, the lease expires automatically. The `containerd.io/gc.expire` label accepts an RFC3339 timestamp; the background GC goroutine deletes the lease after expiry.
+
+**Critical finding:** containerd has *no* size-based eviction. GitHub issue #6583 has requested it for years; the maintainer response is consistently "use Kubernetes node-pressure eviction at a higher layer." This is not viable for a developer tool. The absence of size-based eviction in a production-grade CAS at scale confirms the design space is genuinely hard — and that OCX must ship it rather than defer it.
+
+Sources: [garbage-collection.md](https://github.com/containerd/containerd/blob/main/docs/garbage-collection.md), [issue #6583](https://github.com/containerd/containerd/issues/6583).
+
+### Proxmox Backup Server — atime-based two-phase GC with explicit grace period
+
+PBS uses `utimes()` to update chunk atime during the mark phase, then deletes chunks whose atime predates a cutoff in the sweep phase. The cutoff is `min(oldest active backup writer start time, now - 24h5m)`. The 24-hour window is both the in-flight grace period and the atime reliability hedge — PBS explicitly calls `utimes()` itself rather than relying on kernel read-triggered atime updates.
+
+Cautionary tale: PBS makes atime work only because it controls its own `utimes()` call during mark. OCX cannot assume control over filesystem mount options (Docker mounts, CI runners, network mounts all commonly disable or throttle atime).
+
+Source: [PBS Maintenance Docs](https://pbs.proxmox.com/docs/maintenance.html).
+
+### Nix — symlink-root reachability GC, no TTL or size cap
+
+GC starts from `/nix/var/nix/gcroots/` and marks all reachable paths. No TTL. No size budget. Users must manually delete old profile generations. This is the right model for the **package-referenced** blob category (already implemented in OCX via `refs/symlinks/` BFS) but offers nothing for orphaned non-package blobs.
+
+Source: [Nix Pills — GC](https://nixos.org/guides/nix-pills/11-garbage-collector.html).
+
+### Bazel disk cache — LRU + size cap, eviction delegated to bazel-remote
+
+Bazel's native local disk cache grows unboundedly. Issue #5139 (opened 2018, open in 2026) tracks automatic GC. `bazel-remote` fills the gap with `--max_size` (LRU size cap) and `--cache_max_age` (TTL). Lesson: do not defer size-based eviction — it is the single most common user complaint in the Bazel ecosystem.
+
+Sources: [Bazel issue #5139](https://github.com/bazelbuild/bazel/issues/5139), [bazel-remote docs](https://the-pi-guy.com/blog/managing_bazels_build_cache_and_eviction_policies/).
+
+### Go module cache — nuclear option only
+
+`go clean -modcache` deletes the entire cache. No TTL, no size cap, no selective eviction. Do not emulate.
+
+Source: [Go Modules Reference](https://go.dev/ref/mod).
+
+### OCI distribution spec — reachability-only, no TTL standard
+
+OCI dist-spec v1.1 added the referrers API: untagged artifacts with a live `subject` reference are protected from GC. No TTL or size-based eviction is standardized. Registry-side GC remains implementation-specific. The referrers model applies to registry-side cleanup, not local store cleanup.
+
+Source: [OCI Specs v1.1 Release](https://opencontainers.org/posts/blog/2024-03-13-image-and-distribution-1-1/).
+
+## Industry Context and Trends
+
+**Established patterns.** SQLite sidecar for last-use tracking (Cargo since 1.75), hybrid TTL + size-cap composition (Cargo, bazel-remote), staging directory for in-flight protection (Cargo `.crate.part`, OCX `TempStore`), symlink-root reachability for protected blobs (Nix, Git, OCX already).
+
+**Trending.** SQLite is the dominant choice for local tool metadata stores in 2024-2026 (Cargo, uv, mise, proto all use it). Explicit pinning APIs are gaining adoption in CI toolchain managers (mise `pin`, proto `pin`).
+
+**Declining.** atime-based GC (unreliable on modern Linux, Docker, NFS). Background GC daemons for single-user CLI tools (coordination complexity without benefit). All-or-nothing cache deletion (Go's approach is widely criticized).
+
+## Design Patterns for Retention in CAS
+
+### LRU vs TTL vs size-cap vs hybrid
+
+Pure LRU requires a complete ordering maintained in the index — correct but the index is the only practical place to store it. Pure TTL evicts useful items that simply haven't been accessed recently. Pure size-cap is fair under pressure but may evict blobs that are still very useful. The winning pattern across every surveyed tool is **hybrid**: TTL removes obviously stale items cheaply first, then size-cap trims remaining entries by age if the budget is exceeded. This matches Cargo's `max-download-age` + `max-download-size` composition exactly.
+
+### Tracking last-access cheaply
+
+| Mechanism | Reliability | Cost | Cross-platform |
+|---|---|---|---|
+| Kernel atime | Low — `noatime`, `relatime`, Docker mounts | Zero | Poor |
+| Explicit `utimes()` on read | Medium — OCX controls the call | One syscall per read | Good |
+| SQLite sidecar with coalesced writes | High | Negligible (300 s coalesce, end-of-command flush) | Excellent |
+| Per-blob JSON sidecar file | Medium — not atomic for concurrent writers | One file write per read | Good |
+
+SQLite with write coalescing is the right choice. It is the only mechanism that survives Docker volume mounts, NFS, and CI runner environments without relying on kernel behaviour.
+
+### Pinning mechanisms
+
+Three patterns observed: symlink roots (Nix/Git — already used in OCX for package-referenced blobs), lease tokens (containerd — suited for daemons, overkill for OCX), and explicit pin records in the index (simplest, sufficient for a single-process tool). OCX needs explicit pins only for the prefetched/portable category where CI workflows need to guarantee a blob survives across runs.
+
+### Eviction triggers
+
+On-write triggers (check quota before each write) add latency to the write path. Background daemons add lifecycle complexity. The right balance for a CLI tool is **end-of-command once per day** (Cargo's model): check `gc_state.last_auto_gc` at command completion, run eviction if more than 24 hours have elapsed, skip in `--offline` mode. An explicit `ocx clean [--max-age] [--max-size] [--dry-run]` command gives users direct control and CI pipelines a predictable hook.
+
+### In-flight race protection
+
+The classic hazard: GC runs while a download is in progress; the blob is written to `blobs/` after GC's scan but before GC completes — except GC deletes by reading from the sidecar index, and the index is only updated after `rename(temp/ → blobs/)`. The staging directory is therefore the primary defence: blobs live in `TempStore` (not registered in the sidecar index) until complete.
+
+Two additional guards are warranted:
+
+1. Register a sidecar index row only **after** `fs::rename` returns `Ok`.
+2. GC skips any index entry with `created_at > now - 5 min` as a clock-skew and crash grace window.
+
+OCX's existing `TempStore` already implements the staging half. The sidecar index just needs to honour the "write after rename" invariant.
+
+## Known Pitfalls
+
+**atime on modern Linux.** `relatime` is the default mount option since kernel 2.6.30. With `relatime`, atime is only updated when the current atime predates the mtime, or more than 24 hours have passed since the last atime update. Docker volume mounts typically disable atime entirely. Never use kernel atime for GC decisions in a tool that runs in CI.
+
+**Clock skew and TTL.** If `OCX_HOME` is on a network filesystem, `SystemTime::now()` on the client can skew ±minutes from the server's mtime. Mitigation: use day-granularity TTLs and tolerate ±1-day errors as acceptable. Do not use sub-hour TTLs.
+
+**Eviction stampede.** A bulk `index update` that caches thousands of resolution manifests at once will age-out simultaneously after the TTL. Mitigation: cap deletions per GC run (e.g., 500 blobs) and carry overflow to the next daily run. Log the count so users can understand disk pressure.
+
+**Correctness hazard — mixing reachable and unreachable blobs.** OCX's three-tier CAS cleanly separates package-referenced blobs (tracked via `refs/blobs/`, GC'd by reachability BFS) from resolution-cache and prefetched blobs. The sidecar index must track **only TTL-eligible entries** — never blobs that are reachable from a package. Simplest enforcement: any blob written as part of a package install (pull pipeline) is never inserted into the sidecar index. Only `index update` (resolution cache) and `ocx prefetch` / bundle operations are sidecar-eligible writes.
+
+**Surprising finding.** Containerd still has no size-based eviction after years of requests. This is the strongest validation that OCX must implement size-based eviction rather than treating it as a future item. If containerd at CNCF scale has not shipped it, the problem is underestimated in complexity. Start with the Cargo approach (size-ordered deletion by age), which is proven and simple.
+
+## Recommendation for OCX
+
+### Policy shape: hybrid TTL + size-cap + explicit pins
+
+Three retention classes:
+
+| Blob category | Default max-age | Size-cap participation | Pin mechanism |
+|---|---|---|---|
+| Package-referenced (live `refs/blobs/` edge) | Never — reachability GC only | No | Reachability via `refs/blobs/` forward-ref |
+| Resolution cache (manifests from `index update`) | 90 days | Yes | None by default |
+| Prefetched / portable (tarballs for offline bundles) | 365 days | Yes | Explicit `ocx pin add` |
+
+Resolution-cache and prefetched blobs share a combined size-cap budget. Proposed default: **5 GiB**. When the budget is exceeded, both pools are drained together ordered by `last_used ASC` until total drops below the budget, regardless of whether individual entries have exceeded their TTL.
+
+### Tracking mechanism: sidecar SQLite at `$OCX_HOME/blobs/.cache-index.db`
+
+Proposed schema:
+
+```sql
+CREATE TABLE blob_cache (
+    digest       TEXT    PRIMARY KEY,  -- "sha256:{hex}"
+    registry     TEXT    NOT NULL,     -- slugified registry hostname
+    category     TEXT    NOT NULL,     -- "resolution" | "prefetched"
+    size_bytes   INTEGER NOT NULL,
+    created_at   INTEGER NOT NULL,     -- Unix seconds
+    last_used    INTEGER NOT NULL,     -- Unix seconds
+    pinned       INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE pin (
+    digest     TEXT PRIMARY KEY REFERENCES blob_cache(digest),
+    label      TEXT,
+    created_at INTEGER NOT NULL
+);
+CREATE TABLE gc_state (
+    key    TEXT PRIMARY KEY,
+    value  TEXT NOT NULL               -- e.g. "last_auto_gc" -> ISO 8601
+);
+```
+
+**Write coalescing.** Buffer `last_used` updates in memory during command execution, flush once at command end. Skip flush in `--offline` mode. Use a 300-second resolution threshold (same as Cargo) to avoid write amplification when the same blob is accessed multiple times in one session.
+
+### Eviction trigger: end-of-command, daily frequency
+
+At the end of any command that writes to `blobs/`, check `gc_state WHERE key = 'last_auto_gc'`. If more than 24 hours have elapsed, run:
+
+1. **Age-based deletion:** `DELETE FROM blob_cache WHERE last_used < (now - max_age_seconds) AND pinned = 0`
+2. **Size-based deletion** if budget exceeded: SELECT all non-pinned entries `ORDER BY last_used ASC`, accumulate `size_bytes`, mark oldest for deletion until total fits in budget.
+3. **Cap per-run deletions at 500 entries** to avoid stampede.
+4. **Remove actual blob directories** from `BlobStore` for each deleted index entry.
+5. Update `last_auto_gc`.
+
+Exposed as `ocx clean [--max-age <duration>] [--max-size <bytes>] [--dry-run]`.
+
+### In-flight protection
+
+`TempStore` already provides staging. The sidecar index must honour one invariant: **register a blob entry only after `fs::rename(temp_dir, blob_dir)` returns `Ok`**. Additionally, skip index entries with `created_at > now - 5 min` during GC as a belt-and-suspenders guard.
+
+### Pin mechanism
+
+`ocx pin add <digest> [--label <label>]` inserts into `pin` and sets `pinned = 1`. `ocx pin list` and `ocx pin remove` round out the API. Pinned entries are excluded from both TTL and size-cap eviction. Minimal interface CI pipelines need to guarantee a bundle blob survives across runs.
+
+## Sources
+
+- [Cargo Cache Cleaning](https://blog.rust-lang.org/2023/12/11/cargo-cache-cleaning/) — auto-GC trigger design, TTL defaults, SQLite rationale, Docker atime problems
+- [global_cache_tracker.rs](https://github.com/rust-lang/cargo/blob/master/src/cargo/core/global_cache_tracker.rs) — SQLite schema, `UPDATE_RESOLUTION` constant, age + size eviction queries
+- [containerd garbage-collection.md](https://github.com/containerd/containerd/blob/main/docs/garbage-collection.md) — lease lifecycle, `gc.expire` TTL, reachability-only model
+- [containerd issue #6583](https://github.com/containerd/containerd/issues/6583) — size-based eviction still unimplemented
+- [PBS Maintenance Docs](https://pbs.proxmox.com/docs/maintenance.html) — atime-based two-phase GC, cutoff calculation, in-flight grace period
+- [Nix Pills — GC](https://nixos.org/guides/nix-pills/11-garbage-collector.html) — symlink-root reachability model
+- [Bazel issue #5139](https://github.com/bazelbuild/bazel/issues/5139) — eviction as long-standing unresolved gap
+- [bazel-remote eviction docs](https://the-pi-guy.com/blog/managing_bazels_build_cache_and_eviction_policies/) — LRU + `max_size` + `max_age` composition
+- [Go Modules Reference](https://go.dev/ref/mod) — all-or-nothing `go clean -modcache`
+- [OCI Specs v1.1 Release](https://opencontainers.org/posts/blog/2024-03-13-image-and-distribution-1-1/) — referrers API, untagged artifact GC protection
+- [noatime/relatime performance notes](https://opensource.com/article/20/6/linux-noatime) — atime unreliability
+- `.claude/artifacts/research_content_addressed_storage.md` — prior OCX CAS research
+- `.claude/artifacts/adr_three_tier_cas_storage.md` — accepted OCX three-tier CAS ADR

--- a/.claude/rules/arch-principles.md
+++ b/.claude/rules/arch-principles.md
@@ -133,6 +133,7 @@ These `crates/ocx_lib/src/` modules have no dedicated subsystem rule — they se
 | Sorted / dedup a `Vec` fluently | `VecExt::sorted` / `unique_clone` | prelude |
 | Ignore a `Result` deliberately | `ResultExt::ignore` | prelude |
 | Cross-process advisory file lock (shared/exclusive, timeout, RAII) | `file_lock::FileLock` | `crates/ocx_lib/src/file_lock.rs` |
+| Shared/exclusive advisory lock on blob data files with RAII cleanup | `BlobGuard::acquire_read` / `acquire_write` | `crates/ocx_lib/src/file_structure/blob_store/blob_guard.rs` |
 | RAII "delete path on drop" guard | `utility::fs::DropFile` | `utility/fs/drop_file.rs` |
 | Watch-based async singleflight (dedupe in-flight work by key) | `utility::singleflight` | `utility/singleflight.rs` |
 | Parallel directory tree walk with pruning decisions | `utility::fs::{DirWalker, WalkDecision}` | `utility/fs/dir_walker.rs` |

--- a/.claude/rules/subsystem-file-structure.md
+++ b/.claude/rules/subsystem-file-structure.md
@@ -24,6 +24,7 @@ Separating `refs/` into four named subdirs (`symlinks/`, `deps/`, `layers/`, `bl
 |------|---------|-----------|
 | `file_structure.rs` | Composite root; `slugify()`, `repository_path()` | `FileStructure` |
 | `blob_store.rs` | Raw OCI blob storage | `BlobStore`, `BlobDir` |
+| `blob_store/blob_guard.rs` | RAII read/write lock on individual blob data files | `BlobGuard` |
 | `layer_store.rs` | Extracted layer storage | `LayerStore`, `LayerDir` |
 | `package_store.rs` | Assembled package storage | `PackageStore`, `PackageDir` |
 | `tag_store.rs` | Local tag→digest index | `TagStore` |
@@ -170,6 +171,10 @@ Blob forward-ref: created by `pull` directly. Symlink in `refs/blobs/` targets `
 ## GC Safety
 
 GC (`garbage_collection/reachability_graph.rs`) builds a `ReachabilityGraph` covering all three CAS tiers in a single BFS pass. Packages with live `refs/symlinks/` entries or profile content-mode references are roots. BFS follows four edge types from each package: `refs/deps/` (dependent packages), `refs/layers/` (extracted layers), `refs/blobs/` (raw blobs). Layers and blobs have no outgoing edges — they are reachable only through package refs. Everything unreachable is collected.
+
+Blobs are first-class BFS entries: every `CasTier` variant (`Package`, `Layer`, `Blob`) is included in the reachability walk. The previous `tier != CasTier::Blob` skip has been removed; blobs are retained only when a live `refs/blobs/` symlink points to them.
+
+`BlobGuard` (`blob_store/blob_guard.rs`) provides RAII shared/exclusive advisory locking for individual blob data files. Acquire a read lock before reading, a write lock before writing. Internals use `file_lock::FileLock` (which wraps `fs2` in `spawn_blocking`) — do not call `BlobStore::data()` directly in concurrent paths; always go through `BlobGuard::acquire_read` / `acquire_write`.
 
 ## symlink Module
 

--- a/.claude/rules/subsystem-oci.md
+++ b/.claude/rules/subsystem-oci.md
@@ -17,10 +17,12 @@ Trait-based dispatch (`IndexImpl`) enables swapping local/remote index implement
 | Path | Purpose |
 |------|---------|
 | `oci.rs` | Root module; re-exports public types |
-| `oci/index.rs` | Public `Index` wrapper; `SelectResult` enum; `fetch_candidates()`, `select()` |
+| `oci/index.rs` | Public `Index` wrapper; `ChainMode` enum; `SelectResult` enum; `fetch_candidates()`, `select()` |
 | `oci/index/index_impl.rs` | Private `IndexImpl` async trait (4 core methods) |
-| `oci/index/local_index.rs` | `LocalIndex`: file-backed snapshot of registry metadata |
+| `oci/index/chained_index.rs` | `ChainedIndex`: cache + ordered sources + `ChainMode` routing |
+| `oci/index/local_index.rs` | `LocalIndex`: file-backed snapshot; high-level entry points `refresh_tags`, `write_chain_and_commit_tag` |
 | `oci/index/local_index/cache.rs` | In-memory shared cache (tags + manifests) |
+| `oci/index/local_index/tag_manager.rs` | Tag read/write helpers used by `LocalIndex` |
 | `oci/index/remote_index.rs` | `RemoteIndex`: wraps `Client`, in-memory cache only |
 | `oci/index/remote_index/cache.rs` | In-memory shared cache (repositories, tags, digests) |
 | `oci/index/snapshot.rs` | `Snapshot` struct: tag → [(digest, platform)] (orphan, not yet wired as IndexImpl) |
@@ -37,6 +39,23 @@ Trait-based dispatch (`IndexImpl`) enables swapping local/remote index implement
 
 ## Key Types
 
+### ChainMode
+
+```rust
+#[non_exhaustive]
+pub enum ChainMode {
+    Default,  // Cache-first; write-through on source fetch. Normal online operation.
+    Remote,   // Tag/catalog bypass cache, go straight to source. Immutable (digest) lookups still cache. Used for `--remote`.
+    Offline,  // Cache only; source never consulted; cache miss returns None. Used for `--offline`.
+}
+```
+
+| Mode | Tag/catalog lookup | Blob/manifest (digest-addressed) | `$OCX_HOME/tags/` updated? |
+|------|-------------------|----------------------------------|---------------------------|
+| `Default` | Local cache first, then source | Cache + write-through | Yes |
+| `Remote` | Source always (bypass cache) | Cache + write-through | No |
+| `Offline` | Cache only | Cache only | No |
+
 ### Identifier
 
 Parsed OCI reference: `registry/repository[:tag][@digest]`.
@@ -51,7 +70,8 @@ Parsed OCI reference: `registry/repository[:tag][@digest]`.
 ### Index (public wrapper)
 
 Type-erased wrapper over `Box<dyn IndexImpl>`. Construction:
-- `from_local(local_index)` or `from_remote(remote_index)`
+- `from_chained(cache: LocalIndex, sources: Vec<Index>, mode: ChainMode)` — the standard constructor; wraps a `ChainedIndex` that orchestrates cache + source routing per `ChainMode`
+- `from_remote(remote_index)` — wraps a bare `RemoteIndex` (no caching)
 - Clone shares in-memory cache (via `Arc<RwLock>`)
 
 Key methods: `list_tags()`, `fetch_manifest()`, `fetch_candidates()`, `select(identifier, platforms) → SelectResult`
@@ -59,6 +79,7 @@ Key methods: `list_tags()`, `fetch_manifest()`, `fetch_candidates()`, `select(id
 ### SelectResult
 
 ```rust
+#[non_exhaustive]
 pub enum SelectResult {
     Found(Identifier),           // Exactly one match
     Ambiguous(Vec<Identifier>),  // Multiple matches
@@ -77,17 +98,26 @@ async fn fetch_manifest_digest(&self, id: &Identifier) -> Result<Option<Digest>>
 
 **Return convention**: `Result<Option<T>>` — `None` = not found (not an error), `Err` = network/IO failure.
 
+### LocalIndex
+
+File-backed snapshot of registry metadata. High-level public entry points:
+
+- `refresh_tags(source, identifier)` — fetch tags from `source`, persist to `$OCX_HOME/tags/`; used by `ChainedIndex` for tag/catalog operations
+- `write_chain_and_commit_tag(source, identifier)` — orchestrate a full chain walk (image index → manifest), persist all blobs to `$OCX_HOME/blobs/`, then commit the tag pointer; called by `ChainedIndex` after a source fetch
+
+Internal helpers `persist_manifest_chain` and `commit_tag` are private — callers always go through these two high-level methods.
+
 ### LocalIndex vs RemoteIndex
 
 | Aspect | LocalIndex | RemoteIndex |
 |--------|-----------|-------------|
 | Storage | Disk JSON + in-memory cache | In-memory cache only |
-| Population | Explicit `update()` call | Lazy on access |
+| Population | Via `ChainedIndex` write-through | Lazy on access |
 | Manifest cache | Yes (disk + memory) | No (re-fetches each time) |
 | Offline support | Yes | No |
 | Clone behavior | Shares in-memory cache | Shares in-memory cache |
 
-**LocalIndex update semantics:**
+**Write-through semantics** (via `ChainedIndex`):
 - Tagged identifier (`cmake:3.28`): fetches only that tag; preserves other tags locally
 - Bare identifier (`cmake`): fetches all tags; does not remove local-only tags
 - Always merges, never overwrites; safe for parallel updates to different tags

--- a/.claude/rules/subsystem-package-manager.md
+++ b/.claude/rules/subsystem-package-manager.md
@@ -64,6 +64,7 @@ enum Error {
     InstallFailed(Vec<PackageError>),
     UninstallFailed(Vec<PackageError>),
     DeselectFailed(Vec<PackageError>),
+    ResolveFailed(Vec<PackageError>),  // returned by resolve_all()
 }
 
 // Layer 2: Package-specific
@@ -84,12 +85,33 @@ enum PackageErrorKind {
 
 **Convention**: Single-item methods return `Result<T, PackageErrorKind>`. `_all` batch methods return `Result<T, Error>`.
 
+`resolve_all()` returns `Err(Error::ResolveFailed(...))` when one or more packages fail to resolve; it does not reuse `FindFailed`. `find_all()` continues to use `FindFailed` for failures during the install-lookup phase.
+
+## ResolvedChain
+
+`PackageManager::resolve()` returns a `ResolvedChain` struct that carries the full OCI resolution chain traversed for the identifier — image index manifest, platform manifest, and any intermediate manifests — along with their digests. Callers (e.g. `pull`, `find`, `find_symlink`) pass this struct to `ReferenceManager::link_blobs` to populate `refs/blobs/` so GC can trace the complete chain.
+
+## link_blobs Call Pattern
+
+`ReferenceManager::link_blobs(content_path, chain)` is an `async fn`. It creates a symlink in
+`refs/blobs/` for each blob digest in the chain, targeting the corresponding `BlobStore` data file.
+An empty chain is a no-op (returns `Ok(())` without creating the directory).
+
+Called by `pull`, `find`, and `find_symlink` after resolving a package:
+
+```
+let chain = manager.resolve(identifier).await?;
+reference_manager.link_blobs(pkg.content(), chain.blobs()).await?;
+```
+
+The TOCTOU `!target.exists()` pre-check is intentionally absent — eventual consistency handles dangling refs, and the idempotent `symlink::update` makes repeated calls safe.
+
 ## Task Methods
 
 | Method | Auto-Install | Returns | Notes |
 |--------|-------------|---------|-------|
-| `find()` / `find_all()` | No | `InstallInfo` | Resolves locally only |
-| `find_symlink()` / `find_symlink_all()` | No | `InstallInfo` | Via candidate/current symlink |
+| `find()` / `find_all()` | No | `InstallInfo` | Resolves locally only; calls `link_blobs` |
+| `find_symlink()` / `find_symlink_all()` | No | `InstallInfo` | Via candidate/current symlink; calls `link_blobs` |
 | `find_or_install()` / `find_or_install_all()` | **Yes** (if online) | `InstallInfo` | Falls through to install on NotFound |
 | `install()` / `install_all()` | N/A | `InstallInfo` | Downloads; `candidate` flag creates symlink; `select` flag sets current |
 | `uninstall()` / `uninstall_all()` | N/A | `Option<UninstallResult>` | None = candidate was already absent |

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,9 +28,7 @@ jobs:
           fetch-depth: 0
           submodules: true
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
@@ -96,9 +94,7 @@ jobs:
         with:
           submodules: true
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
-        with:
-          toolchain: stable
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       - name: Install uv
         uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - name: Generate SBOM and dependencies page

--- a/.github/workflows/verify-basic.yml
+++ b/.github/workflows/verify-basic.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
-          toolchain: stable
-          components: clippy,rustfmt
           matcher: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/.github/workflows/verify-licenses.yml
+++ b/.github/workflows/verify-licenses.yml
@@ -43,8 +43,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
-        with:
-          toolchain: stable
       - name: Install cargo-deny
         uses: taiki-e/install-action@94cb46f8d6e437890146ffbd78a778b78e623fb2 # v2.74.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** `--remote` / `OCX_REMOTE` semantics narrowed — tag and catalog lookups now bypass the local tag store and query the registry directly, but digest-addressed blob reads still use the local cache with write-through to `$OCX_HOME/blobs/`. Previously, `--remote` routed all operations to the registry. Only `$OCX_HOME/tags/` is no longer updated under `--remote`. *(oci)*
+- **Breaking:** `ocx index update` no longer pre-fetches manifest or layer blobs. It writes only tag→digest pointers to `$OCX_HOME/tags/`. Run `ocx install <pkg>` online first to populate the blob cache before using `--offline`. *(index)*
+
+### Fixed
+
+- `ocx --offline install <pkg>` after a bare `ocx index update <pkg>` now fails with a clear `OfflineManifestMissing` error naming the missing digest instead of a silent failure. Recovery: run `ocx install <pkg>` online to populate the blob cache. *(oci)*
+
 ## [0.2.1] - 2026-03-24
 
 ### Added

--- a/crates/ocx_cli/src/app/context.rs
+++ b/crates/ocx_cli/src/app/context.rs
@@ -62,17 +62,26 @@ impl Context {
             blob_store: BlobStore::new(file_structure.blobs.root().to_path_buf()),
         });
 
-        let selected_index = if options.remote {
-            if let Some(remote_index) = &remote_index {
-                index::Index::from_remote(remote_index.clone())
-            } else {
-                return Err(anyhow::anyhow!("Remote index is not available in offline mode."));
+        // Single `Index::from_chained` entry point. `remote_index` is the
+        // authoritative signal: `None` means offline (no network sources);
+        // `Some` means online (wrap it as a chain source). `options.remote`
+        // then selects between `Default` (cache-first) and `Remote`
+        // (mutable lookups bypass cache) for online mode. Deriving mode and
+        // sources from the same value prevents the `(offline=false,
+        // remote_index=None)` unreachable case the older bool-based match
+        // produced.
+        let (mode, sources): (index::ChainMode, Vec<index::Index>) = match &remote_index {
+            None => (index::ChainMode::Offline, Vec::new()),
+            Some(remote) => {
+                let mode = if options.remote {
+                    index::ChainMode::Remote
+                } else {
+                    index::ChainMode::Default
+                };
+                (mode, vec![index::Index::from_remote(remote.clone())])
             }
-        } else if let Some(remote_index) = &remote_index {
-            index::Index::from_cached_remote(local_index.clone(), remote_index.clone())
-        } else {
-            index::Index::from_local(local_index.clone())
         };
+        let selected_index = index::Index::from_chained(local_index.clone(), sources, mode);
 
         let default_registry = env::string("OCX_DEFAULT_REGISTRY", ocx_lib::oci::DEFAULT_REGISTRY.into());
 

--- a/crates/ocx_cli/src/command/deps.rs
+++ b/crates/ocx_cli/src/command/deps.rs
@@ -53,8 +53,7 @@ pub struct Deps {
 impl Deps {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
         let platforms = platforms_or_default(&self.platforms);
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let manager = context.manager();
         let infos = manager.find_all(identifiers, platforms).await?;

--- a/crates/ocx_cli/src/command/deselect.rs
+++ b/crates/ocx_cli/src/command/deselect.rs
@@ -22,8 +22,7 @@ pub struct Deselect {
 
 impl Deselect {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let results = context.manager().deselect_all(&identifiers).await?;
 

--- a/crates/ocx_cli/src/command/env.rs
+++ b/crates/ocx_cli/src/command/env.rs
@@ -38,8 +38,7 @@ pub struct Env {
 impl Env {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
         let platforms = platforms_or_default(&self.platforms);
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let manager = context.manager();
 

--- a/crates/ocx_cli/src/command/exec.rs
+++ b/crates/ocx_cli/src/command/exec.rs
@@ -37,8 +37,7 @@ pub struct Exec {
 impl Exec {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
         let platforms = platforms_or_default(&self.platforms);
-        let identifier =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifier = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let manager = context.manager();
         let info = manager.find_or_install_all(identifier, platforms).await?;
@@ -65,7 +64,7 @@ impl Exec {
             })
             .stderr(Stdio::inherit())
             .stdout(Stdio::inherit())
-            .envs(process_env.into_iter())
+            .envs(process_env)
             .spawn()?;
 
         let status = child_process.wait().await?;

--- a/crates/ocx_cli/src/command/find.rs
+++ b/crates/ocx_cli/src/command/find.rs
@@ -37,8 +37,7 @@ pub struct Find {
 
 impl Find {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let manager = context.manager();
 

--- a/crates/ocx_cli/src/command/index_list.rs
+++ b/crates/ocx_cli/src/command/index_list.rs
@@ -45,30 +45,25 @@ impl IndexList {
     }
 
     async fn resolve_tags(&self, context: &crate::app::Context) -> anyhow::Result<ResolvedTags> {
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
-        let futures = self
-            .packages
-            .iter()
-            .zip(identifiers.into_iter())
-            .map(|(package, identifier)| {
-                let context = context.clone();
-                async move {
-                    let all_tags = match context.default_index().list_tags(&identifier).await? {
-                        Some(tags) => tags,
-                        None => {
-                            log::warn!("Package '{}' not found in the index.", identifier);
-                            Vec::new()
-                        }
-                    };
-                    let mut tags = all_tags;
-                    if let Some(requested_tag) = identifier.tag() {
-                        tags.retain(|t| t == requested_tag);
+        let futures = self.packages.iter().zip(identifiers).map(|(package, identifier)| {
+            let context = context.clone();
+            async move {
+                let all_tags = match context.default_index().list_tags(&identifier).await? {
+                    Some(tags) => tags,
+                    None => {
+                        log::warn!("Package '{}' not found in the index.", identifier);
+                        Vec::new()
                     }
-                    Ok((package.raw().to_string(), identifier, tags))
+                };
+                let mut tags = all_tags;
+                if let Some(requested_tag) = identifier.tag() {
+                    tags.retain(|t| t == requested_tag);
                 }
-            });
+                Ok((package.raw().to_string(), identifier, tags))
+            }
+        });
 
         futures::future::join_all(futures)
             .await

--- a/crates/ocx_cli/src/command/index_update.rs
+++ b/crates/ocx_cli/src/command/index_update.rs
@@ -16,16 +16,19 @@ pub struct IndexUpdate {
 
 impl IndexUpdate {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
+        // `ocx index update` is strictly a tag refresh: it locks the
+        // tag → digest pointer into the local index file without persisting
+        // any manifest blobs. Install-time ChainedIndex write-through owns
+        // the manifest chain persistence contract.
         let remote_index = index::Index::from_remote(context.remote_index()?.clone());
-        let packages =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let packages = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let mut join_set = tokio::task::JoinSet::new();
         for identifier in &packages {
             let remote_index = remote_index.clone();
             let context = context.clone();
             let identifier = identifier.clone();
-            join_set.spawn(async move { context.local_index().update(&remote_index, &identifier).await });
+            join_set.spawn(async move { context.local_index().refresh_tags(&identifier, &remote_index).await });
         }
 
         while let Some(result) = join_set.join_next().await {

--- a/crates/ocx_cli/src/command/install.rs
+++ b/crates/ocx_cli/src/command/install.rs
@@ -25,8 +25,7 @@ pub struct Install {
 
 impl Install {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        let oci_packages =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let oci_packages = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
         log::info!(
             "Installing packages: {}",
             oci_packages

--- a/crates/ocx_cli/src/command/package_pull.rs
+++ b/crates/ocx_cli/src/command/package_pull.rs
@@ -27,8 +27,7 @@ pub struct PackagePull {
 
 impl PackagePull {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        let oci_packages =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let oci_packages = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
         let install_infos = context
             .manager()
             .pull_all(&oci_packages, platforms_or_default(&self.platforms))

--- a/crates/ocx_cli/src/command/select.rs
+++ b/crates/ocx_cli/src/command/select.rs
@@ -26,8 +26,7 @@ pub struct Select {
 
 impl Select {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let fs = context.file_structure().clone();
         let rm = ReferenceManager::new(fs.clone());

--- a/crates/ocx_cli/src/command/shell_profile_add.rs
+++ b/crates/ocx_cli/src/command/shell_profile_add.rs
@@ -56,8 +56,7 @@ impl ShellProfileAdd {
         };
 
         let default_registry = context.default_registry();
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), default_registry.clone())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), default_registry.clone())?;
 
         // Auto-install: find_or_install_all handles both already-installed and missing packages
         let platforms = platforms_or_default(&self.platforms);

--- a/crates/ocx_cli/src/command/shell_profile_remove.rs
+++ b/crates/ocx_cli/src/command/shell_profile_remove.rs
@@ -22,7 +22,7 @@ pub struct ShellProfileRemove {
 impl ShellProfileRemove {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
         let default_registry = context.default_registry();
-        let identifiers = options::Identifier::transform_all(self.packages.clone().into_iter(), default_registry)?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), default_registry)?;
 
         let results = context.manager().profile().remove_all(&identifiers)?;
 

--- a/crates/ocx_cli/src/command/uninstall.rs
+++ b/crates/ocx_cli/src/command/uninstall.rs
@@ -33,8 +33,7 @@ pub struct Uninstall {
 
 impl Uninstall {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        let identifiers =
-            options::Identifier::transform_all(self.packages.clone().into_iter(), context.default_registry())?;
+        let identifiers = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
         let results = context
             .manager()

--- a/crates/ocx_lib/src/error.rs
+++ b/crates/ocx_lib/src/error.rs
@@ -82,3 +82,45 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub fn file_error(path: impl AsRef<std::path::Path>, error: std::io::Error) -> Error {
     Error::InternalFile(path.as_ref().to_path_buf(), error)
 }
+
+/// Clonable, source-preserving wrapper around [`Error`].
+///
+/// `crate::Error` is not `Clone` because several of its variants hold
+/// `io::Error`, which is not `Clone`. That prevents it from flowing through
+/// APIs that must broadcast a single failure to multiple consumers — most
+/// notably [`crate::utility::singleflight`], which clones the leader's error
+/// to every waiter.
+///
+/// `ArcError` wraps the typed error in an `Arc` so cloning is cheap and
+/// preserves the full error chain (`source()` delegates to the inner
+/// `Error`). Callers that need to broadcast a typed `Error` should accept
+/// `ArcError` in the variant that carries the failure so downstream code
+/// can still walk the chain and (where necessary) downcast to the original
+/// variant.
+#[derive(Debug, Clone)]
+pub struct ArcError(std::sync::Arc<Error>);
+
+impl ArcError {
+    /// Returns a reference to the wrapped error.
+    pub fn as_error(&self) -> &Error {
+        &self.0
+    }
+}
+
+impl From<Error> for ArcError {
+    fn from(error: Error) -> Self {
+        Self(std::sync::Arc::new(error))
+    }
+}
+
+impl std::fmt::Display for ArcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&*self.0, f)
+    }
+}
+
+impl std::error::Error for ArcError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.0.source()
+    }
+}

--- a/crates/ocx_lib/src/file_structure.rs
+++ b/crates/ocx_lib/src/file_structure.rs
@@ -10,7 +10,7 @@ mod symlink_store;
 mod tag_store;
 mod temp_store;
 
-pub use blob_store::{BlobDir, BlobStore};
+pub use blob_store::{BlobDir, BlobGuard, BlobStore};
 pub use cas_path::{CasTier, DIGEST_FILENAME, cas_ref_name, read_digest_file, write_digest_file};
 pub use layer_store::{LayerDir, LayerStore};
 pub use package_store::{PackageDir, PackageStore};

--- a/crates/ocx_lib/src/file_structure/blob_store.rs
+++ b/crates/ocx_lib/src/file_structure/blob_store.rs
@@ -5,6 +5,10 @@ use std::path::{Path, PathBuf};
 
 use crate::{Result, log, oci};
 
+mod blob_guard;
+
+pub use blob_guard::BlobGuard;
+
 /// Represents a single content-addressed blob directory within the blob store.
 ///
 /// A blob directory has a fixed layout:
@@ -66,13 +70,43 @@ impl BlobStore {
     }
 
     /// Returns the `data` file path for the given registry and digest.
-    pub fn data(&self, registry: &str, digest: &oci::Digest) -> PathBuf {
+    ///
+    /// # Invariant
+    /// All writes to this path MUST go through `BlobStore::acquire_write` to
+    /// respect the cooperative advisory lock protocol. Direct `fs` writes
+    /// corrupt concurrent readers.
+    pub(crate) fn data(&self, registry: &str, digest: &oci::Digest) -> PathBuf {
         self.path(registry, digest).join("data")
     }
 
     /// Returns the `digest` file path for the given registry and digest.
     pub fn digest_file(&self, registry: &str, digest: &oci::Digest) -> PathBuf {
         self.path(registry, digest).join(super::cas_path::DIGEST_FILENAME)
+    }
+
+    /// Acquires an exclusive lock on the blob `data` file for the given
+    /// pinned identifier (registry + digest), creating parent directories on
+    /// first use. Writers must hold this guard while calling
+    /// [`BlobGuard::write_bytes`](blob_guard::BlobGuard::write_bytes).
+    ///
+    /// Also writes the sibling `digest` marker file so that CAS recovery
+    /// tools can map the sharded directory back to its full digest string.
+    /// The marker write is idempotent — re-acquiring the same blob rewrites
+    /// the same content.
+    pub async fn acquire_write(&self, pinned: &oci::PinnedIdentifier) -> Result<BlobGuard> {
+        let digest = pinned.digest();
+        let data_path = self.data(pinned.registry(), &digest);
+        let guard = BlobGuard::acquire_exclusive(data_path).await?;
+        let digest_path = self.digest_file(pinned.registry(), &digest);
+        super::cas_path::write_digest_file(&digest_path, &digest).await?;
+        Ok(guard)
+    }
+
+    /// Acquires a shared lock on the blob `data` file for the given pinned
+    /// identifier. Returns `Ok(None)` when the file does not exist.
+    pub async fn acquire_read(&self, pinned: &oci::PinnedIdentifier) -> Result<Option<BlobGuard>> {
+        let data_path = self.data(pinned.registry(), &pinned.digest());
+        BlobGuard::acquire_shared(data_path).await
     }
 
     /// Lists all blob directories currently present in the store.
@@ -216,6 +250,91 @@ mod tests {
         let store = BlobStore::new(dir.path());
         let blobs = store.list_all().await.unwrap();
         assert_eq!(blobs.len(), 1);
+    }
+
+    // ── BlobStore wrapper tests (plan_resolution_chain_refs.md tests 11-13) ──
+
+    /// Builds a pinned identifier for `example.com/pkg@sha256:<SHA256_HEX>`.
+    fn pinned() -> oci::PinnedIdentifier {
+        let id = oci::Identifier::new_registry("pkg", "example.com")
+            .clone_with_digest(oci::Digest::Sha256(SHA256_HEX.to_string()));
+        oci::PinnedIdentifier::try_from(id).unwrap()
+    }
+
+    /// Test 11: acquire_write writes a sibling digest marker file in addition
+    /// to the locked `data` file. The digest file path must be the sibling
+    /// `digest` file next to `data`.
+    #[tokio::test]
+    async fn acquire_write_writes_sibling_digest_marker_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = BlobStore::new(dir.path());
+        let pinned = pinned();
+        let guard = store.acquire_write(&pinned).await.unwrap();
+        guard.write_bytes(b"{}").await.unwrap();
+        drop(guard);
+        // After a successful write, the sibling `digest` file must exist.
+        let digest_file = store.digest_file(pinned.registry(), &pinned.digest());
+        assert!(
+            digest_file.exists(),
+            "digest marker file must be written alongside data after acquire_write"
+        );
+    }
+
+    /// Test 12: acquire_write followed by acquire_read returns the same bytes.
+    #[tokio::test]
+    async fn acquire_write_then_acquire_read_returns_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = BlobStore::new(dir.path());
+        let pinned = pinned();
+        let payload = b"manifest content here";
+        let writer = store.acquire_write(&pinned).await.unwrap();
+        writer.write_bytes(payload).await.unwrap();
+        drop(writer);
+
+        let reader = store.acquire_read(&pinned).await.unwrap().unwrap();
+        let bytes = reader.read_bytes().await.unwrap();
+        assert_eq!(bytes, payload, "acquire_read must return what acquire_write wrote");
+    }
+
+    /// Test 13: eight concurrent tasks acquire_write on the same digest;
+    /// the final file content is valid (no corruption). Only one writer wins
+    /// per round; `BlobGuard` serialises them via `fs2` exclusive lock.
+    #[tokio::test]
+    async fn concurrent_acquire_write_on_same_digest_serialises() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(BlobStore::new(dir.path()));
+        let pinned = pinned();
+
+        let mut tasks = tokio::task::JoinSet::new();
+        for i in 0u8..8 {
+            let store_clone = store.clone();
+            let pinned_clone = pinned.clone();
+            tasks.spawn(async move {
+                let guard = store_clone.acquire_write(&pinned_clone).await.unwrap();
+                // Each writer writes a fixed-length payload distinct by `i`.
+                let payload = vec![i; 16];
+                guard.write_bytes(&payload).await.unwrap();
+            });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            joined.expect("task panicked");
+        }
+
+        // The data file must exist and contain exactly 16 bytes (one writer's payload).
+        let data_path = store.data(pinned.registry(), &pinned.digest());
+        let content = std::fs::read(&data_path).unwrap();
+        assert_eq!(
+            content.len(),
+            16,
+            "concurrent writes must not corrupt the data file; got {} bytes",
+            content.len()
+        );
+        // All bytes must be the same value (one writer's uniform payload).
+        let first_byte = content[0];
+        assert!(
+            content.iter().all(|&b| b == first_byte),
+            "data file must contain a single writer's uniform payload, not mixed bytes"
+        );
     }
 
     #[tokio::test]

--- a/crates/ocx_lib/src/file_structure/blob_store/blob_guard.rs
+++ b/crates/ocx_lib/src/file_structure/blob_store/blob_guard.rs
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The OCX Authors
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+use crate::file_lock::FileLock;
+use crate::{Result, error::file_error};
+
+/// Max time we're willing to block waiting for another writer to release the
+/// per-blob `data` file lock. Mirrors `TagGuard::LOCK_TIMEOUT`.
+const LOCK_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Per-blob reader/writer guard over a content-addressed `data` file.
+///
+/// Holds an `fs2` advisory lock — shared for reads, exclusive for writes —
+/// directly on the `data` file itself. No sidecar `.lock`, no temp sibling,
+/// no atomic rename: writers lock the file and update it in place
+/// (truncate + write + `sync_all`).
+///
+/// Modelled exactly on
+/// [`crate::oci::index::local_index::tag_guard::TagGuard`].
+/// Crash trade: a `kill -9` mid-write can leave the `data` file truncated;
+/// the next `Manifest::read_json` attempt will fail to parse,
+/// `LocalIndex::get_manifest` logs at warn and returns `None`, and
+/// `ChainedIndex::fetch_manifest`'s cache-miss path re-fetches the blob.
+/// Safe because blob content is immutable by digest — any re-fetch produces
+/// identical bytes.
+pub struct BlobGuard {
+    _lock: FileLock,
+    target_path: PathBuf,
+}
+
+impl BlobGuard {
+    /// Acquires an exclusive (writer) lock on the blob `data` file at
+    /// `target_path`, creating the file and its parent directories on first
+    /// use. Blocks until the lock is available or [`LOCK_TIMEOUT`] elapses.
+    pub async fn acquire_exclusive(target_path: PathBuf) -> Result<Self> {
+        if let Some(parent) = target_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| file_error(parent, e))?;
+        }
+        let open_path = target_path.clone();
+        let file = tokio::task::spawn_blocking(move || {
+            std::fs::OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(&open_path)
+        })
+        .await
+        .map_err(std::io::Error::other)
+        .and_then(std::convert::identity)
+        .map_err(|e| file_error(&target_path, e))?;
+        let lock = FileLock::lock_exclusive_with_timeout(file, LOCK_TIMEOUT)
+            .await
+            .map_err(|e| file_error(&target_path, e))?;
+        Ok(Self {
+            _lock: lock,
+            target_path,
+        })
+    }
+
+    /// Acquires a shared (reader) lock on the blob `data` file at
+    /// `target_path`. Returns `Ok(None)` if the file does not exist (so
+    /// callers can treat absence as "no blob yet" without racing an
+    /// exclusive writer).
+    pub async fn acquire_shared(target_path: PathBuf) -> Result<Option<Self>> {
+        let open_path = target_path.clone();
+        let open_result = tokio::task::spawn_blocking(move || std::fs::OpenOptions::new().read(true).open(&open_path))
+            .await
+            .map_err(std::io::Error::other)
+            .and_then(std::convert::identity);
+        let file = match open_result {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(file_error(&target_path, e)),
+        };
+        let lock = FileLock::lock_shared_with_timeout(file, LOCK_TIMEOUT)
+            .await
+            .map_err(|e| file_error(&target_path, e))?;
+        Ok(Some(Self {
+            _lock: lock,
+            target_path,
+        }))
+    }
+
+    /// Truncates the blob `data` file in place and writes `bytes`,
+    /// `sync_all`-ing for durability. Concurrent writers are serialised by
+    /// the exclusive lock held by the caller.
+    pub async fn write_bytes(&self, bytes: &[u8]) -> Result<()> {
+        // Second fd: the lock fd from acquire_exclusive cannot portably seek/truncate for a
+        // fresh write, so we open a new fd. fs2 serialization on the lock fd ensures concurrent
+        // writers are sequential, so the second-fd truncate is safe.
+        let mut file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&self.target_path)
+            .await
+            .map_err(|e| file_error(&self.target_path, e))?;
+        file.write_all(bytes)
+            .await
+            .map_err(|e| file_error(&self.target_path, e))?;
+        file.sync_all().await.map_err(|e| file_error(&self.target_path, e))?;
+        Ok(())
+    }
+
+    /// Reads the full blob `data` file under the lock.
+    pub async fn read_bytes(&self) -> Result<Vec<u8>> {
+        let mut file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .open(&self.target_path)
+            .await
+            .map_err(|e| file_error(&self.target_path, e))?;
+        let mut buf = Vec::new();
+        file.read_to_end(&mut buf)
+            .await
+            .map_err(|e| file_error(&self.target_path, e))?;
+        Ok(buf)
+    }
+
+    /// Returns the path this guard was opened on (for inspection in tests).
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub fn target_path(&self) -> &std::path::Path {
+        &self.target_path
+    }
+}
+
+// ── Specification tests ───────────────────────────────────────────────────
+//
+// Written from the design record (plan_resolution_chain_refs.md §Testing
+// Strategy, tests 1-10). These mirror tag_guard.rs tests structurally.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    // ── test 1 ────────────────────────────────────────────────────────────
+
+    /// Design record §1: acquire_exclusive creates the blob data file and its
+    /// parent directories. No sidecar `.lock` file may appear alongside it.
+    #[tokio::test]
+    async fn acquire_exclusive_creates_blob_file_and_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("sha256").join("ab").join("cdef1234").join("data");
+        let guard = BlobGuard::acquire_exclusive(target.clone()).await.unwrap();
+        assert!(target.exists(), "data file must be created on exclusive acquire");
+        drop(guard);
+        // No sidecar .lock file.
+        let sidecar = target.with_extension("data.lock");
+        assert!(!sidecar.exists(), "no sidecar .lock file may be created");
+    }
+
+    // ── test 2 ────────────────────────────────────────────────────────────
+
+    /// Design record §2: acquire_shared on a missing file returns None.
+    #[tokio::test]
+    async fn acquire_shared_on_missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("sha256").join("ab").join("cdef1234").join("data");
+        let result = BlobGuard::acquire_shared(target).await.unwrap();
+        assert!(result.is_none(), "shared acquire on missing file must return None");
+    }
+
+    // ── test 3 ────────────────────────────────────────────────────────────
+
+    /// Design record §3: acquire_shared returns Some when the file exists
+    /// (after an exclusive acquire created it).
+    #[tokio::test]
+    async fn acquire_shared_returns_some_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("sha256").join("ab").join("cdef1234").join("data");
+        // Create the file via an exclusive acquire first.
+        let writer = BlobGuard::acquire_exclusive(target.clone()).await.unwrap();
+        writer.write_bytes(b"blob content").await.unwrap();
+        drop(writer);
+        // Now a shared acquire must succeed.
+        let guard = BlobGuard::acquire_shared(target).await.unwrap();
+        assert!(guard.is_some(), "shared acquire must return Some when file exists");
+    }
+
+    // ── test 4 ────────────────────────────────────────────────────────────
+
+    /// Design record §4: multiple shared locks can coexist simultaneously.
+    #[tokio::test]
+    async fn shared_locks_can_coexist() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("sha256").join("ab").join("data");
+        // Create the file first.
+        let writer = BlobGuard::acquire_exclusive(target.clone()).await.unwrap();
+        writer.write_bytes(b"shared content").await.unwrap();
+        drop(writer);
+        // Acquire two shared locks simultaneously — must not block each other.
+        let a = BlobGuard::acquire_shared(target.clone()).await.unwrap().unwrap();
+        let b = BlobGuard::acquire_shared(target.clone()).await.unwrap().unwrap();
+        drop(a);
+        drop(b);
+    }
+
+    // ── test 5 ────────────────────────────────────────────────────────────
+
+    /// Design record §5: a shared lock blocks behind an exclusive lock and
+    /// unblocks when the exclusive lock is dropped.
+    #[tokio::test]
+    async fn shared_blocks_behind_exclusive() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = Arc::new(dir.path().join("sha256").join("ab").join("data"));
+
+        let exclusive = BlobGuard::acquire_exclusive((*target).clone()).await.unwrap();
+
+        let target_clone = target.clone();
+        let waiter = tokio::spawn(async move { BlobGuard::acquire_shared((*target_clone).clone()).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!waiter.is_finished(), "shared acquire must block behind exclusive");
+
+        drop(exclusive);
+        waiter
+            .await
+            .unwrap()
+            .unwrap()
+            .expect("shared guard must be Some after file exists");
+    }
+
+    // ── test 6 ────────────────────────────────────────────────────────────
+
+    /// Design record §6: a second exclusive acquire blocks behind the first
+    /// and succeeds once the first is dropped.
+    #[tokio::test]
+    async fn second_exclusive_blocks_behind_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = Arc::new(dir.path().join("sha256").join("ab").join("data"));
+
+        let first = BlobGuard::acquire_exclusive((*target).clone()).await.unwrap();
+
+        let target_clone = target.clone();
+        let waiter = tokio::spawn(async move { BlobGuard::acquire_exclusive((*target_clone).clone()).await });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !waiter.is_finished(),
+            "second exclusive acquire must block behind first"
+        );
+
+        drop(first);
+        waiter.await.unwrap().unwrap();
+    }
+
+    // ── test 7 ────────────────────────────────────────────────────────────
+
+    /// Design record §7: write_bytes truncates the file and syncs to disk.
+    /// A second write_bytes replaces the first content entirely.
+    #[tokio::test]
+    async fn write_bytes_truncates_and_syncs() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("sha256").join("ab").join("data");
+        let guard = BlobGuard::acquire_exclusive(target.clone()).await.unwrap();
+        guard.write_bytes(b"first write content").await.unwrap();
+        guard.write_bytes(b"replaced").await.unwrap();
+        drop(guard);
+        // Verify truncation: second write must have replaced first.
+        let content = std::fs::read(&target).unwrap();
+        assert_eq!(content, b"replaced", "write_bytes must truncate before writing");
+    }
+
+    // ── test 8 ────────────────────────────────────────────────────────────
+
+    /// Design record §8: write_bytes then read_bytes round-trips the content.
+    #[tokio::test]
+    async fn read_bytes_round_trips_written_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("sha256").join("ab").join("data");
+        let writer = BlobGuard::acquire_exclusive(target.clone()).await.unwrap();
+        let payload = b"manifest json content here";
+        writer.write_bytes(payload).await.unwrap();
+        drop(writer);
+
+        let reader = BlobGuard::acquire_shared(target).await.unwrap().unwrap();
+        let read_back = reader.read_bytes().await.unwrap();
+        assert_eq!(
+            read_back, payload,
+            "read_bytes must return exactly what write_bytes wrote"
+        );
+    }
+
+    // ── test 9 ────────────────────────────────────────────────────────────
+
+    /// Design record §9: after an exclusive acquire + write + drop, no sidecar
+    /// files (.lock, .tmp, .log) remain in the parent directory.
+    #[tokio::test]
+    async fn no_sidecar_lock_file_created_after_acquire_write_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("sha256").join("ab");
+        let target = parent.join("data");
+        let guard = BlobGuard::acquire_exclusive(target.clone()).await.unwrap();
+        guard.write_bytes(b"blob bytes").await.unwrap();
+        drop(guard);
+
+        let entries: Vec<String> = std::fs::read_dir(&parent)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(
+            entries,
+            vec!["data".to_string()],
+            "only the data file itself must exist; got: {entries:?}"
+        );
+    }
+
+    // ── T4 ───────────────────────────────────────────────────────────────
+    //
+    // T4 (plan review): the old "kill-9 simulation" test here targeted the
+    // wrong contract — it tested that serde_json rejects partial JSON, which
+    // is a library property not worth pinning here.  The production contract
+    // (truncated blob → LocalIndex returns None + logs warn → ChainedIndex
+    // re-fetches) is fully covered by:
+    //   `crates/ocx_lib/src/oci/index/local_index.rs`
+    //   `::get_manifest_on_truncated_blob_file_returns_none_and_logs_warn`
+    // Keeping this test would assert serde_json internals, not our API.
+    // Deleted (Option A from the review plan).
+}

--- a/crates/ocx_lib/src/oci/identifier.rs
+++ b/crates/ocx_lib/src/oci/identifier.rs
@@ -69,6 +69,7 @@ impl Identifier {
     /// If the input already contains a registry (detected by a `.` or `:` in the
     /// first path segment, or `"localhost"`), the default is ignored.
     pub fn parse_with_default_registry(s: &str, default_registry: &str) -> Result<Self, IdentifierError> {
+        validate_segments(s)?;
         parse_internal(s, default_registry)
     }
 
@@ -772,6 +773,18 @@ mod tests {
         let id = Identifier::parse_with_default_registry("myorg/cmake", "ocx.sh").unwrap();
         assert_eq!(id.registry(), "ocx.sh");
         assert_eq!(id.repository(), "myorg/cmake");
+    }
+
+    #[test]
+    fn parse_with_default_registry_rejects_dotdot_traversal() {
+        let err = Identifier::parse_with_default_registry("../evil/cmake", "ocx.sh").unwrap_err();
+        assert!(matches!(err.kind, IdentifierErrorKind::DirectoryTraversal));
+    }
+
+    #[test]
+    fn parse_with_default_registry_rejects_dotdot_segment() {
+        let err = Identifier::parse_with_default_registry("ocx.sh/../evil", "ocx.sh").unwrap_err();
+        assert!(matches!(err.kind, IdentifierErrorKind::DirectoryTraversal));
     }
 
     #[test]

--- a/crates/ocx_lib/src/oci/index.rs
+++ b/crates/ocx_lib/src/oci/index.rs
@@ -18,7 +18,29 @@ mod index_impl;
 mod local_index;
 mod remote_index;
 
+/// Routing policy for a [`ChainedIndex`](chained_index::ChainedIndex).
+///
+/// Threaded through `Index::from_chained` and on into the chained index so
+/// that callers can pick the right cache/source policy without changing the
+/// `IndexImpl` trait. The parameter is threaded end-to-end; each variant
+/// below documents its own cache/source routing behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ChainMode {
+    /// Cache-first for all lookups. Write-through on cache-miss source
+    /// fetches. Used for default (no flag) online operation.
+    Default,
+    /// Mutable lookups (tags, catalog) bypass cache and go straight to
+    /// source. Digest-addressed (immutable) lookups still use cache +
+    /// write-through. Used for `--remote`.
+    Remote,
+    /// Cache only. Source list is empty or never consulted; cache misses
+    /// return `None` from `fetch_manifest`. Used for `--offline`.
+    Offline,
+}
+
 /// The result of a platform-aware package selection.
+#[non_exhaustive]
 pub enum SelectResult {
     /// Exactly one candidate matched.
     Found(oci::Identifier),
@@ -45,12 +67,6 @@ impl Index {
         }
     }
 
-    pub fn from_local(local_index: LocalIndex) -> Self {
-        Self {
-            inner: Box::new(local_index),
-        }
-    }
-
     /// Inject an arbitrary `IndexImpl` implementation.
     ///
     /// Used exclusively in unit tests to wrap `TestIndex` fakes without
@@ -64,16 +80,13 @@ impl Index {
     /// Construct an index that reads from `cache` first, falling through to
     /// `sources` in order on miss. Successful source fetches are persisted
     /// into `cache` via `update_tag`.
-    pub fn from_chained(cache: LocalIndex, sources: Vec<Index>) -> Self {
+    ///
+    /// `mode` controls cache/source routing — see [`ChainMode`] for each
+    /// variant's behaviour.
+    pub fn from_chained(cache: LocalIndex, sources: Vec<Index>, mode: ChainMode) -> Self {
         Self {
-            inner: Box::new(chained_index::ChainedIndex::new(cache, sources)),
+            inner: Box::new(chained_index::ChainedIndex::new(cache, sources, mode)),
         }
-    }
-
-    /// Convenience: cache + single remote source. Equivalent to
-    /// `Index::from_chained(cache, vec![Index::from_remote(remote)])`.
-    pub fn from_cached_remote(cache: LocalIndex, remote: RemoteIndex) -> Self {
-        Self::from_chained(cache, vec![Index::from_remote(remote)])
     }
 
     /// List all repositories available in the given registry.

--- a/crates/ocx_lib/src/oci/index/chained_index.rs
+++ b/crates/ocx_lib/src/oci/index/chained_index.rs
@@ -1,105 +1,217 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The OCX Authors
 
+use std::time::Duration;
+
 use async_trait::async_trait;
 
-use super::{Index, LocalIndex, index_impl};
+use super::{ChainMode, Index, LocalIndex, index_impl};
+use crate::utility::singleflight;
 use crate::{Result, log, oci};
 
 /// Two-role index: a persistent `cache` plus an ordered list of read-only
 /// `sources` queried in order on cache miss.
 ///
-/// On a cache miss the chain is walked until a source successfully syncs the
-/// requested tag into `cache`, after which the cache is re-queried. Successful
-/// fetches are persisted; source errors are logged at `warn` and the chain
-/// continues. For #41 `sources` holds a single remote index, but the `Vec`
-/// shape leaves room for future N-source scenarios (CI cache, org mirror).
-pub(super) struct ChainedIndex {
+/// On a cache miss the chain is walked until a source successfully populates
+/// the cache with both the tag pointer and the full manifest chain, after
+/// which the cache is re-queried. Concurrent identical cache misses are
+/// deduplicated via [`singleflight`](crate::utility::singleflight) — only the
+/// leader task performs the fetch; waiters reuse its result.
+///
+/// `ChainMode` controls how mutable lookups (tag listings, catalog) are
+/// routed: `Default` is cache-first, `Remote` goes straight to the source
+/// for tag lookups (but digest-addressed reads still use the cache because
+/// immutable content can never be wrong), and `Offline` never consults any
+/// source — a cache miss returns `None`.
+pub struct ChainedIndex {
     cache: LocalIndex,
     sources: Vec<Index>,
+    mode: ChainMode,
+    /// Singleflight group for de-duplicating concurrent cache-miss fetches
+    /// against the same (mode, identifier) key. Shared across clones so all
+    /// `box_clone` spawned waiters converge on the same leader.
+    singleflight: singleflight::Group<String, ()>,
 }
 
+/// Max in-flight singleflight keys. Scoped per ChainedIndex instance —
+/// generous because each key maps to one package identifier under refresh.
+const SINGLEFLIGHT_MAX_KEYS: usize = 1024;
+
+/// Max time waiters block for the leader. Matches the blob-store write
+/// timeout so a stuck leader surfaces rather than stalling the CLI forever.
+const SINGLEFLIGHT_TIMEOUT: Duration = Duration::from_secs(120);
+
 impl ChainedIndex {
-    pub(super) fn new(cache: LocalIndex, sources: Vec<Index>) -> Self {
-        Self { cache, sources }
+    pub fn new(cache: LocalIndex, sources: Vec<Index>, mode: ChainMode) -> Self {
+        Self {
+            cache,
+            sources,
+            mode,
+            singleflight: singleflight::Group::new(SINGLEFLIGHT_MAX_KEYS, SINGLEFLIGHT_TIMEOUT),
+        }
     }
 
-    /// Walk the source chain for a tagged identifier, allowing the first source
-    /// that responds without error to populate the cache.
+    /// Walk the source chain for an identifier — fetch the manifest (by tag
+    /// or digest) and persist the full chain into the cache. Wrapped in a
+    /// singleflight guard so concurrent waiters share the leader's result.
     ///
-    /// Returns `Ok(())` when at least one source ran cleanly (whether it
-    /// actually persisted a tag or not — `update_tag` returning `Ok(())` is
-    /// the "no error" signal). The caller is expected to retry the cache
-    /// afterwards: a real hit yields `Some`, a clean miss yields `None` (a
-    /// legitimate not-found).
-    ///
-    /// Returns `Err(_)` only when *every* source returned an error and no
-    /// source ever ran cleanly. This preserves the trust boundary between
-    /// "package does not exist" (cache retry → `None`) and "registry outage
-    /// or auth failure" (`Err` propagated to the caller). Collapsing source
-    /// errors into `Ok(None)` would make a 401 indistinguishable from a 404
-    /// and silently break automation retry logic.
-    ///
-    /// An empty `sources` Vec returns `Ok(())` (cache-only behavior).
+    /// Returns `Ok(())` when one source successfully persisted the chain, or
+    /// `Ok(())` when no sources are configured (cache-only behaviour). Returns
+    /// `Err(_)` when every source errored — preserves the trust boundary
+    /// between "not found" (cache retry → `None`) and "registry outage".
     async fn walk_chain(&self, identifier: &oci::Identifier) -> Result<()> {
-        // Digest-only identifiers (`pkg@sha256:…`) cannot be discovered via
-        // tag fallback — bail out. For every other shape, fall back under
-        // `tag_or_latest()`, which returns the explicit tag when present and
-        // `"latest"` for bare identifiers. That keeps `ocx install cmake`
-        // behaving the same as `ocx install cmake:latest` on a fresh machine;
-        // full tag discovery stays the job of `ocx index update`.
-        if identifier.tag().is_none() && identifier.digest().is_some() {
+        if self.mode == ChainMode::Offline {
+            // Offline mode never consults sources.
             return Ok(());
         }
-        let tagged = identifier.clone_with_tag(identifier.tag_or_latest());
 
+        // Digest-only inputs are fetched directly via `GET /v2/<repo>/manifests/<digest>`
+        // and persisted without a tag commit — there is no tag to pin. Tagged
+        // inputs (or bare repos) normalise to `tag_or_latest()` so the
+        // singleflight key collapses concurrent waiters.
+        let walked = if identifier.tag().is_none() && identifier.digest().is_some() {
+            identifier.clone()
+        } else {
+            identifier.clone_with_tag(identifier.tag_or_latest())
+        };
+        let key = format!("{}|{}|{}", self.mode as u8, walked.registry(), walked);
+
+        // Singleflight: one leader fetches, concurrent waiters block on the
+        // watch channel and reuse the result. The leader's own error path
+        // returns `SourceWalkFailed(ArcError)`, preserving the full typed
+        // `crate::Error` source chain. Waiters receive the leader's failure
+        // via `singleflight::Error::Failed(SharedError)`, which we surface
+        // as `SingleflightFailed`; its `source()` walks the leader's
+        // original error chain for diagnostics, but the variant is erased
+        // to `dyn Error` at the broadcast boundary — downcasting back to
+        // `Error::SourceWalkFailed` is not possible because `SharedError`
+        // holds `Arc<dyn Error + Send + Sync>`, not a typed `crate::Error`.
+        use singleflight::Acquisition;
+        // Singleflight infrastructure failures (capacity, timeout,
+        // abandonment) are distinct from source-walk failures — keep them
+        // in their own variant so callers can distinguish coordination
+        // problems from upstream registry errors.
+        let acquisition = self
+            .singleflight
+            .try_acquire(key)
+            .await
+            .map_err(super::error::Error::SingleflightFailed)?;
+        let handle = match acquisition {
+            Acquisition::Leader(h) => h,
+            Acquisition::Resolved(()) => return Ok(()),
+        };
+
+        // Leader path: walk sources and persist on first success. On
+        // failure, wrap the leader's typed error in `ArcError` and broadcast
+        // the same `SourceWalkFailed(ArcError)` variant to waiters. The
+        // leader also propagates that wrapped variant to its caller so both
+        // ends see a consistent, typed error with the original source chain.
+        match self.fetch_and_persist_chain(&walked).await {
+            Ok(()) => {
+                handle.complete(());
+                Ok(())
+            }
+            Err(e) => {
+                let arc = crate::error::ArcError::from(e);
+                let broadcast = super::error::Error::SourceWalkFailed(arc.clone());
+                let _ = handle.fail(broadcast);
+                Err(super::error::Error::SourceWalkFailed(arc).into())
+            }
+        }
+    }
+
+    /// Leader-side chain walk: iterates sources, fetches tag digest and
+    /// manifest chain from the first success, persists both into the cache.
+    ///
+    /// Sources are tried sequentially in priority order; the first success short-circuits.
+    /// Parallel-peer fallback is intentionally not supported — peer registries are out of scope.
+    ///
+    /// Returns `Ok(())` when one source persisted the chain OR every
+    /// source returned a clean not-found with no errors. Returns
+    /// `Err(_)` when any source errored and no source succeeded — we
+    /// do not treat a later `Ok(false)` as disproving an earlier
+    /// failure.
+    async fn fetch_and_persist_chain(&self, identifier: &oci::Identifier) -> Result<()> {
         let mut last_error: Option<crate::Error> = None;
         for source in &self.sources {
-            match self.cache.update(source, &tagged).await {
-                Ok(()) => {
-                    log::debug!("Fetched tag '{}' from chained source, retrying cache lookup.", tagged);
+            match self.cache.write_chain_and_commit_tag(source, identifier).await {
+                Ok(true) => {
+                    log::debug!("Fetched '{}' from chained source, persisted to cache.", identifier);
                     return Ok(());
                 }
+                Ok(false) => {
+                    log::debug!("Source has no '{}' — trying next source.", identifier);
+                }
                 Err(e) => {
-                    // AC6: surface the underlying cause so users can distinguish
-                    // "manifest not found" vs "connection timed out" vs "401 unauthorized".
-                    log::warn!("Could not fetch tag '{}' from chained source: {e}", tagged);
+                    log::warn!("Could not fetch '{}' from chained source: {e}", identifier);
                     last_error = Some(e);
                 }
             }
         }
 
-        // Every source errored. Propagate the last error so the caller can
-        // distinguish "package not found" from "registry outage / auth failure".
-        match last_error {
-            Some(e) => Err(e),
-            None => Ok(()),
+        if let Some(e) = last_error {
+            // At least one source errored. We don't trust a later Ok(false)
+            // to disprove an earlier Err — a clean "not found" from a mirror
+            // does not contradict a transient failure on the primary.
+            return Err(e);
         }
+        // All sources either replied Ok(false) or there were no sources.
+        Ok(())
     }
 }
 
 #[async_trait]
 impl index_impl::IndexImpl for ChainedIndex {
     async fn list_repositories(&self, registry: &str) -> Result<Vec<String>> {
+        // Repositories always come from the persisted local index; no source
+        // consultation in any mode.
         self.cache.list_repositories(registry).await
     }
 
     async fn list_tags(&self, identifier: &oci::Identifier) -> Result<Option<Vec<String>>> {
+        // Tag listings route by mode. Default and Offline delegate to cache
+        // only; Remote refreshes tags from the source first (but still
+        // persists the write-through) and then reads from cache.
+        //
+        // Trust-boundary: in Remote mode, if every configured source refresh
+        // fails we propagate the last error rather than silently falling
+        // back to cached tags. `--remote` forces live lookups — collapsing a
+        // registry outage into "cached tags" would hide the real problem
+        // from the caller and break retry policy.
+        if self.mode == ChainMode::Remote && !self.sources.is_empty() {
+            let mut any_ok = false;
+            let mut last_error: Option<crate::Error> = None;
+            for source in &self.sources {
+                match self.cache.refresh_tags(identifier, source).await {
+                    Ok(()) => any_ok = true,
+                    Err(e) => {
+                        log::warn!("Remote-mode list_tags refresh failed for '{}': {e}", identifier);
+                        last_error = Some(e);
+                    }
+                }
+            }
+            if !any_ok && let Some(e) = last_error {
+                return Err(e);
+            }
+        }
         self.cache.list_tags(identifier).await
     }
 
     async fn fetch_manifest(&self, identifier: &oci::Identifier) -> Result<Option<(oci::Digest, oci::Manifest)>> {
-        // Cache read errors (e.g. a truncated tag file from a kill-9 during
-        // `TagGuard::write_disk`) must not short-circuit the chain walk —
-        // degrading to the source is the whole point of the fallback.
-        match self.cache.fetch_manifest(identifier).await {
-            Ok(Some(result)) => return Ok(Some(result)),
-            Ok(None) => {}
-            Err(e) => {
-                log::warn!(
-                    "Local tag cache read failed for '{}', falling back to chained source: {e}",
-                    identifier
-                );
+        // Digest-addressed reads are cache-first in every mode — immutable
+        // content cannot be wrong. Mutable (tag-based) reads in `Remote`
+        // mode go straight to the chain walk, skipping the cache read.
+        let is_digest_addressed = identifier.digest().is_some();
+        if is_digest_addressed || self.mode != ChainMode::Remote {
+            match self.cache.fetch_manifest(identifier).await {
+                Ok(Some(result)) => return Ok(Some(result)),
+                Ok(None) => {}
+                Err(e) => {
+                    log::warn!(
+                        "Local tag cache read failed for '{}', falling back to chained source: {e}",
+                        identifier
+                    );
+                }
             }
         }
         self.walk_chain(identifier).await?;
@@ -107,14 +219,17 @@ impl index_impl::IndexImpl for ChainedIndex {
     }
 
     async fn fetch_manifest_digest(&self, identifier: &oci::Identifier) -> Result<Option<oci::Digest>> {
-        match self.cache.fetch_manifest_digest(identifier).await {
-            Ok(Some(digest)) => return Ok(Some(digest)),
-            Ok(None) => {}
-            Err(e) => {
-                log::warn!(
-                    "Local tag cache read failed for '{}', falling back to chained source: {e}",
-                    identifier
-                );
+        let is_digest_addressed = identifier.digest().is_some();
+        if is_digest_addressed || self.mode != ChainMode::Remote {
+            match self.cache.fetch_manifest_digest(identifier).await {
+                Ok(Some(digest)) => return Ok(Some(digest)),
+                Ok(None) => {}
+                Err(e) => {
+                    log::warn!(
+                        "Local tag cache read failed for '{}', falling back to chained source: {e}",
+                        identifier
+                    );
+                }
             }
         }
         self.walk_chain(identifier).await?;
@@ -125,16 +240,505 @@ impl index_impl::IndexImpl for ChainedIndex {
         Box::new(Self {
             cache: self.cache.clone(),
             sources: self.sources.clone(),
+            mode: self.mode,
+            // Singleflight group is shared across clones so waiters coalesce.
+            singleflight: self.singleflight.clone(),
         })
+    }
+}
+
+// ── Specification tests — plan_resolution_chain_refs.md tests 22-32 ─────
+//
+// Tests 22-32: ChainMode routing, singleflight dedup, disk-persistence
+// properties.
+#[cfg(test)]
+mod chain_refs_tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+    use tempfile::TempDir;
+
+    use crate::{
+        Result,
+        file_structure::{BlobStore, TagStore},
+        oci::index::{ChainMode, Index, LocalConfig, LocalIndex, index_impl},
+        oci::{Digest, Identifier, ImageManifest, Manifest},
+    };
+
+    const REGISTRY: &str = "example.com";
+    const REPO: &str = "cmake";
+    const TAG: &str = "3.28";
+    const HEX_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HEX_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn tagged_id() -> Identifier {
+        Identifier::new_registry(REPO, REGISTRY).clone_with_tag(TAG)
+    }
+    fn digest_only_id() -> Identifier {
+        Identifier::new_registry(REPO, REGISTRY).clone_with_digest(Digest::Sha256(HEX_A.to_string()))
+    }
+    fn digest_a() -> Digest {
+        Digest::Sha256(HEX_A.to_string())
+    }
+    fn digest_b() -> Digest {
+        Digest::Sha256(HEX_B.to_string())
+    }
+    fn make_image_manifest() -> Manifest {
+        Manifest::Image(ImageManifest::default())
+    }
+
+    fn make_local_index(dir: &TempDir) -> LocalIndex {
+        LocalIndex::new(LocalConfig {
+            tag_store: TagStore::new(dir.path().join("tags")),
+            blob_store: BlobStore::new(dir.path().join("blobs")),
+        })
+    }
+
+    /// TestIndex with a call counter — records every fetch_manifest_digest call.
+    #[derive(Clone)]
+    struct CountingSource {
+        known_tags: HashMap<String, Digest>,
+        call_count: Arc<Mutex<usize>>,
+    }
+
+    impl CountingSource {
+        fn with_tag(tag: &str, d: Digest) -> Self {
+            let mut known_tags = HashMap::new();
+            known_tags.insert(tag.to_string(), d);
+            Self {
+                known_tags,
+                call_count: Arc::new(Mutex::new(0)),
+            }
+        }
+        fn calls(&self) -> usize {
+            *self.call_count.lock().unwrap()
+        }
+    }
+
+    #[async_trait]
+    impl index_impl::IndexImpl for CountingSource {
+        async fn list_repositories(&self, _: &str) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn list_tags(&self, _: &Identifier) -> Result<Option<Vec<String>>> {
+            Ok(Some(self.known_tags.keys().cloned().collect()))
+        }
+        async fn fetch_manifest(&self, identifier: &Identifier) -> Result<Option<(Digest, Manifest)>> {
+            let tag = identifier.tag_or_latest();
+            *self.call_count.lock().unwrap() += 1;
+            Ok(self.known_tags.get(tag).map(|d| (d.clone(), make_image_manifest())))
+        }
+        async fn fetch_manifest_digest(&self, identifier: &Identifier) -> Result<Option<Digest>> {
+            let tag = identifier.tag_or_latest();
+            *self.call_count.lock().unwrap() += 1;
+            Ok(self.known_tags.get(tag).cloned())
+        }
+        fn box_clone(&self) -> Box<dyn index_impl::IndexImpl> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn make_source(tag: &str, d: Digest) -> (CountingSource, Index) {
+        let src = CountingSource::with_tag(tag, d);
+        let idx = super::super::Index::from_impl(src.clone());
+        (src, idx)
+    }
+
+    /// Seed the cache with the full chain (tag pointer + manifest blob) so
+    /// subsequent cache-only reads succeed. Equivalent to what a successful
+    /// `ChainedIndex` walk would leave behind.
+    async fn seed_full(cache: &LocalIndex, identifier: &Identifier, _d: Digest, source: &Index) {
+        let persisted = cache.write_chain_and_commit_tag(source, identifier).await.unwrap();
+        assert!(persisted, "source must know the seeded tag");
+    }
+
+    // ── test 22 ───────────────────────────────────────────────────────────
+
+    /// Design record §22: in Default mode, a cache hit returns without touching
+    /// sources. Source call count must remain zero.
+    #[tokio::test]
+    async fn default_mode_cache_hit_returns_without_touching_sources() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        // Seed the cache via a temporary source.
+        let (_, seed_idx) = make_source(TAG, digest_a());
+        seed_full(&cache, &tagged_id(), digest_a(), &seed_idx).await;
+
+        // Now create a spy source and verify it is never called on cache hit.
+        let (spy, spy_idx) = make_source(TAG, digest_a());
+        let chained = Index::from_chained(cache, vec![spy_idx], ChainMode::Default);
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_some(), "cache hit must return Some");
+        assert_eq!(spy.calls(), 0, "source must not be queried on cache hit (Default mode)");
+    }
+
+    // ── test 23 ───────────────────────────────────────────────────────────
+
+    /// Design record §23: in Default mode, a cache miss walks the source,
+    /// persists the chain on disk. After the call, the blob data file exists.
+    #[tokio::test]
+    async fn default_mode_cache_miss_walks_source_and_persists_chain_on_disk() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        let blob_store = BlobStore::new(cache_dir.path().join("blobs"));
+
+        let (_, src_idx) = make_source(TAG, digest_a());
+        let chained = Index::from_chained(cache, vec![src_idx], ChainMode::Default);
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_some(), "cache-miss source fetch must return Some");
+
+        // Property: the blob data file must exist after a successful fetch.
+        let expected_blob = blob_store.data(REGISTRY, &digest_a());
+        assert!(
+            expected_blob.exists(),
+            "Default mode: blob data file must be on disk after fetch_manifest; missing: {}",
+            expected_blob.display()
+        );
+    }
+
+    // ── test 24 ───────────────────────────────────────────────────────────
+
+    /// Design record §24: in Remote mode, tag lookups bypass the cache and go
+    /// to the source, but blobs ARE still persisted on disk after the call.
+    #[tokio::test]
+    async fn remote_mode_bypasses_cache_for_tag_lookup_but_still_persists_blobs() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        let blob_store = BlobStore::new(cache_dir.path().join("blobs"));
+
+        // Seed the cache with digest_b so a Default-mode lookup would hit b.
+        let (_, seed) = make_source(TAG, digest_b());
+        seed_full(&cache, &tagged_id(), digest_b(), &seed).await;
+
+        // Source has digest_a — in Remote mode the source is consulted.
+        let (spy, src_idx) = make_source(TAG, digest_a());
+        let chained = Index::from_chained(cache, vec![src_idx], ChainMode::Remote);
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        // Remote mode must have gone to the source (digest_a != digest_b).
+        assert!(result.is_some());
+        assert!(spy.calls() > 0, "Remote mode must consult source for tag lookup");
+
+        // Blob must be persisted even under Remote mode.
+        let expected_blob = blob_store.data(REGISTRY, &digest_a());
+        assert!(
+            expected_blob.exists(),
+            "Remote mode: blob must be persisted after fetch_manifest"
+        );
+    }
+
+    // ── test 25 ───────────────────────────────────────────────────────────
+
+    /// Design record §25: in Remote mode, digest-addressed lookups use the
+    /// cache (immutable content — no reason to bypass). The source must NOT
+    /// be consulted for digest-addressed fetches.
+    #[tokio::test]
+    async fn remote_mode_digest_addressed_lookup_uses_cache() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        // Pre-write the blob data directly so cache has it.
+        // Construct a parallel BlobStore over the same root — LocalIndex.blob_store is private.
+        let blob_store = BlobStore::new(cache_dir.path().join("blobs"));
+        let blob_path = blob_store.data(REGISTRY, &digest_a());
+        std::fs::create_dir_all(blob_path.parent().unwrap()).unwrap();
+        let manifest = Manifest::Image(ImageManifest::default());
+        serde_json::to_writer(std::fs::File::create(&blob_path).unwrap(), &manifest).unwrap();
+
+        let (spy, src_idx) = make_source(TAG, digest_a());
+        let id_with_digest = digest_only_id(); // digest-addressed, no tag
+        let chained = Index::from_chained(cache, vec![src_idx], ChainMode::Remote);
+        let result = chained.fetch_manifest(&id_with_digest).await.unwrap();
+        assert!(
+            result.is_some(),
+            "digest-addressed lookup must hit cache in Remote mode"
+        );
+        assert_eq!(
+            spy.calls(),
+            0,
+            "Remote mode must NOT consult source for digest-addressed lookups"
+        );
+    }
+
+    // ── test 26 ───────────────────────────────────────────────────────────
+
+    /// Design record §26: in Offline mode, a cache miss returns None without
+    /// consulting any sources.
+    #[tokio::test]
+    async fn offline_mode_cache_miss_returns_none_without_consulting_sources() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let (spy, src_idx) = make_source(TAG, digest_a());
+        let chained = Index::from_chained(cache, vec![src_idx], ChainMode::Offline);
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_none(), "Offline mode: cache miss must return None");
+        assert_eq!(spy.calls(), 0, "Offline mode must never consult sources");
+    }
+
+    // ── test 27 ───────────────────────────────────────────────────────────
+
+    /// Design record §27: in Offline mode, a cache hit returns from disk
+    /// without consulting sources.
+    #[tokio::test]
+    async fn offline_mode_cache_hit_returns_from_disk() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        // Seed the cache via an online source.
+        let (_, seed) = make_source(TAG, digest_a());
+        seed_full(&cache, &tagged_id(), digest_a(), &seed).await;
+
+        // Now query Offline mode — must hit from disk, no source calls.
+        let (spy, src_idx) = make_source(TAG, digest_b()); // different digest
+        let chained = Index::from_chained(cache, vec![src_idx], ChainMode::Offline);
+        let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
+        assert!(result.is_some(), "Offline mode: cache hit must return Some");
+        assert_eq!(spy.calls(), 0, "Offline mode must never consult sources on hit");
+    }
+
+    // ── test 28 ───────────────────────────────────────────────────────────
+
+    /// Design record §28: singleflight deduplicates concurrent identical cache
+    /// misses — only 1 source fetch is recorded even when 4 tasks race.
+    #[tokio::test]
+    async fn singleflight_dedups_concurrent_identical_cache_miss_fetches() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let spy = CountingSource::with_tag(TAG, digest_a());
+        let spy_calls = spy.call_count.clone();
+        let src_idx = super::super::Index::from_impl(spy);
+
+        let chained = Arc::new(Index::from_chained(cache, vec![src_idx], ChainMode::Default));
+
+        // 4 concurrent tasks on the identical identifier → should produce exactly 1 source fetch.
+        let mut tasks: tokio::task::JoinSet<Result<Option<(Digest, Manifest)>>> = tokio::task::JoinSet::new();
+        for _ in 0..4 {
+            let ch = chained.clone();
+            let id = tagged_id();
+            tasks.spawn(async move { ch.fetch_manifest(&id).await });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            joined.expect("task panicked").expect("fetch_manifest failed");
+        }
+
+        let total_calls = *spy_calls.lock().unwrap();
+        assert_eq!(
+            total_calls, 1,
+            "singleflight must deduplicate: expected 1 source call, got {total_calls}"
+        );
+    }
+
+    // ── test 29 ───────────────────────────────────────────────────────────
+
+    /// Design record §29: when the source errors during a singleflight-guarded
+    /// fetch, all waiters receive the error (broadcast error propagation).
+    #[tokio::test]
+    async fn singleflight_broadcasts_source_error_to_waiters() {
+        #[derive(Clone)]
+        struct AlwaysErrorSource;
+        #[async_trait]
+        impl index_impl::IndexImpl for AlwaysErrorSource {
+            async fn list_repositories(&self, _: &str) -> Result<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn list_tags(&self, _: &Identifier) -> Result<Option<Vec<String>>> {
+                Ok(None)
+            }
+            async fn fetch_manifest(&self, _: &Identifier) -> Result<Option<(Digest, Manifest)>> {
+                Err(super::super::error::Error::RemoteManifestNotFound("test error".to_string()).into())
+            }
+            async fn fetch_manifest_digest(&self, _: &Identifier) -> Result<Option<Digest>> {
+                Err(super::super::error::Error::RemoteManifestNotFound("test error".to_string()).into())
+            }
+            fn box_clone(&self) -> Box<dyn index_impl::IndexImpl> {
+                Box::new(self.clone())
+            }
+        }
+
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        let src_idx = super::super::Index::from_impl(AlwaysErrorSource);
+        let chained = Arc::new(Index::from_chained(cache, vec![src_idx], ChainMode::Default));
+
+        let mut tasks: tokio::task::JoinSet<Result<Option<(Digest, Manifest)>>> = tokio::task::JoinSet::new();
+        for _ in 0..3 {
+            let ch = chained.clone();
+            let id = tagged_id();
+            tasks.spawn(async move { ch.fetch_manifest(&id).await });
+        }
+
+        let mut error_count = 0;
+        while let Some(joined) = tasks.join_next().await {
+            let result = joined.expect("task panicked");
+            if result.is_err() {
+                error_count += 1;
+            }
+        }
+        assert!(
+            error_count > 0,
+            "singleflight must broadcast source errors to all waiters"
+        );
+    }
+
+    // ── test 30 ───────────────────────────────────────────────────────────
+
+    /// Design record §30: list_tags respects ChainMode.
+    /// Default: uses cache only.
+    /// Remote: hits source and persists.
+    /// Offline: cache only, never consults source.
+    #[tokio::test]
+    async fn list_tags_respects_chain_mode() {
+        // --- Default: cache only ---
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        let (spy, src_idx) = make_source(TAG, digest_a());
+        let chained = Index::from_chained(cache.clone(), vec![src_idx], ChainMode::Default);
+        // Cache is empty — list_tags must return None or empty (no source call).
+        let result = chained.list_tags(&tagged_id()).await.unwrap();
+        let is_empty_or_none = result.is_none() || result.unwrap().is_empty();
+        assert!(is_empty_or_none, "Default mode list_tags must delegate to cache only");
+        assert_eq!(spy.calls(), 0, "Default mode list_tags must not consult source");
+
+        // --- Offline: same contract ---
+        let cache_dir2 = TempDir::new().unwrap();
+        let cache2 = make_local_index(&cache_dir2);
+        let (spy2, src_idx2) = make_source(TAG, digest_a());
+        let chained2 = Index::from_chained(cache2, vec![src_idx2], ChainMode::Offline);
+        let result2 = chained2.list_tags(&tagged_id()).await.unwrap();
+        let empty2 = result2.is_none() || result2.unwrap().is_empty();
+        assert!(empty2, "Offline mode list_tags must delegate to cache only");
+        assert_eq!(spy2.calls(), 0, "Offline mode list_tags must not consult source");
+    }
+
+    // ── test 31 ───────────────────────────────────────────────────────────
+
+    /// Design record §31: list_repositories respects ChainMode — in all modes,
+    /// list_repositories delegates to the cache (repos come from the persisted
+    /// local tag index, not from the source).
+    #[tokio::test]
+    async fn list_repositories_respects_chain_mode() {
+        for mode in [ChainMode::Default, ChainMode::Remote, ChainMode::Offline] {
+            let cache_dir = TempDir::new().unwrap();
+            let cache = make_local_index(&cache_dir);
+            let (spy, src_idx) = make_source(TAG, digest_a());
+            let chained = Index::from_chained(cache, vec![src_idx], mode);
+            let repos = chained.list_repositories(REGISTRY).await.unwrap();
+            assert!(
+                repos.is_empty(),
+                "{mode:?}: list_repositories must read from cache (empty on fresh index)"
+            );
+            assert_eq!(spy.calls(), 0, "{mode:?}: list_repositories must not consult source");
+        }
+    }
+
+    // ── regression: Remote-mode list_tags must propagate source errors ───
+
+    /// Remote mode must NOT silently fall back to cached tags when every
+    /// configured source errors — that would hide registry outages from
+    /// callers relying on `--remote` for live lookups.
+    #[tokio::test]
+    async fn remote_mode_list_tags_propagates_source_errors() {
+        #[derive(Clone)]
+        struct AlwaysErrorSource;
+        #[async_trait]
+        impl index_impl::IndexImpl for AlwaysErrorSource {
+            async fn list_repositories(&self, _: &str) -> Result<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn list_tags(&self, _: &Identifier) -> Result<Option<Vec<String>>> {
+                Err(super::super::error::Error::RemoteManifestNotFound("boom".to_string()).into())
+            }
+            async fn fetch_manifest(&self, _: &Identifier) -> Result<Option<(Digest, Manifest)>> {
+                Ok(None)
+            }
+            async fn fetch_manifest_digest(&self, _: &Identifier) -> Result<Option<Digest>> {
+                Err(super::super::error::Error::RemoteManifestNotFound("boom".to_string()).into())
+            }
+            fn box_clone(&self) -> Box<dyn index_impl::IndexImpl> {
+                Box::new(self.clone())
+            }
+        }
+
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        let src_idx = super::super::Index::from_impl(AlwaysErrorSource);
+        let chained = Index::from_chained(cache, vec![src_idx], ChainMode::Remote);
+        let result = chained.list_tags(&tagged_id()).await;
+        assert!(
+            result.is_err(),
+            "Remote mode must propagate source errors, not fall back to cache"
+        );
+    }
+
+    // ── test 32 ───────────────────────────────────────────────────────────
+
+    /// Design record §32: property — for any mode, after a successful
+    /// fetch_manifest returning Some((digest, _)), the blob data file must
+    /// exist on disk (digest is guaranteed on disk).
+    #[tokio::test]
+    async fn fetch_manifest_post_persist_is_guaranteed_on_disk() {
+        // Test with Default mode (the main case; Remote is covered in test 24).
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+        let blob_store = BlobStore::new(cache_dir.path().join("blobs"));
+
+        let (_, src_idx) = make_source(TAG, digest_a());
+        let chained = Index::from_chained(cache, vec![src_idx], ChainMode::Default);
+
+        if let Some((digest, _)) = chained.fetch_manifest(&tagged_id()).await.unwrap() {
+            let blob_path = blob_store.data(REGISTRY, &digest);
+            assert!(
+                blob_path.exists(),
+                "property violated: fetch_manifest returned digest {:?} but blob is not on disk at {}",
+                digest,
+                blob_path.display()
+            );
+        }
+        // If None: no blob expected, test passes trivially.
+    }
+
+    // ── T3 ────────────────────────────────────────────────────────────────
+
+    /// T3 (plan review): singleflight deduplication under high concurrency —
+    /// 8 simultaneous tasks racing on the same tagged identifier must produce
+    /// exactly 1 source call. Complements test 28 (4 tasks) with a larger
+    /// concurrency factor to stress the singleflight key computation.
+    #[tokio::test]
+    async fn singleflight_dedups_eight_concurrent_identical_cache_miss_fetches() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let spy = CountingSource::with_tag(TAG, digest_a());
+        let spy_calls = spy.call_count.clone();
+        let src_idx = super::super::Index::from_impl(spy);
+
+        let chained = Arc::new(Index::from_chained(cache, vec![src_idx], ChainMode::Default));
+
+        const N: usize = 8;
+        let mut tasks: tokio::task::JoinSet<Result<Option<(Digest, Manifest)>>> = tokio::task::JoinSet::new();
+        for _ in 0..N {
+            let ch = chained.clone();
+            let id = tagged_id();
+            tasks.spawn(async move { ch.fetch_manifest(&id).await });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            joined.expect("task panicked").expect("fetch_manifest failed");
+        }
+
+        let total_calls = *spy_calls.lock().unwrap();
+        assert_eq!(
+            total_calls, 1,
+            "singleflight must deduplicate {N} concurrent waiters to exactly 1 source call; \
+             got {total_calls}"
+        );
     }
 }
 
 // ── Specification tests ───────────────────────────────────────────────────
 //
 // Written from the design record (plan_tag_fallback.md) in specification mode.
-// These tests encode the expected ChainedIndex behaviour and MUST fail with
-// `unimplemented!()` panics against the current stub bodies.  They are the
-// executable specification that Phase 4 (implementation) must satisfy.
+// These tests encode the expected ChainedIndex behaviour.
 //
 // Test → design-record traceability:
 //   cache_hit_*           → "Tag in cache → Return immediately (no source walked)"
@@ -301,7 +905,7 @@ mod tests {
     // the same file / module), using a real `LocalIndex` as the cache and a
     // `TestIndex` wrapped in a minimal `Index` as the source.
     //
-    // The wrapper trick: `Index::from_chained(empty_local, vec![])` produces
+    // The wrapper trick: `Index::from_chained(empty_local, vec![], super::super::ChainMode::Default)` produces
     // an `Index` that always returns `None` from all methods (the ChainedIndex
     // finds nothing in the empty cache and has no sources to fall back to).
     // That `Index` is not useful as a source.
@@ -325,6 +929,13 @@ mod tests {
         super::super::Index::from_impl(t)
     }
 
+    /// Seed the cache with the full chain (tag pointer + manifest blob) so
+    /// subsequent cache-only reads succeed.
+    async fn seed_full(cache: &LocalIndex, identifier: &Identifier, _d: Digest, source: &Index) {
+        let persisted = cache.write_chain_and_commit_tag(source, identifier).await.unwrap();
+        assert!(persisted, "source must know the seeded tag");
+    }
+
     // ── Single-source chain tests ─────────────────────────────────────────
 
     // Case 1: cache hit → no source consulted.
@@ -342,16 +953,16 @@ mod tests {
         let cache_dir = TempDir::new().unwrap();
         let cache = make_local_index(&cache_dir);
 
-        // Populate the cache by running update_tag via a source that has the tag.
+        // Populate the cache with the full chain (tag + manifest blob).
         let seed_source = TestIndex::with_tag(TAG, digest_a());
         let seed_index = make_source(seed_source);
-        cache.update(&seed_index, &tagged_id()).await.unwrap();
+        seed_full(&cache, &tagged_id(), digest_a(), &seed_index).await;
 
         // Now build the ChainedIndex with a *spy* source that records calls.
         let spy = TestIndex::empty();
         let spy_calls = spy.calls.clone();
         let source = make_source(spy);
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
 
@@ -369,7 +980,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
 
@@ -385,7 +996,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained.fetch_manifest_digest(&tagged_id()).await.unwrap();
 
@@ -399,7 +1010,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::empty());
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
         assert!(result.is_none(), "unknown tag should degrade to None");
@@ -417,7 +1028,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::failing("connection timed out"));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained.fetch_manifest(&tagged_id()).await;
         assert!(
@@ -438,7 +1049,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::failing("401 unauthorized"));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained.fetch_manifest_digest(&tagged_id()).await;
         assert!(
@@ -452,47 +1063,46 @@ mod tests {
         );
     }
 
-    // Case 5: digest-only identifier → no chain walk, returns cache result (None if not cached).
+    // Case 5: digest-only identifier → walks the source chain via
+    // `GET /v2/<repo>/manifests/<digest>` and persists the blob, even though
+    // there is no tag to commit. Required for `ocx install repo@sha256:...`.
     #[tokio::test]
-    async fn digest_only_identifier_no_chain_walk() {
+    async fn digest_only_identifier_walks_chain() {
         let cache_dir = TempDir::new().unwrap();
         let cache = make_local_index(&cache_dir);
 
-        // Source has the HEX_A digest but the identifier has no tag,
-        // so the chain must NOT walk the source.
         let spy = TestIndex::with_tag(TAG, digest_a());
         let spy_calls = spy.calls.clone();
         let source = make_source(spy);
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let id = digest_only_id(); // no tag
-        let result = chained.fetch_manifest(&id).await.unwrap();
+        let _ = chained.fetch_manifest(&id).await.unwrap();
 
-        assert!(result.is_none(), "digest-only id with empty cache should return None");
         assert!(
-            spy_calls.lock().unwrap().is_empty(),
-            "source must NOT be queried for digest-only identifiers"
+            !spy_calls.lock().unwrap().is_empty(),
+            "source must be queried for digest-only identifiers — \
+             registries support GET /v2/<repo>/manifests/<digest>"
         );
     }
 
-    // Case 5b: fetch_manifest_digest with digest-only identifier.
+    // Case 5b: fetch_manifest_digest with digest-only identifier walks the chain too.
     #[tokio::test]
-    async fn digest_only_identifier_digest_query_no_chain_walk() {
+    async fn digest_only_identifier_digest_query_walks_chain() {
         let cache_dir = TempDir::new().unwrap();
         let cache = make_local_index(&cache_dir);
 
         let spy = TestIndex::with_tag(TAG, digest_a());
         let spy_calls = spy.calls.clone();
         let source = make_source(spy);
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let id = digest_only_id();
-        let result = chained.fetch_manifest_digest(&id).await.unwrap();
+        let _ = chained.fetch_manifest_digest(&id).await.unwrap();
 
-        assert!(result.is_none());
         assert!(
-            spy_calls.lock().unwrap().is_empty(),
-            "source must NOT be queried for digest-only identifiers"
+            !spy_calls.lock().unwrap().is_empty(),
+            "source must be queried for digest-only identifiers"
         );
     }
 
@@ -506,7 +1116,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::with_tag("latest", digest_a()));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let bare = Identifier::new_registry(REPO, REGISTRY);
         let result = chained.fetch_manifest(&bare).await.unwrap();
@@ -524,7 +1134,7 @@ mod tests {
 
         // Source knows about TAG (3.28) but not "latest".
         let source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let bare = Identifier::new_registry(REPO, REGISTRY);
         let result = chained.fetch_manifest(&bare).await.unwrap();
@@ -544,12 +1154,12 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::empty());
-        let original = super::super::Index::from_chained(cache.clone(), vec![source]);
+        let original = super::super::Index::from_chained(cache.clone(), vec![source], super::super::ChainMode::Default);
         let cloned = original.clone(); // calls box_clone internally
 
         // Seed the shared cache via the original by using a source that has the tag.
         let seed_source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        cache.update(&seed_source, &tagged_id()).await.unwrap();
+        seed_full(&cache, &tagged_id(), digest_a(), &seed_source).await;
 
         // The cloned index should see the tag because caches are shared via Arc.
         let result_via_clone = cloned.fetch_manifest(&tagged_id()).await.unwrap();
@@ -569,7 +1179,7 @@ mod tests {
         let spy = TestIndex::with_tag(TAG, digest_a());
         let spy_calls = spy.calls.clone();
         let source = make_source(spy);
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         // list_tags on an identifier not in the cache should return None or an
         // empty list — NOT the source's tags.
@@ -593,7 +1203,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         let source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         // Cache is empty → expect empty list.
         let repos = chained.list_repositories(REGISTRY).await.unwrap();
@@ -615,7 +1225,11 @@ mod tests {
         let second = TestIndex::empty();
         let second_calls = second.calls.clone();
 
-        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+        let chained = super::super::Index::from_chained(
+            cache,
+            vec![make_source(first), make_source(second)],
+            super::super::ChainMode::Default,
+        );
 
         let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
         assert!(result.is_some(), "first source hit should succeed");
@@ -636,7 +1250,11 @@ mod tests {
         let first = TestIndex::failing("connection refused");
         let second = TestIndex::with_tag(TAG, digest_b());
 
-        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+        let chained = super::super::Index::from_chained(
+            cache,
+            vec![make_source(first), make_source(second)],
+            super::super::ChainMode::Default,
+        );
 
         let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
         assert!(result.is_some(), "second source should succeed when first errors");
@@ -653,7 +1271,11 @@ mod tests {
         let first = TestIndex::failing("timeout");
         let second = TestIndex::with_tag(TAG, digest_b());
 
-        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+        let chained = super::super::Index::from_chained(
+            cache,
+            vec![make_source(first), make_source(second)],
+            super::super::ChainMode::Default,
+        );
 
         let result = chained.fetch_manifest_digest(&tagged_id()).await.unwrap();
         assert_eq!(result, Some(digest_b()));
@@ -672,7 +1294,11 @@ mod tests {
         let first = TestIndex::failing("network unreachable");
         let second = TestIndex::failing("503 service unavailable");
 
-        let chained = super::super::Index::from_chained(cache, vec![make_source(first), make_source(second)]);
+        let chained = super::super::Index::from_chained(
+            cache,
+            vec![make_source(first), make_source(second)],
+            super::super::ChainMode::Default,
+        );
 
         let result = chained.fetch_manifest(&tagged_id()).await;
         assert!(result.is_err(), "all-source-error must propagate as Err");
@@ -683,6 +1309,61 @@ mod tests {
         );
     }
 
+    // Case 11b: first source errors, second source returns a clean miss → the
+    // chain must NOT collapse the earlier error into `Ok(None)`. A mirror
+    // answering "not found" does not disprove an authoritative source's
+    // transient failure; callers still need the `Err` to keep retry policy honest.
+    #[tokio::test]
+    async fn fetch_and_persist_chain_propagates_error_when_later_source_misses_cleanly() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let primary = TestIndex::failing("401 unauthorized");
+        let mirror = TestIndex::empty(); // clean Ok(None)
+
+        let chained = super::super::Index::from_chained(
+            cache,
+            vec![make_source(primary), make_source(mirror)],
+            super::super::ChainMode::Default,
+        );
+
+        let result = chained.fetch_manifest(&tagged_id()).await;
+        assert!(
+            result.is_err(),
+            "error on primary followed by clean miss on mirror must propagate as Err, \
+             not collapse into Ok(None)"
+        );
+        let err_message = result.unwrap_err().to_string();
+        assert!(
+            err_message.contains("401 unauthorized"),
+            "propagated error must carry the primary source's message; got: {err_message}"
+        );
+    }
+
+    // Case 11c: same scenario for fetch_manifest_digest.
+    #[tokio::test]
+    async fn fetch_and_persist_chain_digest_propagates_error_when_later_source_misses_cleanly() {
+        let cache_dir = TempDir::new().unwrap();
+        let cache = make_local_index(&cache_dir);
+
+        let primary = TestIndex::failing("connection refused");
+        let mirror = TestIndex::empty();
+
+        let chained = super::super::Index::from_chained(
+            cache,
+            vec![make_source(primary), make_source(mirror)],
+            super::super::ChainMode::Default,
+        );
+
+        let result = chained.fetch_manifest_digest(&tagged_id()).await;
+        assert!(result.is_err(), "digest query: error-then-miss must propagate as Err");
+        let err_message = result.unwrap_err().to_string();
+        assert!(
+            err_message.contains("connection refused"),
+            "propagated error must carry the primary source's message; got: {err_message}"
+        );
+    }
+
     // Case 12: empty sources Vec → behaves like LocalIndex alone (no fallback).
     #[tokio::test]
     async fn empty_sources_behaves_like_local_index() {
@@ -690,7 +1371,7 @@ mod tests {
         let cache = make_local_index(&cache_dir);
 
         // No sources — empty chain.
-        let chained = super::super::Index::from_chained(cache, vec![]);
+        let chained = super::super::Index::from_chained(cache, vec![], super::super::ChainMode::Default);
 
         let result = chained.fetch_manifest(&tagged_id()).await.unwrap();
         assert!(result.is_none(), "empty sources and empty cache → None");
@@ -706,13 +1387,14 @@ mod tests {
         // First call: source has the tag, chain fetches and persists it.
         let source = make_source(TestIndex::with_tag(TAG, digest_a()));
         {
-            let chained = super::super::Index::from_chained(cache.clone(), vec![source]);
+            let chained =
+                super::super::Index::from_chained(cache.clone(), vec![source], super::super::ChainMode::Default);
             let _ = chained.fetch_manifest(&tagged_id()).await.unwrap();
         }
 
         // Second call: same cache, but NO sources.  Must still return the tag
         // from cache because the first call persisted it.
-        let chained_no_source = super::super::Index::from_chained(cache, vec![]);
+        let chained_no_source = super::super::Index::from_chained(cache, vec![], super::super::ChainMode::Default);
         let result = chained_no_source.fetch_manifest(&tagged_id()).await.unwrap();
         assert!(
             result.is_some(),
@@ -741,7 +1423,7 @@ mod tests {
         std::fs::write(&tag_file, b"{not valid json at all").unwrap();
 
         let source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained
             .fetch_manifest(&tagged_id())
@@ -770,7 +1452,7 @@ mod tests {
         std::fs::write(&tag_file, b"garbage").unwrap();
 
         let source = make_source(TestIndex::with_tag(TAG, digest_a()));
-        let chained = super::super::Index::from_chained(cache, vec![source]);
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
 
         let result = chained
             .fetch_manifest_digest(&tagged_id())

--- a/crates/ocx_lib/src/oci/index/error.rs
+++ b/crates/ocx_lib/src/oci/index/error.rs
@@ -16,4 +16,24 @@ pub enum Error {
         expected: crate::oci::Repository,
         found: crate::oci::Repository,
     },
+
+    /// A chained-index source walk failed. Carries the original typed error
+    /// inside an [`ArcError`] so it can be cloned for singleflight broadcast
+    /// to waiters while preserving the full error chain. The leader and
+    /// every waiter see the same underlying `crate::Error`.
+    #[error("Chained index source walk failed: {0}")]
+    SourceWalkFailed(#[source] crate::error::ArcError),
+
+    /// A singleflight coordination primitive failed (capacity exceeded,
+    /// timeout, or abandoned leader) while walking the chain. Distinct
+    /// from [`Self::SourceWalkFailed`], which reports a source-side failure.
+    #[error("Chained index singleflight failed")]
+    SingleflightFailed(#[source] crate::utility::singleflight::Error),
+
+    /// A nested image index was encountered while persisting a manifest
+    /// chain. The OCI spec does not describe an image index nested inside
+    /// another image index, so writing one would produce a corrupt cache
+    /// entry; abort the persist instead.
+    #[error("nested image index at {digest} is not a supported OCI shape")]
+    NestedImageIndex { digest: crate::oci::Digest },
 }

--- a/crates/ocx_lib/src/oci/index/local_index.rs
+++ b/crates/ocx_lib/src/oci/index/local_index.rs
@@ -4,13 +4,7 @@
 use async_trait::async_trait;
 use std::collections::HashMap;
 
-use crate::{
-    Result,
-    file_structure::{BlobStore, TagStore},
-    log, oci,
-    package::tag::Tag,
-    prelude::*,
-};
+use crate::{Result, file_structure::BlobStore, log, oci, package::tag::Tag};
 
 use super::index_impl;
 
@@ -18,210 +12,197 @@ mod cache;
 mod config;
 mod tag_guard;
 mod tag_lock;
+mod tag_manager;
 
 pub use config::Config;
 
+use tag_manager::TagManager;
+
 #[derive(Clone)]
 pub struct LocalIndex {
-    tag_store: TagStore,
+    tags: TagManager,
     blob_store: BlobStore,
     cache: cache::SharedCache,
 }
 
 impl LocalIndex {
     pub fn new(config: Config) -> Self {
+        let cache = cache::SharedCache::default();
         Self {
-            tag_store: config.tag_store,
+            tags: TagManager::new(config.tag_store, cache.clone()),
             blob_store: config.blob_store,
-            cache: cache::SharedCache::default(),
+            cache,
         }
     }
 
-    /// Syncs the local index with `index` for the given identifier.
+    /// Atomic tag refresh entry point. Delegates to [`TagManager::refresh`].
     ///
-    /// When the identifier carries a tag (e.g. `cmake:3.28`), only that tag is
-    /// refreshed — no remote tag listing. A bare identifier (`cmake`) triggers
-    /// `list_tags` to discover every tag to sync. Both paths funnel into
-    /// [`update_tags`](Self::update_tags) with a pre-computed tag set.
-    pub async fn update(&self, index: &super::Index, identifier: &oci::Identifier) -> Result<()> {
-        let tags = match identifier.tag() {
-            Some(tag) => vec![tag.to_owned()],
-            None => index.list_tags(identifier).await?.unwrap_or_default(),
-        };
-        self.update_tags(index, identifier, tags).await
+    /// Retained on `LocalIndex` so higher layers (`ChainedIndex`, tests) can
+    /// drive tag refreshes through the same facade they use for manifest
+    /// reads, without reaching into the tag-layer internals.
+    pub async fn refresh_tags(&self, identifier: &oci::Identifier, source: &super::Index) -> Result<()> {
+        self.tags.refresh(identifier, source).await
     }
 
-    /// Refreshes `tags` on `identifier` from `index` into the local tag log.
+    /// Fetches the manifest chain from `source` and, if successful, commits
+    /// the tag pointer via [`TagManager::commit`] so that subsequent cache
+    /// reads short-circuit the chain walk. Digest-only identifiers are
+    /// fully addressed by the digest itself and skip the tag commit.
     ///
-    /// Remote I/O (digest fetches and any missing manifest downloads) runs
-    /// **outside** the per-repo exclusive lock so that a slow registry cannot
-    /// stall other OCX processes touching the same repo. Only the final
-    /// read-modify-write on the tag file is serialised, and only if at least
-    /// one tag actually changed.
-    async fn update_tags(&self, index: &super::Index, identifier: &oci::Identifier, tags: Vec<String>) -> Result<()> {
-        // Seed from cache / disk to skip tags that already resolve to the
-        // same digest. Safe to be stale — the merge under the exclusive lock
-        // below is the authoritative read-modify-write.
-        let seed = self.get_tags(identifier).await?.unwrap_or_default();
-
-        let mut fetched: HashMap<String, oci::Digest> = HashMap::new();
-        for tag in tags {
-            let tagged = identifier.clone_with_tag(&tag);
-            log::info!("Updating tag '{}' for identifier '{}'.", tag, identifier);
-
-            let Some(digest) = index.fetch_manifest_digest(&tagged).await? else {
-                log::debug!("Remote has no digest for tag '{}' — skipping.", tag);
-                continue;
-            };
-
-            if seed.get(&tag) == Some(&digest) {
-                log::debug!(
-                    "Tag '{}' for identifier '{}' is up to date with digest '{}'.",
-                    tag,
-                    identifier,
-                    digest
-                );
-                continue;
-            }
-
-            let manifest_path = self.blob_store.data(tagged.registry(), &digest);
-            if !manifest_path.exists() {
-                self.update_manifest(index, &tagged, &digest).await?;
-            }
-
-            fetched.insert(tag, digest);
-        }
-
-        if fetched.is_empty() {
-            return Ok(());
-        }
-
-        // Per-repo exclusive lock guards the read-modify-write so concurrent
-        // writers in other OCX processes don't clobber each other. Existing
-        // disk-only entries are preserved; identical-tag races resolve
-        // last-writer-wins.
-        let tags_path = self.tag_store.tags(identifier);
-        let guard = tag_guard::TagGuard::acquire_exclusive(tags_path).await?;
-        let mut merged = guard.read_disk(identifier).await?;
-        merged.extend(fetched);
-        guard.write_disk(identifier, &merged).await?;
-
-        let cache = self.cache.write().await;
-        cache.set_tags(identifier.clone(), merged).await;
-
-        Ok(())
-    }
-
-    async fn update_manifest(
+    /// Returns `Ok(true)` when the chain was persisted, `Ok(false)` when
+    /// the source cleanly does not have the identifier, and `Err` on source
+    /// failure.
+    ///
+    /// The single entry point used by `ChainedIndex` on cache miss. Chain
+    /// persistence and tag commit are exposed as one atomic operation to
+    /// keep the write-through sequence inside the cache facade.
+    pub async fn write_chain_and_commit_tag(
         &self,
-        index: &super::Index,
+        source: &super::Index,
         identifier: &oci::Identifier,
-        digest: &oci::Digest,
-    ) -> Result<()> {
-        let (_, manifest) = index
-            .fetch_manifest(identifier)
-            .await?
-            .ok_or_else(|| super::error::Error::RemoteManifestNotFound(identifier.to_string()))?;
-        let path = self.blob_store.data(identifier.registry(), digest);
-        manifest.write_json(&path).await?;
+    ) -> Result<bool> {
+        // `depth = 0` at the top-level entry. Child manifests inside an
+        // image index are written inline (not via recursion) because the
+        // OCI spec does not describe a nested image index — the inline
+        // `matches!` check below rejects that shape. The `depth` parameter
+        // is defence-in-depth: if a future refactor routes child
+        // processing through this function recursively, it must pass
+        // `depth + 1`, and the guard at the top of `_inner` will catch
+        // any unsupported nesting before a corrupt cache entry is written.
+        let Some(digest) = self.persist_manifest_chain_inner(source, identifier, 0).await? else {
+            return Ok(false);
+        };
+        // Digest-only inputs have no tag to pin — the chain is fully addressed by
+        // the digest itself, so we skip the tag commit. Tag-bearing inputs (the
+        // common path from `walk_chain`'s `tag_or_latest()` normalisation) commit
+        // the tag pointer so subsequent cache reads short-circuit the chain walk.
+        if let Some(tag) = identifier.tag() {
+            self.tags.commit(identifier, tag, &digest).await?;
+        }
+        Ok(true)
+    }
+
+    async fn persist_manifest_chain_inner(
+        &self,
+        source: &super::Index,
+        identifier: &oci::Identifier,
+        depth: usize,
+    ) -> Result<Option<oci::Digest>> {
+        if depth > 1 {
+            // Any recursive call past depth 1 implies an image index nested
+            // inside another image index — not a supported OCI shape.
+            let digest = identifier
+                .digest()
+                .ok_or_else(|| super::error::Error::RemoteManifestNotFound(identifier.to_string()))?;
+            return Err(super::error::Error::NestedImageIndex { digest }.into());
+        }
+
+        let Some((digest, manifest)) = source.fetch_manifest(identifier).await? else {
+            return Ok(None);
+        };
+
+        let pinned: oci::PinnedIdentifier = identifier.clone_with_digest(digest.clone()).try_into()?;
+        write_manifest_blob(&self.blob_store, &pinned, &manifest).await?;
 
         if let oci::Manifest::ImageIndex(image_index) = manifest {
-            for manifest in image_index.manifests {
-                let digest = manifest.digest.clone().try_into()?;
-                let identifier = identifier.clone_with_digest(digest);
-                let (digest, manifest) = index
-                    .fetch_manifest(&identifier)
+            for entry in image_index.manifests {
+                let child_digest: oci::Digest = entry.digest.clone().try_into()?;
+                let child_id = identifier.clone_with_digest(child_digest.clone());
+                let (_, child_manifest) = source
+                    .fetch_manifest(&child_id)
                     .await?
-                    .ok_or_else(|| super::error::Error::RemoteManifestNotFound(identifier.to_string()))?;
-                let path = self.blob_store.data(identifier.registry(), &digest);
-                manifest.write_json(&path).await?;
+                    .ok_or_else(|| super::error::Error::RemoteManifestNotFound(child_id.to_string()))?;
+                // An image index nested inside an image index is not a
+                // supported OCI shape; writing it would produce a corrupt
+                // cache entry. Abort the persist.
+                if matches!(child_manifest, oci::Manifest::ImageIndex(_)) {
+                    return Err(super::error::Error::NestedImageIndex { digest: child_digest }.into());
+                }
+                let child_pinned: oci::PinnedIdentifier = child_id.try_into()?;
+                write_manifest_blob(&self.blob_store, &child_pinned, &child_manifest).await?;
             }
         }
 
-        Ok(())
+        Ok(Some(digest))
     }
 
     async fn get_tags(&self, identifier: &oci::Identifier) -> Result<Option<HashMap<String, oci::Digest>>> {
-        {
-            let cache = self.cache.read().await;
-            if let Some(cached) = cache.get_tags(identifier).await {
-                return Ok(Some(cached));
-            }
-        }
-
-        let tags_path = self.tag_store.tags(identifier);
-
-        // Shared (reader) lock on the tag file itself. `acquire_shared`
-        // returns `Ok(None)` when the file doesn't exist, which is how we
-        // distinguish "no tags known for this repo" from a real I/O error.
-        let Some(guard) = tag_guard::TagGuard::acquire_shared(tags_path.clone()).await? else {
-            log::debug!(
-                "Tags file '{}' not found for identifier '{}'.",
-                tags_path.display(),
-                identifier
-            );
-            return Ok(None);
-        };
-        let tags = guard.read_disk(identifier).await?;
-        drop(guard);
-
-        {
-            let cache = self.cache.write().await;
-            cache.set_tags(identifier.clone(), tags.clone()).await;
-        }
-
-        Ok(Some(tags))
+        self.tags.get(identifier).await
     }
 
     async fn get_manifest(&self, identifier: &oci::Identifier, digest: &oci::Digest) -> Result<Option<oci::Manifest>> {
-        {
-            let cache = self.cache.read().await;
-            if let Some(cached) = cache.get_manifest(identifier, digest).await {
-                log::trace!(
-                    "Manifest for identifier '{}' and digest '{}' found in cache.",
-                    identifier,
-                    digest
-                );
-                return Ok(Some(cached));
-            }
+        if let Some(cached) = self.cache.get_manifest(identifier, digest).await {
+            log::trace!(
+                "Manifest for identifier '{}' and digest '{}' found in cache.",
+                identifier,
+                digest
+            );
+            return Ok(Some(cached));
         }
 
-        let manifest_path = self.blob_store.data(identifier.registry(), digest);
-        if !manifest_path.exists() {
+        // Shared lock on the blob `data` file. Missing file → `Ok(None)`,
+        // which is the cache-miss signal ChainedIndex turns into a chain walk.
+        let pinned: oci::PinnedIdentifier = identifier.clone_with_digest(digest.clone()).try_into()?;
+        let Some(guard) = self.blob_store.acquire_read(&pinned).await? else {
             log::debug!(
                 "Manifest file not found for identifier '{}' and digest '{}'.",
                 identifier,
                 digest
             );
             return Ok(None);
-        }
+        };
 
         log::trace!(
-            "Reading manifest for identifier '{}' and digest '{}' from path '{}'.",
+            "Reading manifest for identifier '{}' and digest '{}'.",
             identifier,
-            digest,
-            manifest_path.display()
+            digest
         );
-        let manifest = oci::Manifest::read_json(manifest_path).await?;
-        {
-            log::trace!(
-                "Caching manifest for identifier '{}' and digest '{}'.",
-                identifier,
-                digest
-            );
-            let cache = self.cache.write().await;
-            cache
-                .set_manifest(identifier.clone(), digest.clone(), manifest.clone())
-                .await;
-        }
+        let bytes = guard.read_bytes().await?;
+        drop(guard);
+        let manifest: oci::Manifest = match serde_json::from_slice(&bytes) {
+            Ok(m) => m,
+            Err(e) => {
+                // Kill-9 recovery window: a truncated `data` file from a
+                // previous crash must not propagate as an error. Log at warn
+                // and treat as a cache miss so ChainedIndex can re-fetch.
+                log::warn!(
+                    "Manifest blob for '{}'@'{}' is unparseable ({e}) — treating as cache miss for recovery.",
+                    identifier,
+                    digest
+                );
+                return Ok(None);
+            }
+        };
+        log::trace!(
+            "Caching manifest for identifier '{}' and digest '{}'.",
+            identifier,
+            digest
+        );
+        self.cache
+            .set_manifest(identifier.clone(), digest.clone(), manifest.clone())
+            .await;
         Ok(Some(manifest))
     }
+}
+
+/// Writes `manifest` under an exclusive `BlobGuard` on the blob store's
+/// CAS path for `pinned`. Also writes the sibling `digest` marker file as
+/// part of `BlobStore::acquire_write`.
+async fn write_manifest_blob(
+    blob_store: &BlobStore,
+    pinned: &oci::PinnedIdentifier,
+    manifest: &oci::Manifest,
+) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(manifest)?;
+    let guard = blob_store.acquire_write(pinned).await?;
+    guard.write_bytes(&bytes).await?;
+    Ok(())
 }
 
 #[async_trait]
 impl index_impl::IndexImpl for LocalIndex {
     async fn list_repositories(&self, registry: &str) -> Result<Vec<String>> {
-        self.tag_store.list_repositories(registry).await
+        self.tags.tag_store().list_repositories(registry).await
     }
 
     async fn list_tags(&self, identifier: &oci::Identifier) -> Result<Option<Vec<String>>> {
@@ -291,11 +272,479 @@ impl index_impl::IndexImpl for LocalIndex {
     }
 
     fn box_clone(&self) -> Box<dyn index_impl::IndexImpl> {
-        Box::new(Self {
-            tag_store: self.tag_store.clone(),
-            blob_store: self.blob_store.clone(),
-            cache: self.cache.clone(),
+        Box::new(self.clone())
+    }
+}
+
+// ── Specification tests — plan_resolution_chain_refs.md tests 14-21 ─────
+//
+// Each test encodes the expected behaviour of the LocalIndex primitives
+// introduced for the resolution-chain-refs design.
+#[cfg(test)]
+mod spec_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use async_trait::async_trait;
+    use tempfile::TempDir;
+
+    use crate::file_structure::{BlobStore, TagStore};
+    use crate::oci::{ImageManifest, Manifest};
+
+    const REGISTRY: &str = "example.com";
+    const REPO: &str = "cmake";
+
+    fn make_index(dir: &TempDir) -> LocalIndex {
+        LocalIndex::new(Config {
+            tag_store: TagStore::new(dir.path().join("tags")),
+            blob_store: BlobStore::new(dir.path().join("blobs")),
         })
+    }
+
+    fn repo_id() -> oci::Identifier {
+        oci::Identifier::new_registry(REPO, REGISTRY)
+    }
+
+    fn tagged_id(tag: &str) -> oci::Identifier {
+        repo_id().clone_with_tag(tag)
+    }
+
+    fn digest(hex_char: char) -> oci::Digest {
+        oci::Digest::Sha256(hex_char.to_string().repeat(64))
+    }
+
+    /// Minimal fake IndexImpl that returns a fixed ImageManifest for any tag.
+    #[derive(Clone)]
+    struct FakeSource {
+        known_tags: HashMap<String, oci::Digest>,
+    }
+
+    impl FakeSource {
+        fn with_tag(tag: &str, d: oci::Digest) -> Self {
+            let mut known_tags = HashMap::new();
+            known_tags.insert(tag.to_string(), d);
+            Self { known_tags }
+        }
+    }
+
+    #[async_trait]
+    impl super::super::index_impl::IndexImpl for FakeSource {
+        async fn list_repositories(&self, _: &str) -> crate::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn list_tags(&self, _: &oci::Identifier) -> crate::Result<Option<Vec<String>>> {
+            Ok(Some(self.known_tags.keys().cloned().collect()))
+        }
+        async fn fetch_manifest(&self, identifier: &oci::Identifier) -> crate::Result<Option<(oci::Digest, Manifest)>> {
+            let tag = identifier.tag_or_latest();
+            Ok(self
+                .known_tags
+                .get(tag)
+                .map(|d| (d.clone(), Manifest::Image(ImageManifest::default()))))
+        }
+        async fn fetch_manifest_digest(&self, identifier: &oci::Identifier) -> crate::Result<Option<oci::Digest>> {
+            Ok(self.known_tags.get(identifier.tag_or_latest()).cloned())
+        }
+        fn box_clone(&self) -> Box<dyn super::super::index_impl::IndexImpl> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn make_source(tag: &str, d: oci::Digest) -> super::super::Index {
+        super::super::Index::from_impl(FakeSource::with_tag(tag, d))
+    }
+
+    /// Fake source that knows a configurable set of tags, each resolving to
+    /// a fixed `ImageManifest` blob. Multi-tag variant of `FakeSource`.
+    #[derive(Clone)]
+    struct MultiTagSource {
+        known: HashMap<String, oci::Digest>,
+    }
+
+    #[async_trait]
+    impl super::super::index_impl::IndexImpl for MultiTagSource {
+        async fn list_repositories(&self, _: &str) -> crate::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn list_tags(&self, _: &oci::Identifier) -> crate::Result<Option<Vec<String>>> {
+            Ok(Some(self.known.keys().cloned().collect()))
+        }
+        async fn fetch_manifest(&self, identifier: &oci::Identifier) -> crate::Result<Option<(oci::Digest, Manifest)>> {
+            let tag = identifier.tag_or_latest();
+            Ok(self
+                .known
+                .get(tag)
+                .map(|d| (d.clone(), Manifest::Image(ImageManifest::default()))))
+        }
+        async fn fetch_manifest_digest(&self, identifier: &oci::Identifier) -> crate::Result<Option<oci::Digest>> {
+            Ok(self.known.get(identifier.tag_or_latest()).cloned())
+        }
+        fn box_clone(&self) -> Box<dyn super::super::index_impl::IndexImpl> {
+            Box::new(self.clone())
+        }
+    }
+
+    fn source_with(tags: &[(&str, oci::Digest)]) -> super::super::Index {
+        let mut known = HashMap::new();
+        for (t, d) in tags {
+            known.insert((*t).to_string(), d.clone());
+        }
+        super::super::Index::from_impl(MultiTagSource { known })
+    }
+
+    /// Helper: seed an existing tag on disk by routing through `refresh_tags`
+    /// against a single-tag source. Uses the same entry point the rest of
+    /// the suite exercises, so the test reflects the real write path.
+    async fn seed_tag(index: &LocalIndex, id: &oci::Identifier, tag: &str, d: oci::Digest) {
+        let tagged = id.clone_with_tag(tag);
+        let source = make_source(tag, d);
+        index.refresh_tags(&tagged, &source).await.unwrap();
+    }
+
+    // ── refresh_tags: merge with existing disk entries ───────────────────
+
+    /// Design record (rev §4 of plan_resolution_chain_refs.md):
+    /// `refresh_tags` merges the source's tag set with any existing on-disk
+    /// entries, preserving tags that the source does not report.
+    #[tokio::test]
+    async fn refresh_tags_merges_new_tags_with_existing_disk_entries() {
+        let dir = TempDir::new().unwrap();
+        let index = make_index(&dir);
+        let id = repo_id();
+
+        // Seed an initial tag via refresh_tags itself.
+        seed_tag(&index, &id, "1.0", digest('a')).await;
+
+        // Refresh a different tag from a fresh source.
+        let second = source_with(&[("2.0", digest('b'))]);
+        index.refresh_tags(&id.clone_with_tag("2.0"), &second).await.unwrap();
+
+        let fresh = make_index(&dir);
+        let tags = fresh.get_tags(&id).await.unwrap().unwrap();
+        assert!(tags.contains_key("1.0"), "tag 1.0 must survive the merge");
+        assert!(tags.contains_key("2.0"), "tag 2.0 must be present after merge");
+    }
+
+    // ── refresh_tags: non-destructive for tags not in source ─────────────
+
+    /// `refresh_tags` must preserve tags present on disk that the source
+    /// does not report for the requested identifier.
+    #[tokio::test]
+    async fn refresh_tags_preserves_tags_not_in_source() {
+        let dir = TempDir::new().unwrap();
+        let index = make_index(&dir);
+        let id = repo_id();
+
+        seed_tag(&index, &id, "existing", digest('e')).await;
+
+        // Refresh a different tag — the source never mentions "existing".
+        // (Use hex char 'f' for the digest — 'n' is not a valid hex digit and
+        // would fail deserialization.)
+        let source = source_with(&[("new-tag", digest('f'))]);
+        index
+            .refresh_tags(&id.clone_with_tag("new-tag"), &source)
+            .await
+            .unwrap();
+
+        let fresh = make_index(&dir);
+        let tags = fresh.get_tags(&id).await.unwrap().unwrap();
+        assert!(
+            tags.contains_key("existing"),
+            "pre-existing tag must be preserved by refresh_tags non-destructive merge"
+        );
+    }
+
+    // ── refresh_tags: concurrent callers visible on disk ─────────────────
+
+    /// Eight concurrent `refresh_tags` callers on different tags all land
+    /// on disk — proves the atomic tag-writer serialises correctly.
+    #[tokio::test]
+    async fn refresh_tags_concurrent_callers_both_visible_on_disk() {
+        let dir = TempDir::new().unwrap();
+        let index = make_index(&dir);
+        let id = repo_id();
+
+        let mut tasks: tokio::task::JoinSet<crate::Result<()>> = tokio::task::JoinSet::new();
+        for i in 0u8..8 {
+            let idx = index.clone();
+            let ident = id.clone();
+            tasks.spawn(async move {
+                let tag = format!("v{i}");
+                let d = oci::Digest::Sha256(format!("{i:0>64}"));
+                let source = source_with(&[(&tag, d)]);
+                idx.refresh_tags(&ident.clone_with_tag(&tag), &source).await
+            });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            joined.expect("task panicked").expect("refresh_tags failed");
+        }
+
+        let fresh = make_index(&dir);
+        let tags = fresh.get_tags(&id).await.unwrap().unwrap();
+        assert_eq!(tags.len(), 8, "all 8 concurrent writers' entries must be on disk");
+    }
+
+    // ── ChainedIndex cache-miss persistence: image manifest ──────────────
+
+    /// `ChainedIndex::fetch_manifest` on a cache miss must persist the
+    /// fetched image manifest blob at the expected CAS path.
+    #[tokio::test]
+    async fn chained_fetch_manifest_persists_image_blob_at_expected_cas_path() {
+        let dir = TempDir::new().unwrap();
+        let cache = make_index(&dir);
+        let d = digest('a');
+        let source = make_source("3.28", d.clone());
+        let id = tagged_id("3.28");
+
+        let cache_clone = cache.clone();
+        let chained = super::super::Index::from_chained(cache_clone, vec![source], super::super::ChainMode::Default);
+        let _ = chained.fetch_manifest(&id).await.unwrap();
+
+        let expected = cache.blob_store.data(REGISTRY, &d);
+        assert!(
+            expected.exists(),
+            "chained fetch_manifest must persist the blob at {}",
+            expected.display()
+        );
+    }
+
+    // ── ChainedIndex cache-miss persistence: digest-only input ───────────
+
+    /// Regression for the digest-only `walk_chain` short-circuit. A digest-
+    /// pinned identifier must walk the source chain via
+    /// `GET /v2/<repo>/manifests/<digest>` and persist the blob into the
+    /// cache — no tag commit, but the data file must exist after the fetch.
+    #[tokio::test]
+    async fn chained_fetch_manifest_persists_blob_for_digest_only_identifier() {
+        let dir = TempDir::new().unwrap();
+        let cache = make_index(&dir);
+        let d = digest('a');
+
+        // Source serves the manifest by digest, ignoring the tag slot.
+        #[derive(Clone)]
+        struct DigestOnlySource {
+            d: oci::Digest,
+        }
+        #[async_trait]
+        impl super::super::index_impl::IndexImpl for DigestOnlySource {
+            async fn list_repositories(&self, _: &str) -> crate::Result<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn list_tags(&self, _: &oci::Identifier) -> crate::Result<Option<Vec<String>>> {
+                Ok(None)
+            }
+            async fn fetch_manifest(&self, _: &oci::Identifier) -> crate::Result<Option<(oci::Digest, Manifest)>> {
+                Ok(Some((self.d.clone(), Manifest::Image(ImageManifest::default()))))
+            }
+            async fn fetch_manifest_digest(&self, _: &oci::Identifier) -> crate::Result<Option<oci::Digest>> {
+                Ok(Some(self.d.clone()))
+            }
+            fn box_clone(&self) -> Box<dyn super::super::index_impl::IndexImpl> {
+                Box::new(self.clone())
+            }
+        }
+
+        let source = super::super::Index::from_impl(DigestOnlySource { d: d.clone() });
+        let id = repo_id().clone_with_digest(d.clone());
+
+        let cache_clone = cache.clone();
+        let chained = super::super::Index::from_chained(cache_clone, vec![source], super::super::ChainMode::Default);
+        let result = chained.fetch_manifest(&id).await.unwrap();
+        assert!(
+            result.is_some(),
+            "digest-only fetch_manifest must walk the chain and return Some"
+        );
+
+        let expected = cache.blob_store.data(REGISTRY, &d);
+        assert!(
+            expected.exists(),
+            "digest-only walk_chain must persist the blob at {}",
+            expected.display()
+        );
+    }
+
+    // ── ChainedIndex cache-miss persistence: image-index recursion ───────
+
+    /// `ChainedIndex::fetch_manifest` must write both the top-level image
+    /// index blob and every child manifest blob when the resolved identifier
+    /// points at an image index.
+    #[tokio::test]
+    async fn chained_fetch_manifest_recurses_for_image_index_children() {
+        let dir = TempDir::new().unwrap();
+        let cache = make_index(&dir);
+
+        let child_digest = oci::Digest::Sha256('b'.to_string().repeat(64));
+        let parent_digest = digest('a');
+        let child_digest_str = format!("sha256:{}", 'b'.to_string().repeat(64));
+
+        #[derive(Clone)]
+        struct ImageIndexSource {
+            parent: oci::Digest,
+            child: oci::Digest,
+            child_digest_str: String,
+        }
+        #[async_trait]
+        impl super::super::index_impl::IndexImpl for ImageIndexSource {
+            async fn list_repositories(&self, _: &str) -> crate::Result<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn list_tags(&self, _: &oci::Identifier) -> crate::Result<Option<Vec<String>>> {
+                Ok(None)
+            }
+            async fn fetch_manifest(
+                &self,
+                identifier: &oci::Identifier,
+            ) -> crate::Result<Option<(oci::Digest, Manifest)>> {
+                // Tag-only lookups (no digest) return the parent image index;
+                // digest-bearing lookups (child recursion) return a leaf image
+                // manifest. `clone_with_digest` preserves the tag, so we key
+                // on the digest slot, not the tag slot.
+                if identifier.digest().is_none() {
+                    let idx = oci::Manifest::ImageIndex(oci::ImageIndex {
+                        schema_version: 2,
+                        media_type: Some("application/vnd.oci.image.index.v1+json".to_string()),
+                        manifests: vec![oci::ImageIndexEntry {
+                            media_type: "application/vnd.oci.image.manifest.v1+json".to_string(),
+                            digest: self.child_digest_str.clone(),
+                            size: 1,
+                            platform: None,
+                            annotations: None,
+                        }],
+                        artifact_type: None,
+                        annotations: None,
+                    });
+                    Ok(Some((self.parent.clone(), idx)))
+                } else {
+                    Ok(Some((self.child.clone(), Manifest::Image(ImageManifest::default()))))
+                }
+            }
+            async fn fetch_manifest_digest(&self, _: &oci::Identifier) -> crate::Result<Option<oci::Digest>> {
+                Ok(Some(self.parent.clone()))
+            }
+            fn box_clone(&self) -> Box<dyn super::super::index_impl::IndexImpl> {
+                Box::new(self.clone())
+            }
+        }
+
+        let source = super::super::Index::from_impl(ImageIndexSource {
+            parent: parent_digest.clone(),
+            child: child_digest.clone(),
+            child_digest_str,
+        });
+        let id = tagged_id("3.28");
+
+        let cache_clone = cache.clone();
+        let chained = super::super::Index::from_chained(cache_clone, vec![source], super::super::ChainMode::Default);
+        let _ = chained.fetch_manifest(&id).await.unwrap();
+
+        let parent_path = cache.blob_store.data(REGISTRY, &parent_digest);
+        let child_path = cache.blob_store.data(REGISTRY, &child_digest);
+        assert!(
+            parent_path.exists(),
+            "parent index blob must exist at {}",
+            parent_path.display()
+        );
+        assert!(
+            child_path.exists(),
+            "child manifest blob must exist at {}",
+            child_path.display()
+        );
+    }
+
+    // ── ChainedIndex cache-miss persistence: sibling digest marker ───────
+
+    /// Every blob `ChainedIndex::fetch_manifest` persists on a cache miss
+    /// is accompanied by a sibling `digest` marker file.
+    #[tokio::test]
+    async fn chained_fetch_manifest_writes_sibling_digest_marker_for_every_blob() {
+        let dir = TempDir::new().unwrap();
+        let cache = make_index(&dir);
+        let d = digest('c');
+        let source = make_source("3.28", d.clone());
+        let id = tagged_id("3.28");
+
+        let cache_clone = cache.clone();
+        let chained = super::super::Index::from_chained(cache_clone, vec![source], super::super::ChainMode::Default);
+        let _ = chained.fetch_manifest(&id).await.unwrap();
+
+        let digest_file = cache.blob_store.digest_file(REGISTRY, &d);
+        assert!(
+            digest_file.exists(),
+            "sibling digest marker must be written alongside data; missing: {}",
+            digest_file.display()
+        );
+    }
+
+    // ── test 20 ───────────────────────────────────────────────────────────
+
+    /// Design record §20: get_manifest on a truncated blob data file returns
+    /// None (log warn, treat as cache miss for graceful recovery).
+    ///
+    /// This verifies the Phase E.3 requirement: BlobStore::acquire_read
+    /// wrapping + graceful parse-failure recovery in get_manifest.
+    #[tokio::test]
+    async fn get_manifest_on_truncated_blob_file_returns_none_and_logs_warn() {
+        let dir = TempDir::new().unwrap();
+        let index = make_index(&dir);
+        let d = digest('d');
+        // Write partial/corrupt JSON directly to the blob data path.
+        let data_path = index.blob_store.data(REGISTRY, &d);
+        std::fs::create_dir_all(data_path.parent().unwrap()).unwrap();
+        std::fs::write(&data_path, b"{\"schemaVersion\":2,\"broken\"").unwrap();
+
+        // get_manifest must return Ok(None) — not an error — for corrupt data.
+        let id = tagged_id("3.28");
+        let result = index.get_manifest(&id, &d).await.unwrap();
+        assert!(
+            result.is_none(),
+            "get_manifest on a truncated blob file must return Ok(None), not Err"
+        );
+    }
+
+    // ── latent-bug fix (integration via ChainedIndex) ────────────────────
+
+    /// The latent-bug fix. A tag file is present on disk pointing at digest
+    /// D, but D's blob file is missing. `fetch_manifest` via a `ChainedIndex`
+    /// must re-populate the blob on cache miss and return `Some` — not loop
+    /// forever or return `None`.
+    ///
+    /// This is an integration-style test because it exercises the full path:
+    /// `LocalIndex::fetch_manifest` sees cache-miss on the blob → `ChainedIndex`
+    /// walks the source → write-through persists it → re-read succeeds.
+    #[tokio::test]
+    async fn latent_bug_fix_missing_manifest_triggers_refetch_via_chain() {
+        let dir = TempDir::new().unwrap();
+        let cache = make_index(&dir);
+
+        // Step 1: seed a tag file pointing at digest 'd' via refresh_tags.
+        let d = digest('d');
+        let id = tagged_id("3.28");
+        seed_tag(&cache, &id, "3.28", d.clone()).await;
+
+        // Step 2: nuke the blob data file — simulate it being missing while
+        // the tag pointer remains on disk. (refresh_tags' side-effect of
+        // persisting the manifest blob is what we're explicitly undoing.)
+        let blob_path = cache.blob_store.data(REGISTRY, &d);
+        if blob_path.exists() {
+            std::fs::remove_file(&blob_path).unwrap();
+        }
+        assert!(!blob_path.exists(), "prerequisite: blob file must be absent");
+
+        // Step 3: construct a ChainedIndex with a source that can serve the manifest.
+        let source = make_source("3.28", d.clone());
+        let chained = super::super::Index::from_chained(cache, vec![source], super::super::ChainMode::Default);
+
+        // Step 4: fetch_manifest must re-fetch and return Some.
+        let result = chained.fetch_manifest(&id).await.unwrap();
+        assert!(
+            result.is_some(),
+            "latent-bug fix: fetch_manifest with tag cached but blob missing must re-fetch and return Some"
+        );
+        let (returned_digest, _) = result.unwrap();
+        assert_eq!(
+            returned_digest, d,
+            "returned digest must match the expected blob digest"
+        );
     }
 }
 
@@ -401,7 +850,7 @@ mod concurrency_tests {
             let digest = hex_digest_n((i as u8) % 16);
             let source = super::super::Index::from_impl(TestIndex::with_tag(&tag, digest));
             let id = repo_id().clone_with_tag(&tag);
-            set.spawn(async move { index.update(&source, &id).await });
+            set.spawn(async move { index.refresh_tags(&id, &source).await });
         }
         while let Some(joined) = set.join_next().await {
             joined.expect("task panicked").expect("update failed");
@@ -434,7 +883,7 @@ mod concurrency_tests {
             let digest = hex_digest_n((i as u8) % 16);
             let source = super::super::Index::from_impl(TestIndex::with_tag(&tag, digest));
             let id = repo_id().clone_with_tag(&tag);
-            set.spawn(async move { index.update(&source, &id).await });
+            set.spawn(async move { index.refresh_tags(&id, &source).await });
         }
         while let Some(joined) = set.join_next().await {
             joined.expect("task panicked").expect("update failed");

--- a/crates/ocx_lib/src/oci/index/local_index/cache.rs
+++ b/crates/ocx_lib/src/oci/index/local_index/cache.rs
@@ -37,4 +37,15 @@ impl Cache {
     }
 }
 
-pub type SharedCache = std::sync::Arc<tokio::sync::RwLock<Cache>>;
+/// Shared handle to the in-memory index cache.
+///
+/// The inner fields of [`Cache`] are each independently guarded by a
+/// `tokio::sync::RwLock`, so the outer handle is a plain `Arc<Cache>` —
+/// no outer lock. A previous revision wrapped this in an outer `RwLock`,
+/// which caused writers to hold the outer write-guard across the inner
+/// `.await` in `set_tags` / `set_manifest`. Tokio locks allow this in
+/// principle but it blocks every other reader for the entire suspension
+/// window. Moving to `Arc<Cache>` eliminates the contention at the type
+/// level — readers and writers only contend on the specific sub-map they
+/// touch, and no guard is ever held across an `.await` on a foreign lock.
+pub type SharedCache = std::sync::Arc<Cache>;

--- a/crates/ocx_lib/src/oci/index/local_index/tag_lock.rs
+++ b/crates/ocx_lib/src/oci/index/local_index/tag_lock.rs
@@ -30,14 +30,14 @@ pub(crate) enum Version {
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct TagLock {
-    pub version: Version,
-    pub repository: oci::Repository,
-    pub tags: HashMap<String, oci::Digest>,
+    pub(crate) version: Version,
+    pub(crate) repository: oci::Repository,
+    pub(crate) tags: HashMap<String, oci::Digest>,
 }
 
 impl TagLock {
     /// Creates a new tag lock from an identifier and its tags.
-    pub fn new(identifier: &oci::Identifier, tags: HashMap<String, oci::Digest>) -> Self {
+    pub(crate) fn new(identifier: &oci::Identifier, tags: HashMap<String, oci::Digest>) -> Self {
         Self {
             version: Version::V1,
             repository: oci::Repository::from(identifier),
@@ -46,7 +46,11 @@ impl TagLock {
     }
 
     /// Validates the repository, then returns the inner tags map.
-    pub fn into_tags(self, expected: &oci::Identifier, path: &Path) -> crate::Result<HashMap<String, oci::Digest>> {
+    pub(crate) fn into_tags(
+        self,
+        expected: &oci::Identifier,
+        path: &Path,
+    ) -> crate::Result<HashMap<String, oci::Digest>> {
         let expected_repo = oci::Repository::from(expected);
         if self.repository != expected_repo {
             return Err(super::super::error::Error::TagLockRepositoryMismatch {

--- a/crates/ocx_lib/src/oci/index/local_index/tag_manager.rs
+++ b/crates/ocx_lib/src/oci/index/local_index/tag_manager.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The OCX Authors
+
+use std::collections::HashMap;
+
+use crate::{Result, file_structure::TagStore, log, oci};
+
+use super::{cache, tag_guard::TagGuard};
+
+/// Self-contained manager for the local tag store.
+///
+/// Owns the disk tag files, the per-repo exclusive lock discipline, and the
+/// in-memory tag cache. Exposes a small interface — `refresh`, `commit`,
+/// `get` — that captures the legitimate tag-layer operations without leaking
+/// the raw lock/merge machinery to `LocalIndex` or higher layers.
+#[derive(Clone)]
+pub struct TagManager {
+    tag_store: TagStore,
+    cache: cache::SharedCache,
+}
+
+impl TagManager {
+    pub fn new(tag_store: TagStore, cache: cache::SharedCache) -> Self {
+        Self { tag_store, cache }
+    }
+
+    /// Returns the underlying tag store. Used by `LocalIndex` for
+    /// repository enumeration, which is a store-level operation unrelated
+    /// to tag read/write.
+    pub fn tag_store(&self) -> &TagStore {
+        &self.tag_store
+    }
+
+    /// Atomic tag refresh entry point. Fetches the requested tag set from
+    /// `source` and writes it into the on-disk tag file under an exclusive
+    /// `TagGuard`, merging non-destructively with any existing entries.
+    ///
+    /// A tagged identifier (e.g. `cmake:3.28`) refreshes only that tag. A
+    /// bare identifier (`cmake`) first calls `list_tags` on the source to
+    /// discover every tag to sync. Either path funnels into the same atomic
+    /// read-modify-write on the on-disk tag file.
+    ///
+    /// This method does NOT short-circuit when a tag's seed digest matches
+    /// the source — the downstream correctness invariant ("tag cached AND
+    /// manifest on disk") is enforced by `ChainedIndex`'s walk path, not
+    /// here. `refresh` is strictly about tag pointers; manifest persistence
+    /// is a separate concern.
+    pub async fn refresh(&self, identifier: &oci::Identifier, source: &super::super::Index) -> Result<()> {
+        let tags = match identifier.tag() {
+            Some(tag) => vec![tag.to_owned()],
+            None => source.list_tags(identifier).await?.unwrap_or_default(),
+        };
+
+        let mut fetched: HashMap<String, oci::Digest> = HashMap::new();
+        for tag in tags {
+            let tagged = identifier.clone_with_tag(&tag);
+            log::info!("Refreshing tag '{}' for identifier '{}'.", tag, identifier);
+            let Some(digest) = source.fetch_manifest_digest(&tagged).await? else {
+                log::debug!("Source has no digest for tag '{}' — skipping.", tag);
+                continue;
+            };
+            fetched.insert(tag, digest);
+        }
+
+        if fetched.is_empty() {
+            return Ok(());
+        }
+
+        let merged = self.merge_under_lock(identifier, fetched).await?;
+        self.publish_to_cache(identifier.clone(), merged).await;
+        Ok(())
+    }
+
+    /// Pins a single `(tag, digest)` pair. Used by `ChainedIndex::walk_chain`
+    /// to record the tag pointer once the resolution chain has been
+    /// persisted to the blob store. Equivalent to `refresh` with a
+    /// pre-fetched digest — no source round-trip.
+    pub async fn commit(&self, identifier: &oci::Identifier, tag: &str, digest: &oci::Digest) -> Result<()> {
+        let mut fetched = HashMap::new();
+        fetched.insert(tag.to_owned(), digest.clone());
+        let merged = self.merge_under_lock(identifier, fetched).await?;
+        self.publish_to_cache(identifier.clone(), merged).await;
+        Ok(())
+    }
+
+    /// Reads the tag map for `identifier`, consulting the in-memory cache
+    /// first and falling back to the on-disk tag file under a shared lock.
+    /// Returns `Ok(None)` when no tag file exists for the repository.
+    pub async fn get(&self, identifier: &oci::Identifier) -> Result<Option<HashMap<String, oci::Digest>>> {
+        if let Some(cached) = self.cache.get_tags(identifier).await {
+            return Ok(Some(cached));
+        }
+
+        let tags_path = self.tag_store.tags(identifier);
+
+        // Shared (reader) lock on the tag file itself. `acquire_shared`
+        // returns `Ok(None)` when the file doesn't exist, which is how we
+        // distinguish "no tags known for this repo" from a real I/O error.
+        let Some(guard) = TagGuard::acquire_shared(tags_path.clone()).await? else {
+            log::debug!(
+                "Tags file '{}' not found for identifier '{}'.",
+                tags_path.display(),
+                identifier
+            );
+            return Ok(None);
+        };
+        let tags = guard.read_disk(identifier).await?;
+        drop(guard);
+
+        self.publish_to_cache(identifier.clone(), tags.clone()).await;
+        Ok(Some(tags))
+    }
+
+    /// Acquires the per-repo exclusive lock, merges `fetched` into the
+    /// current on-disk map, and writes the result back under the same lock.
+    /// Returns the merged map so callers can publish it to the in-memory
+    /// cache without a second read.
+    async fn merge_under_lock(
+        &self,
+        identifier: &oci::Identifier,
+        fetched: HashMap<String, oci::Digest>,
+    ) -> Result<HashMap<String, oci::Digest>> {
+        // Per-repo exclusive lock guards the read-modify-write so concurrent
+        // writers in other OCX processes don't clobber each other. Existing
+        // disk-only entries are preserved; identical-tag races resolve
+        // last-writer-wins.
+        let tags_path = self.tag_store.tags(identifier);
+        let guard = TagGuard::acquire_exclusive(tags_path).await?;
+        let mut merged = guard.read_disk(identifier).await?;
+        merged.extend(fetched);
+        guard.write_disk(identifier, &merged).await?;
+        drop(guard);
+        Ok(merged)
+    }
+
+    async fn publish_to_cache(&self, identifier: oci::Identifier, tags: HashMap<String, oci::Digest>) {
+        self.cache.set_tags(identifier, tags).await;
+    }
+}

--- a/crates/ocx_lib/src/oci/index/remote_index.rs
+++ b/crates/ocx_lib/src/oci/index/remote_index.rs
@@ -29,29 +29,20 @@ impl Index {
 #[async_trait]
 impl index_impl::IndexImpl for Index {
     async fn list_repositories(&self, registry: &str) -> Result<Vec<String>> {
-        {
-            let cache = self.cache.read().await;
-            if let Some(cached) = cache.get_repositories(registry).await {
-                return Ok(cached);
-            }
+        if let Some(cached) = self.cache.get_repositories(registry).await {
+            return Ok(cached);
         }
 
         let repositories = self.client.list_repositories(registry).await?;
-
-        {
-            let cache = self.cache.write().await;
-            cache.set_repositories(registry.to_string(), repositories.clone()).await;
-        }
-
+        self.cache
+            .set_repositories(registry.to_string(), repositories.clone())
+            .await;
         Ok(repositories)
     }
 
     async fn list_tags(&self, identifier: &oci::Identifier) -> Result<Option<Vec<String>>> {
-        {
-            let cache = self.cache.read().await;
-            if let Some(cached) = cache.get_tags(identifier).await {
-                return Ok(Some(cached));
-            }
+        if let Some(cached) = self.cache.get_tags(identifier).await {
+            return Ok(Some(cached));
         }
 
         let tags: Vec<String> = self
@@ -62,11 +53,7 @@ impl index_impl::IndexImpl for Index {
             .filter(|t| !Tag::is_internal_str(t))
             .collect();
 
-        {
-            let cache = self.cache.write().await;
-            cache.set_tags(identifier.clone(), tags.clone()).await;
-        }
-
+        self.cache.set_tags(identifier.clone(), tags.clone()).await;
         Ok(Some(tags))
     }
 
@@ -75,19 +62,12 @@ impl index_impl::IndexImpl for Index {
     }
 
     async fn fetch_manifest_digest(&self, identifier: &oci::Identifier) -> Result<Option<oci::Digest>> {
-        {
-            let cache = self.cache.read().await;
-            if let Some(cached) = cache.get_tag_digest(identifier).await {
-                return Ok(Some(cached));
-            }
+        if let Some(cached) = self.cache.get_tag_digest(identifier).await {
+            return Ok(Some(cached));
         }
 
         let digest = self.client.fetch_manifest_digest(identifier).await?;
-        {
-            let cache = self.cache.write().await;
-            cache.set_tag_digest(identifier, digest.clone()).await;
-        }
-
+        self.cache.set_tag_digest(identifier, digest.clone()).await;
         Ok(Some(digest))
     }
 

--- a/crates/ocx_lib/src/oci/index/remote_index/cache.rs
+++ b/crates/ocx_lib/src/oci/index/remote_index/cache.rs
@@ -42,4 +42,8 @@ impl Cache {
     }
 }
 
-pub type SharedCache = std::sync::Arc<tokio::sync::RwLock<Cache>>;
+/// Shared handle to the in-memory remote index cache.
+///
+/// Inner fields are independently locked — see
+/// [`super::super::local_index::cache::SharedCache`] for the rationale.
+pub type SharedCache = std::sync::Arc<Cache>;

--- a/crates/ocx_lib/src/package_manager/error.rs
+++ b/crates/ocx_lib/src/package_manager/error.rs
@@ -14,13 +14,20 @@ use crate::{file_structure, oci};
 #[non_exhaustive]
 pub enum Error {
     /// A find operation failed for one or more packages.
+    #[error("{}", format_batch("find", _0))]
     FindFailed(Vec<PackageError>),
     /// An install operation failed for one or more packages.
+    #[error("{}", format_batch("install", _0))]
     InstallFailed(Vec<PackageError>),
     /// An uninstall operation failed for one or more packages.
+    #[error("{}", format_batch("uninstall", _0))]
     UninstallFailed(Vec<PackageError>),
     /// A deselect operation failed for one or more packages.
+    #[error("{}", format_batch("deselect", _0))]
     DeselectFailed(Vec<PackageError>),
+    /// A resolve operation failed for one or more packages.
+    #[error("{}", format_batch("resolve", _0))]
+    ResolveFailed(Vec<PackageError>),
 }
 
 /// An error tied to a specific package.
@@ -38,6 +45,15 @@ impl PackageError {
     }
 }
 
+/// Payload for [`PackageErrorKind::OfflineManifestMissing`]. Boxed in the
+/// enum variant to keep `PackageErrorKind` small (avoids the
+/// `clippy::result_large_err` lint).
+#[derive(Debug)]
+pub struct OfflineManifestMissing {
+    pub identifier: oci::Identifier,
+    pub digest: oci::Digest,
+}
+
 /// The cause of a single-package failure.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -45,6 +61,15 @@ pub enum PackageErrorKind {
     /// The package was not found in the index or object store.
     #[error("package not found")]
     NotFound,
+    /// Offline mode: the tag pointer is cached locally but the manifest
+    /// blob is missing from `blobs/`. The caller needs to re-run the
+    /// command online to populate the blob cache.
+    #[error(
+        "manifest {} is not in the local cache; run `ocx install {}` online to populate it",
+        _0.digest,
+        _0.identifier
+    )]
+    OfflineManifestMissing(Box<OfflineManifestMissing>),
     /// Multiple candidates matched the platform selection.
     #[error("ambiguous selection: {}", _0.iter().map(|id| id.to_string()).collect::<Vec<_>>().join(", "))]
     SelectionAmbiguous(Vec<oci::Identifier>),
@@ -75,30 +100,19 @@ impl From<crate::oci::client::error::ClientError> for PackageErrorKind {
 }
 
 // ---------------------------------------------------------------------------
-// Display — manual impl because multi-line batch formatting is too complex
-// for thiserror's `#[error(...)]` attribute.
+// Batch formatter — used by `#[error(...)]` attributes on `Error` variants.
 // ---------------------------------------------------------------------------
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::FindFailed(errors) => write_batch(f, "find", errors),
-            Error::InstallFailed(errors) => write_batch(f, "install", errors),
-            Error::UninstallFailed(errors) => write_batch(f, "uninstall", errors),
-            Error::DeselectFailed(errors) => write_batch(f, "deselect", errors),
-        }
-    }
-}
-
-fn write_batch(f: &mut std::fmt::Formatter<'_>, verb: &str, errors: &[PackageError]) -> std::fmt::Result {
+fn format_batch(verb: &str, errors: &[PackageError]) -> String {
+    use std::fmt::Write as _;
     if errors.len() == 1 {
-        write!(f, "Failed to {verb} package: {}", errors[0])
+        format!("Failed to {verb} package: {}", errors[0])
     } else {
-        writeln!(f, "Failed to {verb} {} packages:", errors.len())?;
+        let mut s = format!("Failed to {verb} {} packages:", errors.len());
         for e in errors {
-            writeln!(f, "  {e}")?;
+            let _ = write!(s, "\n  {e}");
         }
-        Ok(())
+        s
     }
 }
 

--- a/crates/ocx_lib/src/package_manager/tasks/find.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/find.rs
@@ -34,14 +34,25 @@ impl PackageManager {
     ) -> Result<InstallInfo, PackageErrorKind> {
         log::debug!("Finding package: {}", package);
 
-        let identifier = self.resolve(package, platforms).await?;
+        let resolved = self.resolve(package, platforms).await?;
+        let identifier = resolved.pinned.clone();
 
         log::debug!("Resolved package identifier: {}", &identifier);
 
-        self.find_plain(&identifier).await?.ok_or_else(|| {
+        let info = self.find_plain(&identifier).await?.ok_or_else(|| {
             log::debug!("Package not found locally for '{}'.", identifier);
             PackageErrorKind::NotFound
-        })
+        })?;
+
+        // Upsert the resolution chain into the installed package's `refs/blobs/`
+        // — idempotent, covers legacy installs and alt-tag resolves that walked
+        // through a different image index than the one originally pulled.
+        super::common::reference_manager(self.file_structure())
+            .link_blobs(&info.content, &resolved.chain)
+            .await
+            .map_err(PackageErrorKind::Internal)?;
+
+        Ok(info)
     }
 
     pub async fn find_all(
@@ -111,10 +122,14 @@ mod tests {
     fn setup_manager() -> (tempfile::TempDir, PackageManager, std::path::PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let fs = FileStructure::with_root(dir.path().to_path_buf());
-        let index = Index::from_local(LocalIndex::new(LocalConfig {
-            tag_store: TagStore::new(dir.path().join("tags")),
-            blob_store: BlobStore::new(dir.path().join("blobs")),
-        }));
+        let index = Index::from_chained(
+            LocalIndex::new(LocalConfig {
+                tag_store: TagStore::new(dir.path().join("tags")),
+                blob_store: BlobStore::new(dir.path().join("blobs")),
+            }),
+            Vec::new(),
+            crate::oci::index::ChainMode::Offline,
+        );
         let mgr = PackageManager::new(fs.clone(), index, None, "example.com");
         let obj_path = fs.packages.path(&test_pinned());
         (dir, mgr, obj_path)

--- a/crates/ocx_lib/src/package_manager/tasks/find_symlink.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/find_symlink.rs
@@ -20,6 +20,12 @@ impl PackageManager {
     /// itself* rather than the resolved object-store path.  This is intentional:
     /// downstream consumers embed this path in their output so it must be stable
     /// across package updates.
+    ///
+    /// Unlike the resolver-backed tasks (`find`, `install`, etc.), this path does
+    /// not walk the OCI resolution chain and therefore does not upsert entries
+    /// into `refs/blobs/`. No resolution happens — the install symlink points
+    /// directly at an already-installed package whose `refs/blobs/` was populated
+    /// at install time.
     pub async fn find_symlink(
         &self,
         package: &oci::Identifier,

--- a/crates/ocx_lib/src/package_manager/tasks/garbage_collection.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/garbage_collection.rs
@@ -6,11 +6,7 @@ mod reachability_graph;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use crate::{
-    file_structure::{CasTier, FileStructure},
-    log,
-    profile::ProfileSnapshot,
-};
+use crate::{file_structure::FileStructure, log, profile::ProfileSnapshot};
 
 use reachability_graph::ReachabilityGraph;
 
@@ -32,20 +28,16 @@ impl GarbageCollector {
 
     /// Returns all entries not reachable from any root.
     ///
-    /// Unreferenced blobs are excluded from `clean` because the local index
-    /// stores cached manifests in `blobs/` — collecting them would break
-    /// subsequent installs that resolve from the local tag→manifest cache.
-    /// Once the index supports fall-through resolution (local → network),
-    /// this skip can be removed. See #35 for policy-based blob eviction.
-    ///
-    /// Referenced blobs (via `refs/blobs/`) ARE collected when their parent
-    /// package is purged via [`orphaned_by_seeds`].
+    /// Blobs are first-class GC participants: any blob reachable from an
+    /// installed package's `refs/blobs/` survives, and any orphan blob is
+    /// collected. Follow-up #50 tracks policy-based retention for users who
+    /// want stricter retention semantics in shared `$OCX_HOME` scenarios.
     pub fn unreachable_objects(&self) -> HashSet<PathBuf> {
         let reachable = self.graph.reachable();
         self.graph
             .all_entries
             .iter()
-            .filter(|(path, tier)| **tier != CasTier::Blob && !reachable.contains(*path))
+            .filter(|(path, _)| !reachable.contains(*path))
             .map(|(path, _)| path.clone())
             .collect()
     }
@@ -143,6 +135,7 @@ mod tests {
 
     use super::reachability_graph::tests::{graph, graph_with_tiers, set};
     use super::*;
+    use crate::file_structure::CasTier;
 
     fn path(name: &str) -> PathBuf {
         PathBuf::from(format!("/objects/{name}"))
@@ -196,11 +189,61 @@ mod tests {
         assert_eq!(collector.unreachable_objects(), set(&["L2"]));
     }
 
+    /// Test 44 (plan_resolution_chain_refs.md §44): an unreachable blob
+    /// (not reachable via any package's refs/blobs/) IS collected by clean.
     #[test]
-    fn unreachable_blobs_skipped_by_clean() {
-        // Unreferenced blobs are cache entries — excluded from clean (#35).
+    fn unreachable_blob_is_collected() {
+        // An orphan blob with no root pointing to it must be collected.
         let collector = gc_with_tiers(&["A"], &[], &["orphan_blob"], &[("orphan_blob", CasTier::Blob)]);
-        assert!(collector.unreachable_objects().is_empty());
+        assert!(
+            collector.unreachable_objects().contains(&path("orphan_blob")),
+            "unreachable blob must be collected by ocx clean"
+        );
+    }
+
+    /// Test 45 (plan_resolution_chain_refs.md §45): a blob that IS reachable
+    /// via a root package's refs/blobs/ edge survives GC.
+    ///
+    /// This is the converse of test 44: the GC must distinguish reachable
+    /// blobs (linked from a package) from unreachable orphans.
+    #[test]
+    fn reachable_blob_via_refs_blobs_survives_gc() {
+        // A (root) → B1 (blob via refs/blobs/). B1 is reachable, must not be collected.
+        let collector = gc_with_tiers(&["A"], &[("A", &["B1"])], &[], &[("B1", CasTier::Blob)]);
+        assert!(
+            !collector.unreachable_objects().contains(&path("B1")),
+            "blob reachable via refs/blobs/ from a root package must NOT be collected"
+        );
+        assert!(
+            collector.unreachable_objects().is_empty(),
+            "no unreachable objects when root covers all"
+        );
+    }
+
+    /// Test 46 (plan_resolution_chain_refs.md §46): purge cascades through
+    /// all intermediate chain blobs — both the top-level index blob and the
+    /// platform manifest blob are purged when their parent package is purged.
+    ///
+    /// This generalises the existing purge_cascades_through_blobs test to the
+    /// full two-blob chain scenario (image index + platform manifest).
+    #[test]
+    fn purge_cascades_through_intermediate_chain_blobs() {
+        // Package A → B1 (image index blob) → B2 (platform manifest blob).
+        // Neither B1 nor B2 is a root; both are reachable only via A.
+        // Purging A must cascade to both B1 and B2.
+        let collector = gc_with_tiers(
+            &[],
+            &[("A", &["B1"]), ("B1", &["B2"])],
+            &[],
+            &[("B1", CasTier::Blob), ("B2", CasTier::Blob)],
+        );
+        let orphaned = collector.orphaned_by_seeds(&[path("A")]);
+        assert!(orphaned.contains(&path("A")), "A must be orphaned");
+        assert!(orphaned.contains(&path("B1")), "image index blob B1 must be cascaded");
+        assert!(
+            orphaned.contains(&path("B2")),
+            "platform manifest blob B2 must be cascaded"
+        );
     }
 
     #[test]
@@ -222,8 +265,12 @@ mod tests {
                 ("blob_orphan", CasTier::Blob),
             ],
         );
-        // Packages and layers collected; blobs skipped (cache retention #35).
-        assert_eq!(collector.unreachable_objects(), set(&["pkg_orphan", "layer_orphan"]));
+        // Post-#35: blobs are first-class GC participants, so unreachable
+        // orphans across all three tiers are collected.
+        assert_eq!(
+            collector.unreachable_objects(),
+            set(&["pkg_orphan", "layer_orphan", "blob_orphan"])
+        );
     }
 
     // ── orphaned_by_seeds ───────────────────────────────────────────────

--- a/crates/ocx_lib/src/package_manager/tasks/pull.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/pull.rs
@@ -174,7 +174,12 @@ async fn setup_impl(
     log::debug!("Pulling package: {}", package);
 
     // Step 1: Resolve via the index (Image Index → platform manifest).
-    let pinned = mgr.resolve(package, platforms.clone()).await?;
+    // The returned `ResolvedChain` carries the full `(registry, digest)` walk
+    // (top-level index + platform child where applicable) and the leaf
+    // `final_manifest` — the pull pipeline no longer re-fetches the manifest
+    // from the client, and the chain is linked into `refs/blobs/` in one shot.
+    let resolved = mgr.resolve(package, platforms.clone()).await?;
+    let pinned = resolved.pinned.clone();
     log::debug!("Resolved package identifier: {}", &pinned);
 
     // Step 2: In-process dedup — check if another task is already setting
@@ -187,6 +192,18 @@ async fn setup_impl(
     {
         singleflight::Acquisition::Resolved(info) => {
             log::debug!("Package '{}' already set up by another task, reusing.", &pinned);
+            // Singleflight key is the final pinned digest, so two concurrent
+            // installs of different alias tags (e.g. `cmake:latest` and
+            // `cmake:3.28`) that land on the same leaf manifest share a
+            // leader — but their resolution chains may differ (different
+            // top-level image indexes). The leader linked only its chain,
+            // so top up the waiter's chain here. `link_blobs` is idempotent,
+            // so overlapping entries are no-ops; only the unique entries
+            // (e.g., the waiter's distinct image-index digest) get linked.
+            super::common::reference_manager(mgr.file_structure())
+                .link_blobs(&info.content, &resolved.chain)
+                .await
+                .map_err(PackageErrorKind::Internal)?;
             return Ok(info);
         }
         singleflight::Acquisition::Leader(handle) => handle,
@@ -196,7 +213,7 @@ async fn setup_impl(
     // to waiters. On error, broadcast the error message so waiters get a
     // meaningful diagnostic instead of a generic "abandoned".
     // If we panic, Drop sends Abandoned as a fallback.
-    match setup_owned(mgr, &pinned, platforms, groups).await {
+    match setup_owned(mgr, &pinned, resolved, platforms, groups).await {
         Ok(info) => {
             handle.complete(info.clone());
             Ok(info)
@@ -213,6 +230,7 @@ async fn setup_impl(
 async fn setup_owned(
     mgr: &PackageManager,
     pinned: &oci::PinnedIdentifier,
+    resolved: super::resolve::ResolvedChain,
     platforms: Vec<oci::Platform>,
     groups: SetupGroups,
 ) -> Result<InstallInfo, PackageErrorKind> {
@@ -221,6 +239,13 @@ async fn setup_owned(
         let install_path = mgr.file_structure().packages.install_status(pinned);
         if tokio::fs::try_exists(&install_path).await.unwrap_or(false) {
             log::debug!("Package '{}' already fully installed, skipping.", pinned);
+            // Top up chain refs in case the already-installed package was
+            // resolved via a different image-index path (alias tag). See
+            // the waiter branch in `setup_impl` for the same invariant.
+            super::common::reference_manager(mgr.file_structure())
+                .link_blobs(&info.content, &resolved.chain)
+                .await
+                .map_err(PackageErrorKind::Internal)?;
             return Ok(info);
         }
         // Content exists but sentinel missing — crash recovery, re-pull.
@@ -247,13 +272,18 @@ async fn setup_owned(
                 "Package '{}' installed by another process while waiting for lock, skipping.",
                 pinned
             );
+            super::common::reference_manager(mgr.file_structure())
+                .link_blobs(&info.content, &resolved.chain)
+                .await
+                .map_err(PackageErrorKind::Internal)?;
             return Ok(info);
         }
     }
 
-    // Pull manifest + metadata (both fast, ~1KB each).
+    // Manifest comes from the resolver — ChainedIndex already persisted it to
+    // `blobs/` via write-through during resolve, so no extra fetch is needed.
     let client = mgr.client().map_err(PackageErrorKind::Internal)?;
-    let manifest = client.pull_manifest(pinned).await?;
+    let manifest = resolved.final_manifest.clone();
     let metadata = client.pull_metadata(pinned, Some(&manifest)).await?;
 
     // Validate manifest before any extraction work.
@@ -288,9 +318,7 @@ async fn setup_owned(
         .await
         .map_err(PackageErrorKind::Internal)?;
 
-    // Cache manifest in blobs/ store for offline resolution and future lock file support.
     let fs = mgr.file_structure();
-    cache_manifest_blob(fs, pinned, &manifest).await?;
 
     // Extract layers to layers/ store and pull dependencies in parallel.
     let (layer_digests, dependencies) = tokio::join!(
@@ -327,14 +355,14 @@ async fn setup_owned(
 
     // Build resolved package and enrich temp dir.
     // Order invariant: setup_dependencies returns results in declaration order.
-    let resolved = ResolvedPackage::new().with_dependencies(
+    let resolved_package = ResolvedPackage::new().with_dependencies(
         metadata
             .dependencies()
             .iter()
             .zip(dependencies.iter())
             .map(|(decl, info)| (info.identifier.clone(), info.resolved.clone(), decl.visibility)),
     );
-    post_download_actions(&pkg, pinned, &resolved).await?;
+    post_download_actions(&pkg, pinned, &resolved_package).await?;
 
     // Create remaining forward-ref symlinks in temp dir BEFORE move — targets
     // are absolute paths already in their respective stores. This ensures the
@@ -347,14 +375,16 @@ async fn setup_owned(
             .map_err(|e| PackageErrorKind::Internal(crate::Error::InternalFile(deps_dir.clone(), e)))?;
     }
     link_dependencies_in_temp(&pkg, &dependencies)?;
-    let blobs_dir = pkg.refs_blobs_dir();
-    tokio::fs::create_dir_all(&blobs_dir)
+    // Forward-ref every blob the resolver touched into `refs/blobs/` so GC
+    // can reach the full resolution chain from the installed package.
+    super::common::reference_manager(fs)
+        .link_blobs(&pkg.content(), &resolved.chain)
         .await
-        .map_err(|e| PackageErrorKind::Internal(crate::Error::InternalFile(blobs_dir.clone(), e)))?;
-    link_blobs_in_temp(&pkg, pinned.registry(), &pinned.digest(), fs)?;
+        .map_err(PackageErrorKind::Internal)?;
 
     // Atomic move temp → object store.
-    let install_info = move_temp_to_object_store(mgr.file_structure(), pinned, &metadata, resolved, temp).await?;
+    let install_info =
+        move_temp_to_object_store(mgr.file_structure(), pinned, &metadata, resolved_package, temp).await?;
 
     log::debug!("Pull succeeded for '{}'.", pinned);
     Ok(install_info)
@@ -482,33 +512,6 @@ async fn move_temp_to_object_store(
         resolved,
         content,
     })
-}
-
-/// Caches the manifest blob in the blobs/ store for offline resolution.
-async fn cache_manifest_blob(
-    fs: &file_structure::FileStructure,
-    pinned: &oci::PinnedIdentifier,
-    manifest: &oci::ImageManifest,
-) -> Result<(), PackageErrorKind> {
-    let blob_path = fs.blobs.path(pinned.registry(), &pinned.digest());
-    if tokio::fs::try_exists(&blob_path).await.unwrap_or(false) {
-        return Ok(());
-    }
-    tokio::fs::create_dir_all(&blob_path)
-        .await
-        .map_err(|e| PackageErrorKind::Internal(crate::Error::InternalFile(blob_path.clone(), e)))?;
-    let data_path = fs.blobs.data(pinned.registry(), &pinned.digest());
-    manifest
-        .write_json(&data_path)
-        .await
-        .map_err(PackageErrorKind::Internal)?;
-    file_structure::write_digest_file(
-        &fs.blobs.digest_file(pinned.registry(), &pinned.digest()),
-        &pinned.digest(),
-    )
-    .await
-    .map_err(PackageErrorKind::Internal)?;
-    Ok(())
 }
 
 /// Extracts all layers referenced by a manifest in parallel, returning their
@@ -747,28 +750,5 @@ fn link_layers_in_temp(
         let link_path = layers_dir.join(name);
         crate::symlink::create(&layer_content, &link_path).map_err(PackageErrorKind::Internal)?;
     }
-    Ok(())
-}
-
-/// Creates blob forward-refs (`refs/blobs/` symlinks) inside the temp directory.
-///
-/// Symlink targets point to `blobs/.../data` — the data file inside
-/// each blob. GC's `read_refs` takes `.parent()` on each target to recover
-/// the blob entry directory, matching the same convention deps use.
-///
-/// The caller is responsible for pre-creating `pkg.refs_blobs_dir()` via an
-/// async `tokio::fs::create_dir_all` — this helper stays sync so it does not
-/// introduce blocking I/O into an async context.
-fn link_blobs_in_temp(
-    pkg: &file_structure::PackageDir,
-    registry: &str,
-    manifest_digest: &oci::Digest,
-    fs: &file_structure::FileStructure,
-) -> Result<(), PackageErrorKind> {
-    let blobs_dir = pkg.refs_blobs_dir();
-    let blob_data = fs.blobs.data(registry, manifest_digest);
-    let name = crate::file_structure::cas_ref_name(manifest_digest);
-    let link_path = blobs_dir.join(name);
-    crate::symlink::create(&blob_data, &link_path).map_err(PackageErrorKind::Internal)?;
     Ok(())
 }

--- a/crates/ocx_lib/src/package_manager/tasks/resolve.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/resolve.rs
@@ -15,20 +15,140 @@ use crate::{
 
 use super::super::PackageManager;
 
+/// The full resolution output for a single identifier.
+///
+/// `chain` lists every pinned identifier the resolver touched — one entry
+/// per manifest blob, in walk order. Every entry is backed by an on-disk
+/// `blobs/{registry}/.../data` file, guaranteed by `ChainedIndex`
+/// write-through persistence. `final_manifest` is the platform-selected
+/// image manifest (never an image index).
+#[derive(Debug, Clone)]
+pub struct ResolvedChain {
+    /// The platform-selected pinned identifier — same value the old
+    /// `resolve` method returned.
+    pub pinned: oci::PinnedIdentifier,
+    /// Walk-order pinned identifiers for every manifest blob the resolver
+    /// touched, backed by on-disk blob files.
+    pub chain: Vec<oci::PinnedIdentifier>,
+    /// The platform-selected image manifest used by the pull pipeline for
+    /// layer extraction. Never an image index.
+    pub final_manifest: oci::ImageManifest,
+}
+
 impl PackageManager {
-    /// Resolves an identifier through the index (tag → digest, platform matching).
+    /// Resolves an identifier through the index (tag → digest, platform
+    /// matching), returning the pinned identifier plus the full chain of
+    /// blobs that backed the resolution.
     pub async fn resolve(
         &self,
         package: &oci::Identifier,
         platforms: Vec<oci::Platform>,
-    ) -> Result<oci::PinnedIdentifier, PackageErrorKind> {
-        match self.index().select(package, platforms).await {
-            Ok(SelectResult::Found(id)) => {
-                oci::PinnedIdentifier::try_from(id).map_err(|_| PackageErrorKind::DigestMissing)
+    ) -> Result<ResolvedChain, PackageErrorKind> {
+        // Walk the manifest chain through ChainedIndex. Each `fetch_manifest`
+        // returns cache-first with write-through persistence, so every digest
+        // the walk touches is backed by an on-disk blob by the time it lands
+        // in `chain` — that is the `ResolvedChain` invariant.
+        let top_id = if package.digest().is_some() {
+            package.clone()
+        } else {
+            package.clone_with_tag(package.tag_or_latest())
+        };
+        let (top_digest, top_manifest) = match self
+            .index()
+            .fetch_manifest(&top_id)
+            .await
+            .map_err(PackageErrorKind::Internal)?
+        {
+            Some(result) => result,
+            None => {
+                // Distinguish "tag truly unknown" (NotFound) from "tag cached
+                // locally but manifest blob missing from the cache"
+                // (OfflineManifestMissing — requires online re-pull). We ask
+                // the index for the tag → digest mapping: if that succeeds,
+                // the tag is known, so fetch_manifest returning None implies
+                // the blob is missing rather than the tag is unknown.
+                if let Some(digest) = self
+                    .index()
+                    .fetch_manifest_digest(&top_id)
+                    .await
+                    .map_err(PackageErrorKind::Internal)?
+                {
+                    return Err(PackageErrorKind::OfflineManifestMissing(Box::new(
+                        package_manager::error::OfflineManifestMissing {
+                            identifier: top_id.clone(),
+                            digest,
+                        },
+                    )));
+                }
+                return Err(PackageErrorKind::NotFound);
             }
-            Ok(SelectResult::Ambiguous(v)) => Err(PackageErrorKind::SelectionAmbiguous(v)),
-            Ok(SelectResult::NotFound) => Err(PackageErrorKind::NotFound),
-            Err(e) => Err(PackageErrorKind::Internal(e)),
+        };
+
+        let top_pinned = oci::PinnedIdentifier::try_from(top_id.clone_with_digest(top_digest.clone()))
+            .map_err(|_| PackageErrorKind::DigestMissing)?;
+        let mut chain = vec![top_pinned.clone()];
+
+        match top_manifest {
+            // Flat image manifest: the chain is a single entry and the
+            // top-level digest IS the pinned identifier. Platform filtering
+            // does not apply here — a single-platform package always matches.
+            oci::Manifest::Image(img) => Ok(ResolvedChain {
+                pinned: top_pinned,
+                chain,
+                final_manifest: img,
+            }),
+            // Image index: defer platform selection to `Index::select`, then
+            // fetch the selected child to append it to the chain and return
+            // its manifest as `final_manifest`.
+            oci::Manifest::ImageIndex(_) => {
+                let pinned = match self.index().select(&top_id, platforms).await {
+                    Ok(SelectResult::Found(id)) => {
+                        oci::PinnedIdentifier::try_from(id).map_err(|_| PackageErrorKind::DigestMissing)?
+                    }
+                    Ok(SelectResult::Ambiguous(v)) => return Err(PackageErrorKind::SelectionAmbiguous(v)),
+                    Ok(SelectResult::NotFound) => return Err(PackageErrorKind::NotFound),
+                    Err(e) => return Err(PackageErrorKind::Internal(e)),
+                };
+
+                let child_id = top_id.clone_with_digest(pinned.digest());
+                let (child_digest, child_manifest) = match self
+                    .index()
+                    .fetch_manifest(&child_id)
+                    .await
+                    .map_err(PackageErrorKind::Internal)?
+                {
+                    Some(result) => result,
+                    None => {
+                        // Child manifest blob missing but the parent was
+                        // located via an image-index entry — treat as the
+                        // offline-missing case so the user knows to re-pull.
+                        return Err(PackageErrorKind::OfflineManifestMissing(Box::new(
+                            package_manager::error::OfflineManifestMissing {
+                                identifier: child_id,
+                                digest: pinned.digest(),
+                            },
+                        )));
+                    }
+                };
+
+                let final_manifest = match child_manifest {
+                    oci::Manifest::Image(img) => img,
+                    oci::Manifest::ImageIndex(_) => {
+                        return Err(PackageErrorKind::Internal(
+                            oci::index::error::Error::NestedImageIndex { digest: child_digest }.into(),
+                        ));
+                    }
+                };
+                let child_pinned = oci::PinnedIdentifier::try_from(child_id.clone_with_digest(child_digest))
+                    .map_err(|_| PackageErrorKind::DigestMissing)?;
+                chain.push(child_pinned);
+
+                Ok(ResolvedChain {
+                    pinned,
+                    chain,
+                    final_manifest,
+                })
+            }
         }
     }
 
@@ -37,7 +157,7 @@ impl PackageManager {
         &self,
         packages: &[oci::Identifier],
         platforms: Vec<oci::Platform>,
-    ) -> Result<Vec<oci::PinnedIdentifier>, package_manager::error::Error> {
+    ) -> Result<Vec<ResolvedChain>, package_manager::error::Error> {
         if packages.is_empty() {
             return Ok(Vec::new());
         }
@@ -50,7 +170,7 @@ impl PackageManager {
                 ))
                 .await
                 .map_err(|kind| {
-                    package_manager::error::Error::FindFailed(vec![PackageError::new(packages[0].clone(), kind)])
+                    package_manager::error::Error::ResolveFailed(vec![PackageError::new(packages[0].clone(), kind)])
                 })?;
             return Ok(vec![pinned]);
         }
@@ -70,7 +190,7 @@ impl PackageManager {
             );
         }
 
-        super::common::drain_package_tasks(packages, tasks, package_manager::error::Error::FindFailed).await
+        super::common::drain_package_tasks(packages, tasks, package_manager::error::Error::ResolveFailed).await
     }
 
     /// Resolves environment entries for packages, including transitive deps.
@@ -166,4 +286,190 @@ fn check_exported(
     }
     seen_repos.insert(repo_key, digest.clone());
     Ok(seen_digests.insert(digest))
+}
+
+// ── Specification tests — plan_resolution_chain_refs.md (revised) ────────
+//
+// These tests replace the deleted `chain_walk` module's tests 33-38. They
+// exercise `PackageManager::resolve` — now returning `ResolvedChain` — and
+// the chain-accumulation invariants promised by the design record.
+#[cfg(test)]
+mod spec_tests {
+    use tempfile::TempDir;
+
+    use crate::{
+        file_structure::{BlobStore, FileStructure, TagStore},
+        oci::index::{Index, LocalConfig, LocalIndex},
+        oci::{self, Digest, Identifier},
+        package_manager::PackageManager,
+    };
+
+    const REGISTRY: &str = "example.com";
+    const REPO: &str = "cmake";
+    const TAG: &str = "3.28";
+    const HEX_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HEX_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    fn tagged_id() -> Identifier {
+        Identifier::new_registry(REPO, REGISTRY).clone_with_tag(TAG)
+    }
+    fn digest_a() -> Digest {
+        Digest::Sha256(HEX_A.to_string())
+    }
+    fn digest_b() -> Digest {
+        Digest::Sha256(HEX_B.to_string())
+    }
+
+    fn linux_amd64() -> oci::Platform {
+        oci::Platform::current().unwrap()
+    }
+
+    /// Build a `PackageManager` whose local index already has the tag +
+    /// blob files seeded on disk.
+    fn make_manager(dir: &TempDir) -> PackageManager {
+        let fs = FileStructure::with_root(dir.path().to_path_buf());
+        let index = Index::from_chained(
+            LocalIndex::new(LocalConfig {
+                tag_store: TagStore::new(dir.path().join("tags")),
+                blob_store: BlobStore::new(dir.path().join("blobs")),
+            }),
+            Vec::new(),
+            crate::oci::index::ChainMode::Offline,
+        );
+        PackageManager::new(fs, index, None, REGISTRY)
+    }
+
+    /// Writes a `TagLock`-shaped JSON file at `tag_path` mapping `TAG → digest`.
+    /// Mirrors the on-disk format `LocalIndex` expects (see `tag_lock.rs`).
+    fn write_tag_lock(tag_path: &std::path::Path, digest: &Digest) {
+        std::fs::create_dir_all(tag_path.parent().unwrap()).unwrap();
+        let json = format!(r#"{{"version":1,"repository":"{REGISTRY}/{REPO}","tags":{{"{TAG}":"{digest}"}}}}"#);
+        std::fs::write(tag_path, json).unwrap();
+    }
+
+    /// Seed a flat `ImageManifest` tag + blob pair (single-entry chain).
+    fn seed_flat_manifest(dir: &TempDir, digest: &Digest) {
+        let tag_store = TagStore::new(dir.path().join("tags"));
+        let id = Identifier::new_registry(REPO, REGISTRY).clone_with_tag(TAG);
+        write_tag_lock(&tag_store.tags(&id), digest);
+
+        let blob_store = BlobStore::new(dir.path().join("blobs"));
+        let blob_path = blob_store.data(REGISTRY, digest);
+        std::fs::create_dir_all(blob_path.parent().unwrap()).unwrap();
+        let manifest_json = r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","size":2},"layers":[]}"#;
+        std::fs::write(&blob_path, manifest_json).unwrap();
+    }
+
+    /// Seed tag + top-level `ImageIndex` + child `ImageManifest` (two-entry chain).
+    fn seed_image_index(dir: &TempDir, top_digest: &Digest, child_digest: &Digest) {
+        let tag_store = TagStore::new(dir.path().join("tags"));
+        let id = Identifier::new_registry(REPO, REGISTRY).clone_with_tag(TAG);
+        write_tag_lock(&tag_store.tags(&id), top_digest);
+
+        let blob_store = BlobStore::new(dir.path().join("blobs"));
+
+        let index_blob_path = blob_store.data(REGISTRY, top_digest);
+        std::fs::create_dir_all(index_blob_path.parent().unwrap()).unwrap();
+        let index_json = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"{child_digest}","size":1,"platform":{{"os":"linux","architecture":"amd64"}}}}]}}"#
+        );
+        std::fs::write(&index_blob_path, index_json).unwrap();
+
+        let child_blob_path = blob_store.data(REGISTRY, child_digest);
+        std::fs::create_dir_all(child_blob_path.parent().unwrap()).unwrap();
+        let manifest_json = r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:0000000000000000000000000000000000000000000000000000000000000000","size":2},"layers":[]}"#;
+        std::fs::write(&child_blob_path, manifest_json).unwrap();
+    }
+
+    /// `resolve` against a flat `ImageManifest` yields a `ResolvedChain`
+    /// with exactly one entry — the top-level manifest digest.
+    #[tokio::test]
+    async fn resolve_single_image_returns_one_chain_entry() {
+        let dir = TempDir::new().unwrap();
+        seed_flat_manifest(&dir, &digest_a());
+        let mgr = make_manager(&dir);
+        let result = mgr.resolve(&tagged_id(), vec![linux_amd64()]).await.unwrap();
+        assert_eq!(
+            result.chain.len(),
+            1,
+            "flat ImageManifest must produce exactly 1 chain entry"
+        );
+        assert_eq!(result.pinned.digest(), digest_a());
+    }
+
+    /// `resolve` against an `ImageIndex` yields a `ResolvedChain` with two
+    /// entries — the top-level index plus the platform-selected child.
+    #[tokio::test]
+    async fn resolve_image_index_returns_two_chain_entries() {
+        let dir = TempDir::new().unwrap();
+        seed_image_index(&dir, &digest_a(), &digest_b());
+        let mgr = make_manager(&dir);
+        let result = mgr.resolve(&tagged_id(), vec![linux_amd64()]).await.unwrap();
+        assert_eq!(
+            result.chain.len(),
+            2,
+            "ImageIndex must produce 2 chain entries (top + selected platform)"
+        );
+        assert_eq!(
+            result.chain[0].digest(),
+            digest_a(),
+            "first entry must be the top-level index digest"
+        );
+        assert_eq!(
+            result.chain[1].digest(),
+            digest_b(),
+            "second entry must be the platform-selected child digest"
+        );
+        assert_eq!(result.pinned.digest(), digest_b());
+    }
+
+    /// Nested image indexes (index pointing at another index) are rejected
+    /// with a clear error — unsupported OCI shape.
+    #[tokio::test]
+    async fn resolve_rejects_nested_image_index() {
+        let dir = TempDir::new().unwrap();
+
+        let tag_store = TagStore::new(dir.path().join("tags"));
+        let id = Identifier::new_registry(REPO, REGISTRY).clone_with_tag(TAG);
+        write_tag_lock(&tag_store.tags(&id), &digest_a());
+
+        let blob_store = BlobStore::new(dir.path().join("blobs"));
+
+        let blob_path = blob_store.data(REGISTRY, &digest_a());
+        std::fs::create_dir_all(blob_path.parent().unwrap()).unwrap();
+        let index_json = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{{"mediaType":"application/vnd.oci.image.index.v1+json","digest":"{b}","size":1}}]}}"#,
+            b = digest_b()
+        );
+        std::fs::write(&blob_path, index_json).unwrap();
+
+        let child_path = blob_store.data(REGISTRY, &digest_b());
+        std::fs::create_dir_all(child_path.parent().unwrap()).unwrap();
+        let child_json = r#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}"#;
+        std::fs::write(&child_path, child_json).unwrap();
+
+        let mgr = make_manager(&dir);
+        let result = mgr.resolve(&tagged_id(), vec![linux_amd64()]).await;
+        assert!(result.is_err(), "nested ImageIndex must be rejected with an error");
+    }
+
+    /// Property guarantee: every `(registry, digest)` entry in a successful
+    /// `ResolvedChain` has an on-disk `data` file at the CAS-sharded path.
+    #[tokio::test]
+    async fn resolve_result_every_entry_has_on_disk_blob_file() {
+        let dir = TempDir::new().unwrap();
+        seed_flat_manifest(&dir, &digest_a());
+        let blob_store = BlobStore::new(dir.path().join("blobs"));
+        let mgr = make_manager(&dir);
+        let result = mgr.resolve(&tagged_id(), vec![linux_amd64()]).await.unwrap();
+
+        for pinned in &result.chain {
+            let blob_path = blob_store.data(pinned.registry(), &pinned.digest());
+            assert!(
+                blob_path.exists(),
+                "property violated: chain entry {pinned} has no on-disk blob at {}",
+                blob_path.display()
+            );
+        }
+    }
 }

--- a/crates/ocx_lib/src/reference_manager.rs
+++ b/crates/ocx_lib/src/reference_manager.rs
@@ -261,6 +261,54 @@ impl ReferenceManager {
         }
         Ok(broken)
     }
+
+    /// Idempotently upserts a `refs/blobs/` forward-ref for every entry in
+    /// `chain`. The link name is derived from each entry's digest via
+    /// `cas_ref_name` so concurrent peers producing the same chain produce
+    /// identical symlinks — races resolve to the correct state.
+    ///
+    /// Eventual consistency: this function does not verify that targets
+    /// exist on disk. If a target blob is missing (e.g., a concurrent
+    /// `ocx clean` raced the caller), a dangling symlink is written and
+    /// the next GC pass collects it. Callers don't need to serialize
+    /// against GC — the system converges on its own.
+    pub async fn link_blobs(&self, content_path: &Path, chain: &[crate::oci::PinnedIdentifier]) -> Result<()> {
+        if chain.is_empty() {
+            return Ok(());
+        }
+
+        let refs_blobs = self.file_structure.packages.refs_blobs_dir_for_content(content_path)?;
+        tokio::fs::create_dir_all(&refs_blobs)
+            .await
+            .map_err(|e| Error::InternalFile(refs_blobs.clone(), e))?;
+
+        for pinned in chain {
+            let digest = pinned.digest();
+            let target = self.file_structure.blobs.data(pinned.registry(), &digest);
+            let link_path = refs_blobs.join(cas_ref_name(&digest));
+            if symlink::is_link(&link_path) {
+                if let Ok(existing) = std::fs::read_link(&link_path)
+                    && existing == target
+                {
+                    log::trace!(
+                        "refs/blobs/ forward-ref already current: '{}' → '{}'.",
+                        link_path.display(),
+                        target.display(),
+                    );
+                    continue;
+                }
+                log::trace!("Updating stale refs/blobs/ forward-ref '{}'.", link_path.display());
+            }
+
+            symlink::update(&target, &link_path)?;
+            log::trace!(
+                "Created refs/blobs/ forward-ref '{}' → '{}'.",
+                link_path.display(),
+                target.display(),
+            );
+        }
+        Ok(())
+    }
 }
 
 async fn check_refs_dir(refs_dir: &Path, expected_content: &Path) -> Result<Vec<PathBuf>> {
@@ -589,6 +637,154 @@ mod tests {
         assert_eq!(rm.broken_refs().await.unwrap(), Vec::<PathBuf>::new());
     }
 
+    // ── link_blobs tests (plan_resolution_chain_refs.md tests 39-43) ──
+
+    /// Helper: create a real blob data file at the CAS path for (registry, digest).
+    fn make_blob(root: &Path, registry: &str, digest: &crate::oci::Digest) -> std::path::PathBuf {
+        let store = crate::file_structure::BlobStore::new(root.join("blobs"));
+        let data_path = store.data(registry, digest);
+        std::fs::create_dir_all(data_path.parent().unwrap()).unwrap();
+        std::fs::write(&data_path, b"manifest bytes").unwrap();
+        data_path
+    }
+
+    /// Helper: build a `PinnedIdentifier` from a registry + digest pair using
+    /// a synthetic repository (irrelevant for `link_blobs` semantics).
+    fn make_pinned(registry: &str, digest: &crate::oci::Digest) -> crate::oci::PinnedIdentifier {
+        let id = crate::oci::Identifier::new_registry("repo", registry).clone_with_digest(digest.clone());
+        crate::oci::PinnedIdentifier::try_from(id).unwrap()
+    }
+
+    /// Test 39: link_blobs creates a symlink in refs/blobs/ for each
+    /// chain entry. The symlink must point to blobs/{registry}/.../data.
+    #[tokio::test]
+    async fn link_blobs_creates_symlinks_for_all_chain_entries() {
+        let (_dir, root, rm) = setup();
+        let content = make_content(&root, 1);
+
+        let reg = "example.com";
+        let d1 = make_digest(0x01);
+        let d2 = make_digest(0x02);
+        make_blob(&root, reg, &d1);
+        make_blob(&root, reg, &d2);
+
+        let chain = vec![make_pinned(reg, &d1), make_pinned(reg, &d2)];
+        rm.link_blobs(&content, &chain).await.unwrap();
+
+        // Both symlinks must exist in refs/blobs/.
+        let refs_blobs = content.parent().unwrap().join("refs").join("blobs");
+        assert!(refs_blobs.is_dir(), "refs/blobs/ directory must exist");
+        let entries: Vec<_> = std::fs::read_dir(&refs_blobs).unwrap().collect();
+        assert_eq!(
+            entries.len(),
+            2,
+            "two chain entries must produce two refs/blobs/ symlinks"
+        );
+    }
+
+    /// Test 40: link_blobs is idempotent — calling twice produces no
+    /// duplicate entries and no errors.
+    #[tokio::test]
+    async fn link_blobs_idempotent_on_existing_correct_symlinks() {
+        let (_dir, root, rm) = setup();
+        let content = make_content(&root, 2);
+
+        let reg = "example.com";
+        let d1 = make_digest(0x03);
+        make_blob(&root, reg, &d1);
+
+        let chain = vec![make_pinned(reg, &d1)];
+        rm.link_blobs(&content, &chain).await.unwrap();
+        rm.link_blobs(&content, &chain).await.unwrap(); // idempotent second call
+
+        let refs_blobs = content.parent().unwrap().join("refs").join("blobs");
+        let count = std::fs::read_dir(&refs_blobs).unwrap().count();
+        assert_eq!(count, 1, "idempotent call must not create duplicate symlinks");
+    }
+
+    /// Test 41: link_blobs tolerates EEXIST when the target already
+    /// matches — a racing peer creating the same symlink concurrently must not
+    /// cause an error.
+    #[tokio::test]
+    async fn link_blobs_tolerates_eexist_when_target_matches() {
+        let (_dir, root, rm) = setup();
+        let content = make_content(&root, 3);
+
+        let reg = "example.com";
+        let d1 = make_digest(0x04);
+        let blob_path = make_blob(&root, reg, &d1);
+
+        // Pre-create the symlink with the correct target (simulates a racing peer).
+        let refs_blobs = content.parent().unwrap().join("refs").join("blobs");
+        std::fs::create_dir_all(&refs_blobs).unwrap();
+        let ref_name = crate::file_structure::cas_ref_name(&d1);
+        let link_path = refs_blobs.join(&ref_name);
+        crate::symlink::create(&blob_path, &link_path).unwrap();
+
+        let chain = vec![make_pinned(reg, &d1)];
+        // Must not error even though the symlink already exists with the correct target.
+        rm.link_blobs(&content, &chain).await.unwrap();
+    }
+
+    /// Test 42: link_blobs updates a stale symlink target.
+    /// (Stale targets are structurally impossible by construction — the ref
+    /// name is derived from the digest — but the code must handle them.)
+    #[tokio::test]
+    async fn link_blobs_updates_stale_symlink_target() {
+        let (_dir, root, rm) = setup();
+        let content = make_content(&root, 4);
+
+        let reg = "example.com";
+        let d1 = make_digest(0x05);
+        let correct_blob = make_blob(&root, reg, &d1);
+
+        // Pre-create the symlink pointing at an incorrect (stale) target.
+        let refs_blobs = content.parent().unwrap().join("refs").join("blobs");
+        std::fs::create_dir_all(&refs_blobs).unwrap();
+        let ref_name = crate::file_structure::cas_ref_name(&d1);
+        let link_path = refs_blobs.join(&ref_name);
+        let stale_target = root.join("nowhere");
+        crate::symlink::create(&stale_target, &link_path).unwrap();
+
+        let chain = vec![make_pinned(reg, &d1)];
+        rm.link_blobs(&content, &chain).await.unwrap();
+
+        // After the call, the symlink must point at the correct blob.
+        assert_eq!(
+            std::fs::read_link(&link_path).unwrap(),
+            correct_blob,
+            "link_blobs must update a stale symlink target to the correct blob path"
+        );
+    }
+
+    /// Test 43: link_blobs with a missing blob data file still creates the
+    /// forward symlink (a dangling symlink). The eventual-consistency model
+    /// (GC sweeps dangling refs) handles this — the producer no longer needs
+    /// to pre-check for existence, which avoided a TOCTOU race against
+    /// concurrent `ocx clean`.
+    #[tokio::test]
+    async fn link_blobs_missing_blob_file_creates_dangling_symlink() {
+        let (_dir, root, rm) = setup();
+        let content = make_content(&root, 5);
+
+        let reg = "example.com";
+        let d1 = make_digest(0x06);
+        // Do NOT create the blob data file — verify the symlink is still made.
+
+        let chain = vec![make_pinned(reg, &d1)];
+        rm.link_blobs(&content, &chain)
+            .await
+            .expect("link_blobs must succeed even when the blob is missing");
+
+        let refs_blobs = content.parent().unwrap().join("refs").join("blobs");
+        let ref_name = crate::file_structure::cas_ref_name(&d1);
+        let link_path = refs_blobs.join(&ref_name);
+        assert!(
+            crate::symlink::is_link(&link_path),
+            "dangling forward-ref symlink must be present"
+        );
+    }
+
     #[tokio::test]
     async fn broken_refs_skips_non_dir_entries_in_packages() {
         let (_dir, root, rm) = setup();
@@ -671,5 +867,108 @@ mod tests {
 
         // Should not error even though no ref was created.
         rm.unlink_dependency(&dependent_content, &dep_digest).unwrap();
+    }
+
+    // ── T5: empty-chain link_blobs is a no-op ────────────────────────────
+
+    /// T5 (plan review): link_blobs with an empty chain slice returns Ok and
+    /// does not create a refs/blobs/ directory. Cheap regression guard.
+    #[tokio::test]
+    async fn link_blobs_empty_chain_is_noop() {
+        let (_dir, root, rm) = setup();
+        let content = make_content(&root, 0x10);
+
+        rm.link_blobs(&content, &[]).await.unwrap();
+
+        let refs_blobs = content.parent().unwrap().join("refs").join("blobs");
+        // The directory must either not exist or (if it was created) be empty.
+        if refs_blobs.exists() {
+            let count = std::fs::read_dir(&refs_blobs).unwrap().count();
+            assert_eq!(count, 0, "refs/blobs/ must be empty after link_blobs with empty chain");
+        }
+        // No entry created — the call was a no-op.
+    }
+
+    // ── D1: refs/blobs/ symlinks are path-independent after temp→final rename
+
+    /// D1 (plan review): blob forward-refs written against a temp content
+    /// path continue to resolve correctly after the parent directory is
+    /// atomically renamed to the final location.
+    ///
+    /// This validates the current implementation: symlinks in refs/blobs/ are
+    /// absolute paths into the blob store (e.g.
+    /// `{root}/blobs/reg/sha256/…/data`), which is independent of the
+    /// package's own location. A rename of the package directory from a temp
+    /// path to the final content path does not affect blob target resolution.
+    #[tokio::test]
+    async fn link_blobs_symlinks_are_path_independent_after_temp_to_final_rename() {
+        let (_dir, root, rm) = setup();
+
+        // Step 1: create a "temp" content directory (simulates TempStore layout).
+        let temp_content = root
+            .join("temp")
+            .join("deadbeefdeadbeefdeadbeefdeadbeef")
+            .join("content");
+        std::fs::create_dir_all(&temp_content).unwrap();
+
+        // Step 2: seed two real blob data files in the blob store.
+        let reg = "example.com";
+        let d1 = make_digest(0x11);
+        let d2 = make_digest(0x12);
+        make_blob(&root, reg, &d1);
+        make_blob(&root, reg, &d2);
+
+        // Step 3: call link_blobs against the temp content path.
+        let chain = vec![make_pinned(reg, &d1), make_pinned(reg, &d2)];
+        rm.link_blobs(&temp_content, &chain).await.unwrap();
+
+        // Verify symlinks were created in temp content's refs/blobs/.
+        let temp_refs = temp_content.parent().unwrap().join("refs").join("blobs");
+        assert!(
+            temp_refs.is_dir(),
+            "refs/blobs/ must exist in temp dir after link_blobs"
+        );
+        assert_eq!(
+            std::fs::read_dir(&temp_refs).unwrap().count(),
+            2,
+            "two chain entries must produce two symlinks in temp refs/blobs/"
+        );
+
+        // Step 4: rename temp dir (parent of content) to the final location.
+        let final_parent = root
+            .join("packages")
+            .join("reg")
+            .join("sha256")
+            .join("11")
+            .join("ffffffffffffffffffffffffffff11");
+        std::fs::create_dir_all(final_parent.parent().unwrap()).unwrap();
+        std::fs::rename(temp_content.parent().unwrap(), &final_parent).unwrap();
+        let final_refs_blobs = final_parent.join("refs").join("blobs");
+
+        // Step 5: verify all symlinks in the renamed location still resolve.
+        for entry in std::fs::read_dir(&final_refs_blobs).unwrap() {
+            let entry = entry.unwrap();
+            let link_path = entry.path();
+            assert!(
+                crate::symlink::is_link(&link_path),
+                "{} must be a symlink",
+                link_path.display()
+            );
+            // Symlink target is absolute into blobs/ — it must exist regardless
+            // of where the package directory moved.
+            let target = std::fs::read_link(&link_path).unwrap();
+            assert!(
+                target.is_absolute(),
+                "D1: blob forward-ref target must be absolute; got: {}",
+                target.display()
+            );
+            assert!(
+                target.exists(),
+                "D1: blob forward-ref must resolve after temp→final rename; \
+                 target {} not found (link at {})",
+                target.display(),
+                link_path.display()
+            );
+        }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 profile = "default"
 components = ["rustfmt", "clippy"]

--- a/test/tests/conftest.py
+++ b/test/tests/conftest.py
@@ -14,7 +14,11 @@ from src.runner import OcxRunner, PackageInfo
 def unique_repo(request: pytest.FixtureRequest) -> str:
     """Generate a unique OCI repository name for this test."""
     short_id = uuid4().hex[:8]
-    name = re.sub(r"[^a-z0-9_]", "", request.node.name.lower())[:40]
+    # Truncating to 40 chars can leave a trailing `_`, which makes the resulting
+    # repo name (`t_{8}_..._`) violate the OCI distribution spec component
+    # regex (`[a-z0-9]+(...)*`). registry:2 then rejects pushes with a 404.
+    # Strip trailing underscores so any test name maps to a valid repo.
+    name = re.sub(r"[^a-z0-9_]", "", request.node.name.lower())[:40].rstrip("_")
     return f"t_{short_id}_{name}"
 
 

--- a/test/tests/test_dependencies.py
+++ b/test/tests/test_dependencies.py
@@ -886,8 +886,18 @@ def test_clean_dry_run_transitive_chain(
     after = _count_object_dirs(ocx)
 
     assert after == before, "dry-run must not remove objects"
-    # 3 packages + 3 layers (each package has one extracted layer)
-    assert len(result) == 6, f"expected 6 collectible entries in dry-run; got {len(result)}"
+    # Post-#35 blobs are first-class GC participants, so the dry-run reports
+    # entries across all three CAS tiers. Split by path-prefix and assert
+    # per-tier counts so the test stays robust to changes in the per-package
+    # blob shape (single-platform vs image-index).
+    pkg_paths = [e for e in result if "/packages/" in e["path"]]
+    layer_paths = [e for e in result if "/layers/" in e["path"]]
+    blob_paths = [e for e in result if "/blobs/" in e["path"]]
+    assert len(pkg_paths) == 3, f"expected 3 collectible package entries; got {len(pkg_paths)}"
+    assert len(layer_paths) == 3, f"expected 3 collectible layer entries; got {len(layer_paths)}"
+    assert len(blob_paths) >= 3, (
+        f"expected at least 3 collectible blob entries (one manifest per package); got {len(blob_paths)}"
+    )
 
 
 def test_clean_partial_diamond_preserves_shared_leaf(

--- a/test/tests/test_resolution_chain_refs.py
+++ b/test/tests/test_resolution_chain_refs.py
@@ -1,0 +1,897 @@
+"""Acceptance tests for Capture Full OCI Resolution Chain in Package refs/blobs/ (#35).
+
+Specification-mode tests — written from the design record
+(.claude/artifacts/plan_resolution_chain_refs.md), NOT from the implementation.
+
+These tests encode the acceptance criteria (AC1–13) and user-experience
+scenarios (UX1–7) from the design record. They MUST fail against the current
+binary because the ChainedIndex write-through, link_blobs, and GC
+changes are not yet wired.
+
+Acceptance criteria traceability:
+  test 47 → AC1: refs/blobs/ populated after install
+  test 48 → AC2: find via different tag appends refs
+  test 49 → AC3: clean retains reachable blobs
+  test 50 → AC4: clean collects orphaned chain after uninstall --purge
+  test 51 → AC5: offline re-resolve survives clean after full chain capture
+  test 52 → AC7: index update writes only tag files, not blobs
+  test 53 → AC8: --remote install persists and links chain
+  test 54 → AC9: --remote index list refreshes tags from source
+  test 55 → AC10: offline install after bare index update fails cleanly
+  test 56 → UX5: failed install leaves collectable orphans
+  test 57 → AC11: parallel install races preserve full chain
+  test 58 → AC12: no sidecar lock/log/tmp files after install
+  test 59 → AC13/UX7: missing manifest after index update recovers on install
+  test 60 → find read-only against matching chain makes no writes
+  test 61 → AC6: clean collects real chain blobs after uninstall --purge
+  test 62 → AC2 (append): find via different-version tag appends new chain refs
+  test 63 → AC9 (cache-bypass): --remote tag resolution bypasses the local tag cache
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from src import OcxRunner, PackageInfo, make_package, registry_dir
+from src.registry import fetch_manifest_digest, fetch_manifest_from_registry
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _ocx_home(ocx: OcxRunner) -> Path:
+    return Path(ocx.env["OCX_HOME"])
+
+
+def _blobs_dir(ocx: OcxRunner) -> Path:
+    return _ocx_home(ocx) / "blobs"
+
+
+def _tags_dir(ocx: OcxRunner) -> Path:
+    return _ocx_home(ocx) / "tags"
+
+
+def _refs_blobs_dir(content_path: Path) -> Path:
+    """Given a package content path, return its refs/blobs/ directory."""
+    return content_path.parent / "refs" / "blobs"
+
+
+def _install_content(ocx: OcxRunner, pkg: PackageInfo) -> Path:
+    """Install pkg and return the resolved content/ path."""
+    result = ocx.json("install", pkg.short)
+    candidate = Path(result[pkg.short]["path"])
+    return candidate.resolve()
+
+
+def _count_blobs(blobs_dir: Path) -> set[Path]:
+    """Collect all data files in blobs/ — one per blob."""
+    if not blobs_dir.exists():
+        return set()
+    return {p for p in blobs_dir.rglob("data") if p.is_file()}
+
+
+def _collect_sidecar_files(blobs_dir: Path) -> list[Path]:
+    """Return all .lock, .log, .tmp files anywhere under blobs/."""
+    if not blobs_dir.exists():
+        return []
+    sidecars: list[Path] = []
+    for suffix in (".lock", ".log", ".tmp"):
+        sidecars.extend(blobs_dir.rglob(f"*{suffix}"))
+    return sidecars
+
+
+def _wipe_blobs(ocx: OcxRunner) -> None:
+    """Remove the blobs/ directory entirely."""
+    blobs = _blobs_dir(ocx)
+    if blobs.exists():
+        shutil.rmtree(blobs)
+
+
+def _wipe_tags(ocx: OcxRunner) -> None:
+    """Remove the tags/ directory to simulate a fresh machine."""
+    tags = _tags_dir(ocx)
+    if tags.exists():
+        shutil.rmtree(tags)
+
+
+# ── Test 47 — AC1: refs/blobs/ populated after install ───────────────────
+
+
+def test_install_creates_full_chain_refs(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC1: After ocx install <pkg>, the package's refs/blobs/ contains at
+    least one forward-ref for every OCI blob the resolver read.
+
+    Design record AC1: "After ocx install <pkg>, the package's refs/blobs/
+    contains a forward-ref for every OCI blob the resolver read (image index
+    + platform manifest at minimum)."
+
+    A single-platform package pushed via make_package produces at least one
+    manifest blob (the ImageManifest). The refs/blobs/ directory must exist
+    and contain at least one symlink pointing into blobs/.
+    """
+    pkg = published_package
+    content = _install_content(ocx, pkg)
+
+    refs_blobs = _refs_blobs_dir(content)
+    assert refs_blobs.is_dir(), (
+        f"AC1: refs/blobs/ directory must exist after install; missing: {refs_blobs}"
+    )
+    entries = list(refs_blobs.iterdir())
+    assert len(entries) >= 1, (
+        f"AC1: refs/blobs/ must contain at least one forward-ref after install; "
+        f"found: {entries}"
+    )
+    # Every entry must be a symlink pointing into blobs/.
+    for entry in entries:
+        assert entry.is_symlink(), f"AC1: {entry} must be a symlink"
+        target = Path(os.readlink(entry))
+        assert "blobs" in str(target), (
+            f"AC1: ref {entry} must point into blobs/; target: {target}"
+        )
+
+
+# ── Test 48 — AC2: find via different tag appends refs ────────────────────
+
+
+def test_find_via_different_tag_appends_refs(
+    ocx: OcxRunner, published_two_versions: tuple[PackageInfo, PackageInfo]
+) -> None:
+    """AC2 (idempotency half): repeated ocx find against an installed package
+    neither removes, duplicates, nor corrupts refs/blobs/ — the chain-link
+    pass is a safe upsert.
+
+    Design record AC2: "After ocx find <pkg> via a tag path ... those blobs
+    are appended to refs/blobs/ — no duplicate entries, no changed targets,
+    idempotent on re-run."
+
+    The "count grows" half of AC2 requires a scenario where a find call
+    walks an image-index chain that was not present at install time. That
+    is not reachable with the current fixture infrastructure (make_package
+    reuses the same image-index digest across tags for a given version).
+    Test 62 covers the related "different versions produce disjoint refs"
+    invariant instead.
+    """
+    v1, _v2 = published_two_versions
+    content = _install_content(ocx, v1)
+
+    refs_blobs = _refs_blobs_dir(content)
+    before = (
+        {e.name: os.readlink(e) for e in refs_blobs.iterdir() if e.is_symlink()}
+        if refs_blobs.is_dir()
+        else {}
+    )
+    assert before, "AC2 prerequisite: install must have produced chain refs"
+
+    # Two successive finds must leave refs/blobs/ stable — no new duplicates,
+    # no targets mutated, no existing refs removed.
+    ocx.plain("find", v1.short)
+    ocx.plain("find", v1.short)
+
+    after = (
+        {e.name: os.readlink(e) for e in refs_blobs.iterdir() if e.is_symlink()}
+        if refs_blobs.is_dir()
+        else {}
+    )
+    assert set(after) == set(before), (
+        f"AC2: find must not add or remove refs; before={set(before)}, after={set(after)}"
+    )
+    for name, target in after.items():
+        assert target == before[name], (
+            f"AC2: find must not rewrite existing symlinks; {name}: "
+            f"before={before[name]}, after={target}"
+        )
+
+
+# ── Test 49 — AC3: clean retains reachable blobs ─────────────────────────
+
+
+def test_clean_retains_reachable_blobs(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC3: ocx clean does not delete any blob reachable via any installed
+    package's refs/blobs/.
+
+    Design record AC3: "ocx clean does not delete any blob reachable via any
+    installed package's refs/blobs/."
+    """
+    pkg = published_package
+    content = _install_content(ocx, pkg)
+
+    blobs_before = _count_blobs(_blobs_dir(ocx))
+    assert blobs_before, "prerequisite: blobs must exist after install"
+
+    ocx.plain("clean")
+
+    blobs_after = _count_blobs(_blobs_dir(ocx))
+    # All blobs that are reachable via refs/blobs/ must survive.
+    refs_blobs = _refs_blobs_dir(content)
+    if refs_blobs.is_dir():
+        for ref_link in refs_blobs.iterdir():
+            if ref_link.is_symlink():
+                target = Path(os.readlink(ref_link))
+                # Resolve relative paths relative to the symlink directory.
+                if not target.is_absolute():
+                    target = (ref_link.parent / target).resolve()
+                assert target.exists(), (
+                    f"AC3: clean must not delete blob {target} reachable via {ref_link}"
+                )
+
+
+# ── Test 50 — AC4: clean collects orphaned chain after uninstall --purge ──
+
+
+def test_clean_collects_orphaned_chain_after_uninstall_purge(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC4: ocx clean does delete blobs not reachable from any installed package.
+
+    Design record AC4: "ocx clean does delete blobs not reachable from any
+    installed package (e.g., orphans left by a crashed install, or the old
+    chain after uninstall --purge)."
+
+    We install, then uninstall --purge, then inject a fake orphan blob and
+    verify clean removes it.
+    """
+    pkg = published_package
+    _install_content(ocx, pkg)
+    ocx.plain("uninstall", "--purge", pkg.short)
+
+    # Inject a fake orphan blob directly into the blobs/ store.
+    # This simulates a blob left by a crashed install (no refs link to it).
+    # Path components MUST be valid hex — `BlobStore::list_all` silently
+    # skips dirs that don't match `is_valid_cas_path` (2 + 30 hex chars).
+    orphan_dir = _blobs_dir(ocx) / registry_dir(ocx.registry) / "sha256" / "aa" / "bb0000000000000000000000000000"
+    orphan_dir.mkdir(parents=True, exist_ok=True)
+    orphan_data = orphan_dir / "data"
+    orphan_data.write_bytes(b"orphan blob content")
+
+    ocx.plain("clean")
+
+    # The fake orphan blob must have been collected.
+    assert not orphan_data.exists(), (
+        f"AC4: clean must collect the unreachable orphan blob at {orphan_data}"
+    )
+
+
+# ── Test 51 — AC5: offline re-resolve survives clean ─────────────────────
+
+
+def test_offline_reresolve_survives_clean_after_full_chain_capture(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC5: Offline re-resolve of an installed package succeeds for any tag
+    path the package has ever been resolved via.
+
+    Design record AC5: "Offline re-resolve of an installed package succeeds
+    for any tag path the package has ever been resolved via."
+    Design record UX6.
+    """
+    pkg = published_package
+    ocx.plain("install", pkg.short)
+
+    # Offline find must succeed before clean.
+    result = ocx.plain("--offline", "find", pkg.short, check=False)
+    assert result.returncode == 0, "prerequisite: offline find must succeed after install"
+
+    ocx.plain("clean")
+
+    # Offline find must still succeed after clean (reachable blobs must survive).
+    result = ocx.plain("--offline", "find", pkg.short, check=False)
+    assert result.returncode == 0, (
+        "AC5: offline find must still succeed after clean when blobs are in refs/blobs/"
+    )
+
+
+# ── Test 52 — AC7: index update writes only tag files ────────────────────
+
+
+def test_index_update_writes_only_tag_files_not_blobs(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC7: ocx index update <pkg> writes only to $OCX_HOME/tags/, never to
+    $OCX_HOME/blobs/.
+
+    Design record AC7: "ocx index update <pkg> writes only to $OCX_HOME/tags/,
+    never to $OCX_HOME/blobs/. Verified by walking blobs/ before and after
+    and asserting it is unchanged."
+    """
+    pkg = published_package
+
+    blobs_before = _count_blobs(_blobs_dir(ocx))
+
+    # Run index update — must not write any new blobs.
+    ocx.plain("index", "update", pkg.short)
+
+    blobs_after = _count_blobs(_blobs_dir(ocx))
+    assert blobs_after == blobs_before, (
+        f"AC7: index update must not write to blobs/.\n"
+        f"Blobs before: {len(blobs_before)}, after: {len(blobs_after)}"
+    )
+
+
+# ── Test 53 — AC8: --remote install persists and links chain ─────────────
+
+
+def test_remote_flag_install_persists_and_links_chain(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC8: ocx --remote install <pkg> persists the resolution chain into
+    blobs/ and links it into refs/blobs/. --remote no longer disables the
+    cache write-through.
+
+    Design record AC8: "ocx --remote install <pkg> persists the resolution
+    chain into blobs/ and links it into refs/blobs/."
+    Design record UX3.
+    """
+    pkg = published_package
+
+    result = ocx.json("--remote", "install", pkg.short)
+    assert pkg.short in result, f"AC8: --remote install must succeed for {pkg.short}"
+
+    # Resolve the installed content path.
+    candidate = Path(result[pkg.short]["path"])
+    content = candidate.resolve()
+    refs_blobs = _refs_blobs_dir(content)
+
+    assert refs_blobs.is_dir(), (
+        f"AC8: refs/blobs/ must exist after --remote install; missing: {refs_blobs}"
+    )
+    entries = list(refs_blobs.iterdir())
+    assert len(entries) >= 1, (
+        f"AC8: refs/blobs/ must contain at least one forward-ref after --remote install"
+    )
+
+
+# ── Test 54 — AC9: --remote index list refreshes tags ────────────────────
+
+
+def test_remote_flag_index_list_refreshes_tags_from_source(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC9: ocx --remote index list <pkg> still refreshes tag data from the
+    source on every invocation (mutable lookups bypass cache under --remote).
+
+    Design record AC9: "ocx --remote index list <pkg> still refreshes tag
+    data from the source on every invocation."
+    """
+    pkg = published_package
+    # Install once to seed the local cache.
+    ocx.plain("install", pkg.short)
+
+    # --remote index list must succeed and reflect the live registry tags.
+    result = ocx.plain("--remote", "index", "list", pkg.short, check=False)
+    assert result.returncode == 0, (
+        f"AC9: --remote index list must succeed; rc={result.returncode}\n"
+        f"stderr: {result.stderr.strip()}"
+    )
+    # The output must include the installed tag.
+    assert pkg.tag in result.stdout, (
+        f"AC9: --remote index list must include tag {pkg.tag!r} from the live registry"
+    )
+
+
+# ── Test 55 — AC10: offline install after bare index update fails cleanly ─
+
+
+def test_offline_install_after_bare_index_update_fails_cleanly(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC10: ocx --offline install <pkg> after a bare ocx index update <pkg>
+    fails with a clear error naming the missing manifest digest.
+
+    Design record AC10: "ocx --offline install <pkg> after a bare ocx index
+    update <pkg> fails with a clear error naming the missing manifest digest."
+    Design record UX4: "ocx --offline install cmake:3.28 after bare index update
+    must fail — Error: manifest not in local cache."
+    """
+    pkg = published_package
+
+    # Run index update (which now only writes tags, not blobs post-#35).
+    ocx.plain("index", "update", pkg.short)
+
+    # Wipe blobs/ to ensure no blob cache exists.
+    _wipe_blobs(ocx)
+
+    result = ocx.plain("--offline", "install", pkg.short, check=False)
+    assert result.returncode != 0, (
+        "AC10: --offline install after bare index update (no blobs) must fail"
+    )
+    # The error must mention the missing manifest or cache and name the
+    # specific digest so the user knows which artifact to re-pull.
+    combined = result.stderr + result.stdout
+    assert combined.strip(), (
+        "AC10: error output must not be empty — must name missing manifest or cache"
+    )
+    assert "sha256:" in combined, (
+        f"AC10: error must name the missing manifest digest (sha256:...); got: {combined!r}"
+    )
+    assert "manifest" in combined.lower() or "cache" in combined.lower(), (
+        f"AC10: error must describe the missing manifest / cache state; got: {combined!r}"
+    )
+
+
+# ── Test 56 — UX5: failed install leaves collectable orphans ─────────────
+
+
+def test_failed_install_leaves_collectable_orphans(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """UX5: If an install fails mid-chain (network fails after blob is written
+    but before link_blobs runs), the orphaned blob is collected by
+    the next ocx clean run.
+
+    Design record UX5: "ocx install fails mid-chain; image index blob is
+    persisted but install aborts before link_blobs runs; ocx clean
+    removes 1 unreferenced blob."
+
+    We simulate the orphan by writing a fake blob directly — there is no
+    installed package that references it, so it must be collected.
+    """
+    _install_content(ocx, published_package)
+
+    # Inject a fake orphan blob (simulates a blob written by a crashed install
+    # whose link_blobs never ran). Path components MUST be valid hex —
+    # `BlobStore::list_all` silently skips non-CAS dirs.
+    orphan_dir = _blobs_dir(ocx) / registry_dir(ocx.registry) / "sha256" / "cc" / "dd0000000000000000000000000000"
+    orphan_dir.mkdir(parents=True, exist_ok=True)
+    orphan_data = orphan_dir / "data"
+    orphan_data.write_bytes(b"crashed install blob")
+
+    ocx.plain("clean")
+
+    assert not orphan_data.exists(), (
+        "UX5: orphaned blob from failed install must be collected by ocx clean"
+    )
+
+
+# ── Test 57 — AC11: parallel install races preserve full chain ────────────
+
+
+def test_parallel_install_races_preserve_full_chain(
+    ocx: OcxRunner,
+    ocx_binary: Path,
+    unique_repo: str,
+    tmp_path: Path,
+) -> None:
+    """AC11: Two concurrent ocx install processes against the same $OCX_HOME
+    both complete successfully, neither corrupts blob files, both produce full
+    refs/blobs/.
+
+    Design record AC11: "Two concurrent ocx install processes against the
+    same $OCX_HOME both complete successfully, neither corrupts blob files,
+    both produce full refs/blobs/."
+    """
+    v1 = make_package(ocx, unique_repo, "1.0.0", tmp_path / "v1", new=True, cascade=False)
+    v2 = make_package(ocx, unique_repo, "2.0.0", tmp_path / "v2", new=False, cascade=False)
+
+    def run_install(pkg_short: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(ocx_binary), "--format", "json", "install", pkg_short],
+            capture_output=True,
+            text=True,
+            env=ocx.env,
+            check=False,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(run_install, v1.short), pool.submit(run_install, v2.short)]
+        results = [f.result() for f in futures]
+
+    for pkg, result in zip((v1, v2), results, strict=True):
+        assert result.returncode == 0, (
+            f"AC11: concurrent install of {pkg.short} failed (rc={result.returncode}).\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+        data = json.loads(result.stdout)
+        candidate = Path(data[pkg.short]["path"])
+        content = candidate.resolve()
+        refs_blobs = _refs_blobs_dir(content)
+        assert refs_blobs.is_dir(), (
+            f"AC11: refs/blobs/ must exist after parallel install of {pkg.short}"
+        )
+        entries = list(refs_blobs.iterdir())
+        assert len(entries) >= 1, (
+            f"AC11: refs/blobs/ must have at least one entry for {pkg.short}; found: {entries}"
+        )
+
+
+# ── Test 58 — AC12: no sidecar files in blobs/ after install ─────────────
+
+
+def test_no_sidecar_lock_files_in_blobs_dir_after_install(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC12: After any successful install, no sidecar .lock, .log, or .tmp
+    files remain anywhere under $OCX_HOME/blobs/.
+
+    Design record AC12: "After any successful install, no sidecar .lock, .log,
+    or .tmp files remain anywhere under $OCX_HOME/blobs/."
+    """
+    pkg = published_package
+    ocx.plain("install", pkg.short)
+
+    sidecars = _collect_sidecar_files(_blobs_dir(ocx))
+    assert not sidecars, (
+        f"AC12: no sidecar .lock/.log/.tmp files must remain under blobs/ after install.\n"
+        f"Found: {[str(s) for s in sidecars]}"
+    )
+
+
+# ── Test 59 — AC13/UX7: latent-bug fix — missing manifest recovers ────────
+
+
+def test_missing_manifest_after_index_update_recovers_on_install(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC13/UX7: The update_tags latent bug is fixed: deleting a manifest data
+    file from blobs/ (leaving the tag file in place) and then running
+    ocx install <pkg> re-fetches the manifest and completes successfully.
+
+    Design record AC13: "deleting a manifest data file from blobs/ (leaving
+    the tag file in place) and then running ocx install <pkg> re-fetches the
+    manifest and completes successfully (not infinite-loop or NotFound)."
+    Design record UX7.
+    """
+    pkg = published_package
+
+    # Step 1: install online to populate tags/ and blobs/.
+    ocx.plain("install", pkg.short)
+
+    # Step 2: wipe the entire blobs/ directory — leaves tag files in place.
+    _wipe_blobs(ocx)
+    assert not _blobs_dir(ocx).exists() or not list(_blobs_dir(ocx).rglob("data")), (
+        "prerequisite: blobs must be absent"
+    )
+
+    # Step 3: re-install — must re-fetch the manifest and succeed.
+    result = ocx.plain("install", pkg.short, check=False)
+    assert result.returncode == 0, (
+        f"AC13: install must succeed after blobs/ is wiped (latent bug fix).\n"
+        f"stderr: {result.stderr.strip()}"
+    )
+
+
+# ── Test 60 — fast path: read-only find makes no writes ──────────────────
+
+
+def test_find_read_only_against_matching_chain_makes_no_writes(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """Fast-path proof: when find resolves an already-installed package whose
+    refs/blobs/ already contains the full chain, no new symlinks or blobs are
+    written.
+
+    Design record: "find read-only against matching chain makes no writes"
+    (the idempotency guarantee of link_blobs).
+    """
+    pkg = published_package
+    content = _install_content(ocx, pkg)
+
+    refs_blobs = _refs_blobs_dir(content)
+    before_refs = set(refs_blobs.iterdir()) if refs_blobs.is_dir() else set()
+    blobs_before = _count_blobs(_blobs_dir(ocx))
+
+    # Run find — chain is already fully linked, so no writes should occur.
+    ocx.plain("find", pkg.short)
+
+    after_refs = set(refs_blobs.iterdir()) if refs_blobs.is_dir() else set()
+    blobs_after = _count_blobs(_blobs_dir(ocx))
+
+    # No new symlinks or blobs.
+    new_refs = after_refs - before_refs
+    assert not new_refs, (
+        f"find on a fully-linked chain must make no new refs; created: {new_refs}"
+    )
+    assert blobs_after == blobs_before, (
+        "find on a fully-linked chain must write no new blobs"
+    )
+
+
+# ── General resolution-chain cases — Identifier shapes ──────────────────
+
+
+def _chain_entries(content: Path) -> list[Path]:
+    refs_blobs = _refs_blobs_dir(content)
+    if not refs_blobs.is_dir():
+        return []
+    return sorted(refs_blobs.iterdir())
+
+
+def test_resolution_chain_tag_via_image_index(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """General case: tagged identifier → image index → platform manifest.
+
+    Publishing with ``cascade=True`` produces a multi-tag push backed by an
+    image index, so the resolution chain is (image index, platform manifest) —
+    two OCI blobs. Installing via the tag must link both into ``refs/blobs/``.
+    """
+    pkg = make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=True)
+
+    content = _install_content(ocx, pkg)
+    entries = _chain_entries(content)
+
+    assert len(entries) >= 2, (
+        f"tag→image-index→platform-manifest chain must link at least 2 blobs; "
+        f"found {len(entries)}: {entries}"
+    )
+    for entry in entries:
+        assert entry.is_symlink(), f"{entry} must be a symlink"
+        target = Path(os.readlink(entry))
+        resolved = target if target.is_absolute() else (entry.parent / target).resolve()
+        assert resolved.exists(), f"chain ref {entry} must point to an existing blob"
+
+
+def test_resolution_chain_direct_digest_to_image_index(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """General case: direct digest addressing an image index.
+
+    A digest-pinned identifier that points at the image index must still
+    produce a two-blob chain: the index itself plus the platform-selected
+    child manifest.
+    """
+    pkg = make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=True)
+
+    index_digest = fetch_manifest_digest(ocx.registry, unique_repo, pkg.tag)
+    # Sanity: make sure the registry actually returned an image index, not
+    # a plain image manifest — otherwise this test is not exercising the
+    # case we claim to exercise.
+    manifest = fetch_manifest_from_registry(ocx.registry, unique_repo, pkg.tag)
+    assert "manifests" in manifest, (
+        f"prerequisite: {pkg.tag} must resolve to an image index, got: {manifest.get('mediaType')}"
+    )
+
+    digest_ref = f"{ocx.registry}/{unique_repo}@{index_digest}"
+    result = ocx.json("install", digest_ref)
+    candidate = Path(result[digest_ref]["path"])
+    content = candidate.resolve()
+
+    entries = _chain_entries(content)
+    assert len(entries) >= 2, (
+        f"digest→image-index chain must link at least 2 blobs (index + child); "
+        f"found {len(entries)}: {entries}"
+    )
+
+
+def test_resolution_chain_direct_digest_to_platform_manifest(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """General case: direct digest addressing a platform image manifest.
+
+    When the user pins a digest that already refers to a leaf platform
+    manifest (no enclosing image index), the chain contains a single blob —
+    the platform manifest itself.
+    """
+    pkg = make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=True)
+
+    manifest = fetch_manifest_from_registry(ocx.registry, unique_repo, pkg.tag)
+    assert "manifests" in manifest, (
+        "prerequisite: the tag must resolve to an image index so we can pick a child"
+    )
+    # Pick the first platform child — for a single-platform make_package push
+    # that is the current host platform.
+    child_digest = manifest["manifests"][0]["digest"]
+
+    digest_ref = f"{ocx.registry}/{unique_repo}@{child_digest}"
+    result = ocx.json("install", digest_ref)
+    candidate = Path(result[digest_ref]["path"])
+    content = candidate.resolve()
+
+    entries = _chain_entries(content)
+    assert len(entries) >= 1, (
+        f"digest→platform-manifest chain must link at least 1 blob; "
+        f"found {len(entries)}: {entries}"
+    )
+
+
+def test_resolution_chain_tag_via_flat_image_manifest(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """General case: tagged identifier → flat image manifest (no image index).
+
+    Publishing with ``cascade=False`` writes a single image manifest directly
+    under the tag, skipping the image-index layer. The chain then contains
+    exactly the one manifest blob.
+    """
+    pkg = make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=False)
+
+    content = _install_content(ocx, pkg)
+    entries = _chain_entries(content)
+
+    assert len(entries) >= 1, (
+        f"tag→flat-manifest chain must link at least 1 blob; "
+        f"found {len(entries)}: {entries}"
+    )
+    for entry in entries:
+        assert entry.is_symlink(), f"{entry} must be a symlink"
+
+
+# ── Test 61 — AC6: clean collects real chain blobs after uninstall --purge ─
+# AC6 → test_clean_collects_real_chain_blobs_after_uninstall_purge
+
+
+def test_clean_collects_real_chain_blobs_after_uninstall_purge(
+    ocx: OcxRunner, published_package: PackageInfo
+) -> None:
+    """AC6: After ocx uninstall --purge <pkg> + ocx clean, every blob that was
+    linked via refs/blobs/ is collected — not just synthetic orphans.
+
+    Design record AC6 (plan review T1): uninstall --purge removes the install
+    symlinks and refs/blobs/ forward-refs; the subsequent clean run must
+    collect the real chain blobs because nothing else refers to them.
+    """
+    pkg = published_package
+    _install_content(ocx, pkg)
+
+    blobs_after_install = _count_blobs(_blobs_dir(ocx))
+    assert blobs_after_install, (
+        "AC6 prerequisite: blobs must exist after install"
+    )
+
+    ocx.plain("uninstall", "--purge", pkg.short)
+    ocx.plain("clean")
+
+    blobs_after_clean = _count_blobs(_blobs_dir(ocx))
+    assert len(blobs_after_clean) == 0, (
+        f"AC6: clean after uninstall --purge must collect all real chain blobs; "
+        f"remaining: {blobs_after_clean}"
+    )
+
+
+# ── Test 62 — AC2 (v1/v2 isolation): different versions produce disjoint refs ─
+
+
+def test_different_package_versions_produce_disjoint_refs(
+    ocx: OcxRunner,
+    unique_repo: str,
+    tmp_path: Path,
+) -> None:
+    """AC2 corollary: two different package versions installed side-by-side
+    produce disjoint refs/blobs/ entries (no cross-contamination from the
+    shared BlobStore).
+
+    Note: the "count grows" variant of AC2 (same content dir, second find
+    walks a different image-index and appends new refs) is not reachable
+    with the current fixture infrastructure — make_package + cascade reuse
+    the same image-index digest across tags, so every tag for a given
+    version walks the same chain. The genuine append case requires
+    constructing two image-index manifests that share a child platform
+    manifest, which is beyond what make_package exposes.
+
+    What we CAN test is that two different versions installed to two
+    different content dirs have different refs/blobs/ entries (since
+    their chain digests differ), and that each entry is a valid symlink
+    into the shared blob store.
+    """
+    v1 = make_package(ocx, unique_repo, "1.0.0", tmp_path / "v1", new=True, cascade=False)
+    v2 = make_package(ocx, unique_repo, "2.0.0", tmp_path / "v2", new=False, cascade=False)
+
+    content_v1 = _install_content(ocx, v1)
+    content_v2 = _install_content(ocx, v2)
+
+    refs_blobs_v1 = _refs_blobs_dir(content_v1)
+    refs_blobs_v2 = _refs_blobs_dir(content_v2)
+
+    v1_ref_names = {e.name for e in refs_blobs_v1.iterdir()} if refs_blobs_v1.is_dir() else set()
+    v2_ref_names = {e.name for e in refs_blobs_v2.iterdir()} if refs_blobs_v2.is_dir() else set()
+
+    assert v1_ref_names, "AC2: v1 must have at least one chain ref"
+    assert v2_ref_names, "AC2: v2 must have at least one chain ref"
+    assert v1_ref_names.isdisjoint(v2_ref_names), (
+        f"AC2: v1 and v2 have different digests, so their refs/blobs/ "
+        f"entries must be disjoint; v1={v1_ref_names}, v2={v2_ref_names}"
+    )
+
+    # Each ref is a valid symlink into blobs/.
+    for refs_dir in (refs_blobs_v1, refs_blobs_v2):
+        for entry in refs_dir.iterdir():
+            assert entry.is_symlink(), f"AC2: {entry} must be a symlink"
+            target = Path(os.readlink(entry))
+            assert "blobs" in str(target), (
+                f"AC2: ref {entry} must point into blobs/; got: {target}"
+            )
+
+
+# ── Test 63 — AC9 (cache-bypass): --remote bypasses the local tag cache ───
+
+
+def test_remote_mode_tag_resolution_bypasses_local_cache(
+    ocx: OcxRunner,
+    unique_repo: str,
+    tmp_path: Path,
+) -> None:
+    """AC9 (cache-bypass): Under --remote, tag→digest resolution must go to
+    the registry and bypass the local tag cache.  Without --remote, the local
+    tag cache is used and the cached (stale) digest is returned.
+
+    Design record AC9 / plan review T6: "Under --remote, tag→digest resolution
+    must always go to the registry (not cache). Manifest caching for
+    digest-addressed content is allowed."
+
+    Strategy (mirrors test_ac4_stale_cached_tag_uses_cached_digest in
+    test_tag_fallback.py):
+      1. Push v1 to unique_repo:1.0.0 and install it → populates local tag
+         cache with digest_A.
+      2. Snapshot the tag file (digest_A).
+      3. Push v2 to unique_repo:1.0.0 → registry now resolves 1.0.0 to
+         digest_B.  make_package also refreshes the cache to digest_B.
+      4. Restore the tag file to the v1 snapshot (digest_A) — simulates a
+         stale cache while the registry has moved to digest_B.
+      5. ocx --remote index list unique_repo:1.0.0 → must show digest_B
+         (bypassed the cache, fetched from registry).
+      6. ocx index list unique_repo:1.0.0 (no --remote) → must show the
+         cached digest_A (cache wins in Default mode).
+    """
+    v1_dir = tmp_path / "v1"
+    v1_dir.mkdir()
+    pkg_v1 = make_package(ocx, unique_repo, "1.0.0", v1_dir, new=True, cascade=False)
+    ocx.json("install", pkg_v1.short)
+
+    tag_file = (
+        Path(ocx.env["OCX_HOME"])
+        / "tags"
+        / registry_dir(ocx.registry)
+        / f"{unique_repo}.json"
+    )
+    assert tag_file.exists(), "AC9 prerequisite: tag file must exist after install"
+    v1_snapshot = tag_file.read_text()
+    cached_data = json.loads(v1_snapshot)
+    digest_a = cached_data["tags"].get(pkg_v1.tag)
+    assert digest_a is not None, "AC9 prerequisite: digest_A must be cached"
+
+    # Push v2 to the same repo:tag → registry now resolves 1.0.0 to digest_B.
+    v2_dir = tmp_path / "v2"
+    v2_dir.mkdir()
+    _ = make_package(ocx, unique_repo, "1.0.0", v2_dir, new=False, cascade=False)
+    digest_b = fetch_manifest_digest(ocx.registry, unique_repo, "1.0.0")
+    assert digest_b != digest_a, (
+        "AC9 prerequisite: registry digest must differ from cached digest after pushing v2"
+    )
+
+    # Restore the stale cache (digest_A) — make_package refreshed it to digest_B.
+    tag_file.write_text(v1_snapshot)
+
+    # Step 5: --remote index list must bypass cache and refresh the local tag
+    # file to digest_B. We prove this by running --remote index list and then
+    # reading the tag file — it must now contain digest_B.
+    remote_result = ocx.plain("--remote", "index", "list", pkg_v1.short)
+    assert remote_result.returncode == 0, (
+        f"AC9: --remote index list must succeed; rc={remote_result.returncode}\n"
+        f"stderr: {remote_result.stderr}"
+    )
+    # After --remote index list the tag file must have been refreshed to digest_B.
+    refreshed_data = json.loads(tag_file.read_text())
+    stored_after_remote = refreshed_data["tags"].get(pkg_v1.tag)
+    assert stored_after_remote == digest_b, (
+        f"AC9: --remote index list must bypass cache and update tag to registry digest.\n"
+        f"Expected (registry) digest_B: {digest_b}\n"
+        f"Found in tag file after --remote: {stored_after_remote}"
+    )
+
+    # Restore the stale cache again so we can verify default mode still uses it.
+    tag_file.write_text(v1_snapshot)
+
+    # Step 6: default (no --remote) index list must NOT refresh → cache stays digest_A.
+    default_result = ocx.plain("index", "list", pkg_v1.short)
+    assert default_result.returncode == 0, (
+        f"AC9: index list (default mode) must succeed; rc={default_result.returncode}"
+    )
+    default_data = json.loads(tag_file.read_text())
+    stored_after_default = default_data["tags"].get(pkg_v1.tag)
+    assert stored_after_default == digest_a, (
+        f"AC9: default-mode index list must not refresh the tag cache.\n"
+        f"Expected (cached) digest_A: {digest_a}\n"
+        f"Found in tag file after default list: {stored_after_default}"
+    )

--- a/website/src/docs/getting-started.md
+++ b/website/src/docs/getting-started.md
@@ -21,7 +21,7 @@ ocx --remote exec uv:0.10 -- uv --version
 
 <Terminal src="/casts/exec.cast" title="Running a package" collapsed />
 
-The binary is cached in the [object store][fs-objects], so subsequent calls with the same version skip the download and don't need `--remote`. Nothing else persists: no [candidate symlink][fs-symlinks], no [current pointer][fs-symlinks].
+The binary is cached in the [object store][fs-objects], so subsequent calls with the same version skip the download. Nothing else persists: no [candidate symlink][fs-symlinks], no [current pointer][fs-symlinks].
 
 ::: tip
 Use [`ocx exec`][cmd-exec] for one-off tasks or in CI where you want a reproducible, isolated invocation. For tools you reach for every day, read on.

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -32,13 +32,24 @@ The available data depends on the command being executed.
 
 ### `--offline` {#arg-offline}
 
-When set, ocx will run in offline mode, which will not attempt to fetch any remote information.
+When set, ocx will run in offline mode and will not attempt to fetch any remote information.
 If any command requires information that is not already available locally, it will fail with an error.
+
+::: warning
+Running `ocx --offline install <pkg>` after a bare `ocx index update <pkg>` (without a prior
+online install) fails with an `OfflineManifestMissing` error that names the missing digest.
+`ocx index update` writes only tag→digest pointers; it does not download manifest or layer blobs.
+Run `ocx install <pkg>` online first to populate the blob cache, then offline installs will work.
+:::
 
 ### `--remote` {#arg-remote}
 
-When set, ocx will use the remote index by default instead of the local index.
-Combining this flag with [`--offline`](#arg-offline) will most likely result in an error.
+When set, tag and catalog lookups query the registry directly, bypassing the local tag store.
+Digest-addressed blob reads (manifests and layers already identified by a content digest) still
+use the local cache and write newly fetched blobs through to `$OCX_HOME/blobs/`.
+Only `$OCX_HOME/tags/` is not updated — the persistent local tag snapshot is left unchanged.
+
+Combining this flag with [`--offline`](#arg-offline) will result in an error.
 
 ### `--index` {#arg-index}
 
@@ -329,9 +340,16 @@ Lists available tags for one or more packages.
 ocx index update <PACKAGE>...
 ```
 
-Updates the local index by fetching the latest information from the remote index for the specified packages.
+Writes tag→digest pointers to `$OCX_HOME/tags/` for the specified packages by querying the
+registry directly. No manifest or layer blobs are written to `$OCX_HOME/blobs/`.
 
-When a tagged identifier is used (e.g., `cmake:3.28`), only that single tag's digest and manifest are fetched — the remote tag listing is skipped entirely. This is ideal for lockfile workflows where the local index should contain only explicitly requested tags. When a bare identifier is used (e.g., `cmake`), all tags are fetched as before.
+When a tagged identifier is used (e.g., `cmake:3.28`), only that single tag's digest pointer is
+recorded — the remote tag listing is skipped entirely. This is ideal for lockfile workflows where
+the local tag store should contain only explicitly requested tags. When a bare identifier is used
+(e.g., `cmake`), digest pointers for all tags are recorded.
+
+After running `ocx index update <pkg>`, an `ocx --offline install <pkg>` will fail with
+`OfflineManifestMissing` until the blob cache is populated by a prior online `ocx install <pkg>`.
 
 **Arguments**
 

--- a/website/src/docs/reference/environment.md
+++ b/website/src/docs/reference/environment.md
@@ -147,7 +147,11 @@ The command line option [`--offline`](command-line#arg-offline) takes precedence
 
 ### `OCX_REMOTE` {#ocx-remote}
 
-When set to a [truthy value](#truthy-values), OCX will use the remote index by default instead of the local index.
+When set to a [truthy value](#truthy-values), tag and catalog lookups query the registry directly,
+bypassing the local tag store. Digest-addressed blob reads still use the local cache with
+write-through to `$OCX_HOME/blobs/`. Only `$OCX_HOME/tags/` is not updated.
+
+Equivalent to passing the [`--remote`][arg-remote] flag on every invocation.
 
 ## External {#external}
 

--- a/website/src/docs/user-guide.md
+++ b/website/src/docs/user-guide.md
@@ -105,7 +105,7 @@ The tag store is a *snapshot*: it reflects the state of the remote registry at t
 `apt-get update` downloads package metadata from configured sources and caches it in `/var/lib/apt/lists/`. All subsequent `apt-get install` calls resolve packages from that local snapshot — the network is only involved during an explicit refresh, not on every install. `ocx index update <package>` is the per-package equivalent: you control when the snapshot changes, and the rest of the time you work from the local cache.
 :::
 
-`ocx index update <package>` refreshes the tag store for a specific package. The global flag [`--remote`][arg-remote] skips the local tag store entirely and queries the registry directly for a single command — useful for a one-off check without updating the persistent snapshot.
+`ocx index update <package>` refreshes the tag store for a specific package. The global flag [`--remote`][arg-remote] forces tag and catalog lookups to query the registry directly for a single command, without updating the persistent local tag snapshot. Blob data fetched under `--remote` still populates `$OCX_HOME/blobs/` via write-through, so subsequent offline installs work for any package that was resolved while online.
 
 On a fresh machine, you do not need to run [`ocx index update`][cmd-index-update] before the first [`ocx install cmake:3.28`][cmd-install]. When the local tag store has no entry for a requested tag, [`ocx install`][cmd-install] transparently resolves that single tag against the configured remote, persists it to the tag store, and proceeds with the install. Subsequent commands — including [`--offline`][arg-offline] — then work from the cached entry without touching the network. Refreshing a cached tag or discovering every tag for a repository is still the job of [`ocx index update`][cmd-index-update]; the fallback only covers the specific tag being installed.
 
@@ -426,7 +426,7 @@ Every command that resolves a package identifier — [`ocx install`][cmd-install
 | Remote | [`--remote`][arg-remote] | OCI registry | Yes |
 | Offline | [`--offline`][arg-offline] | Local snapshot | Never |
 
-**`--remote`** bypasses the local snapshot for a single command and queries the registry directly. The persistent local index is not updated. Use it for a one-off check — seeing current available tags, or resolving the latest digest — without committing the result to the local snapshot.
+**`--remote`** forces tag and catalog lookups to query the registry directly for a single command. The persistent local tag store (`$OCX_HOME/tags/`) is not updated. Blob data fetched under `--remote` still writes through to `$OCX_HOME/blobs/`, so the command populates the blob cache while bypassing the tag snapshot. Use it for a one-off check — seeing current available tags, or resolving the latest digest — without committing the tag resolution result to the local snapshot.
 
 **`--offline`** prevents all network access for that command. If the local index does not have a requested package, the command fails immediately rather than attempting a registry query. Useful to verify that your current index and object store are self-sufficient before a build in a restricted or air-gapped environment.
 


### PR DESCRIPTION
## Summary

- Full resolution-chain refs — every intermediate image index and child manifest is linked into the installed package's `refs/blobs/`, so packages are re-resolvable offline via any tag path they've ever been resolved through.
- `ocx clean` safely collects orphan blobs (the hardcoded `tier != CasTier::Blob` exemption is removed); GC is now reachability-based end-to-end.
- `--remote` becomes a cache-mode hint: mutable lookups (tags, catalog) bypass the cache, but content-addressed reads still use the local cache and write-through.
- BlobGuard primitive (direct-lock on the blob `data` file), collapsed LocalIndex write API (`write_chain_and_commit_tag`), singleflight-deduped chain walks, and async idempotent `link_blobs`.

## Breaking changes

- `--remote`: "use RemoteIndex directly" → "force mutable lookups to source; digest-addressed reads still use the chained cache".
- `ocx index update` no longer pre-walks manifests. `ocx --offline install` after a bare `ocx index update` fails with `OfflineManifestMissing` where it would previously have succeeded — run the first install online instead.

Closes #35.

## Test plan

- [x] `task verify` passes on `535f26d`
- [x] Acceptance: `test/tests/test_resolution_chain_refs.py` covers AC1–AC13 (refs completeness, offline re-resolve, --remote tag refresh, clean collecting real chain blobs after uninstall --purge, concurrent installs, no sidecar files, and the latent `update_tags` regression)
- [x] Unit: singleflight N=8 dedup, link_blobs empty-chain + path independence, BlobGuard truncation contract, 401-leader and connection-refused-leader fallback propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)