### PR TITLE
refactor: unify bounded-concurrency fan-out on stream::buffered

### DIFF
--- a/crates/ocx_cli/src/command/index_catalog.rs
+++ b/crates/ocx_cli/src/command/index_catalog.rs
@@ -4,9 +4,19 @@
 use std::process::ExitCode;
 
 use clap::Parser;
+use futures::stream::{self, StreamExt};
 use ocx_lib::{log, oci};
 
 use crate::api;
+
+/// Maximum concurrent registry tag fetches when expanding `index catalog --tags`.
+///
+/// Each fetch hits the registry once per repository. The cap keeps interactive
+/// `ocx index catalog --tags` runs well under typical registry rate-limit
+/// budgets (Docker Hub anonymous pull is 100 req/6h per IP) while still being
+/// large enough that a dev-internal registry catalog of dozens of repos
+/// completes in roughly the same wall time as the previous unbounded fan-out.
+const CATALOG_TAG_FETCH_CONCURRENCY: usize = 8;
 
 #[derive(Parser)]
 pub struct IndexCatalog {
@@ -41,31 +51,34 @@ impl IndexCatalog {
             return Ok(ExitCode::SUCCESS);
         }
 
-        let mut join_set = tokio::task::JoinSet::<anyhow::Result<(String, Vec<String>)>>::new();
-        for repo in &repositories {
-            let identifier = oci::Identifier::new_registry(repo.repository(), repo.registry());
-            let display_name = repo.to_string();
-            let context = context.clone();
-            join_set.spawn(async move {
-                let tags = match context.default_index().list_tags(&identifier).await? {
-                    Some(tags) => tags,
-                    None => {
-                        log::warn!("No tags found for repository '{}'.", identifier);
-                        Vec::new()
-                    }
-                };
-                Ok((display_name, tags))
-            });
-        }
+        // Fetch tags with bounded concurrency. `repositories` was sorted at
+        // line 35 and `.buffered` preserves submission order, so the collected
+        // vec is already in display-name order — no separate reorder step.
+        let collected: Vec<(String, Result<Option<Vec<String>>, _>)> = stream::iter(repositories.iter())
+            .map(|repo| {
+                let identifier = oci::Identifier::new_registry(repo.repository(), repo.registry());
+                let display_name = repo.to_string();
+                let context = context.clone();
+                async move {
+                    let result = context.default_index().list_tags(&identifier).await;
+                    (display_name, result)
+                }
+            })
+            .buffered(CATALOG_TAG_FETCH_CONCURRENCY)
+            .collect()
+            .await;
 
-        let mut tags = std::collections::BTreeMap::new();
-        while let Some(result) = join_set.join_next().await {
-            if let Ok(Ok((repository, repository_tags))) = result {
-                tags.insert(repository, repository_tags);
-            } else if let Ok(Err(e)) = result {
-                log::error!("Error fetching tags for repository: {:?}", e);
-            } else if let Err(e) = result {
-                log::error!("Task panicked while fetching tags for repository: {:?}", e);
+        let mut tags: Vec<(String, Vec<String>)> = Vec::with_capacity(collected.len());
+        for (display_name, result) in collected {
+            match result {
+                Ok(Some(repo_tags)) => tags.push((display_name, repo_tags)),
+                Ok(None) => {
+                    log::warn!("No tags found for repository '{display_name}'.");
+                    tags.push((display_name, Vec::new()));
+                }
+                Err(e) => {
+                    log::error!("Error fetching tags for repository '{display_name}': {e:?}");
+                }
             }
         }
 

--- a/crates/ocx_cli/src/command/index_update.rs
+++ b/crates/ocx_cli/src/command/index_update.rs
@@ -4,9 +4,19 @@
 use std::process::ExitCode;
 
 use clap::Parser;
+use futures::stream::{self, StreamExt};
 use ocx_lib::{log, oci::index};
 
 use crate::options;
+
+/// Maximum concurrent registry tag refreshes when running `index update`.
+///
+/// Each task hits the remote registry once per identifier. The cap matches
+/// `index catalog --tags` (`CATALOG_TAG_FETCH_CONCURRENCY = 8`) — both are
+/// network-bound interactive commands with the same registry rate-limit
+/// budget. `.buffered` preserves input order, so error logs land in
+/// package-list order instead of arrival order.
+const INDEX_UPDATE_CONCURRENCY: usize = 8;
 
 #[derive(Parser)]
 pub struct IndexUpdate {
@@ -23,19 +33,20 @@ impl IndexUpdate {
         let remote_index = index::Index::from_remote(context.remote_index()?.clone());
         let packages = options::Identifier::transform_all(self.packages.clone(), context.default_registry())?;
 
-        let mut join_set = tokio::task::JoinSet::new();
-        for identifier in &packages {
-            let remote_index = remote_index.clone();
-            let context = context.clone();
-            let identifier = identifier.clone();
-            join_set.spawn(async move { context.local_index().refresh_tags(&identifier, &remote_index).await });
-        }
+        let results = stream::iter(packages.iter())
+            .map(|identifier| {
+                let remote_index = remote_index.clone();
+                let context = context.clone();
+                let identifier = identifier.clone();
+                async move { context.local_index().refresh_tags(&identifier, &remote_index).await }
+            })
+            .buffered(INDEX_UPDATE_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
 
-        while let Some(result) = join_set.join_next().await {
-            match result {
-                Ok(Ok(())) => (),
-                Ok(Err(e)) => log::error!("Failed to update index for a package: {e}"),
-                Err(e) => log::error!("Task panicked while updating index for a package: {e}"),
+        for result in results {
+            if let Err(e) = result {
+                log::error!("Failed to update index for a package: {e}");
             }
         }
 

--- a/crates/ocx_lib/src/package_manager/tasks/garbage_collection/reachability_graph.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/garbage_collection/reachability_graph.rs
@@ -11,8 +11,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tokio::sync::Semaphore;
-use tokio::task::JoinSet;
+use futures::stream::{self, StreamExt};
 
 use crate::{
     file_structure::{CasTier, FileStructure},
@@ -65,48 +64,45 @@ impl ReachabilityGraph {
             })
             .collect();
 
-        // Spawn parallel I/O tasks to probe refs/ for each package.
-        let sem = Arc::new(Semaphore::new(BUILD_CONCURRENCY));
-        let mut tasks = JoinSet::new();
-
+        // Probe refs/ for each package with bounded concurrency. The same
+        // `.buffered` pattern is used by the pull-side `extract_layers` /
+        // `setup_dependencies` and the push-side `push_layers_to_repository`.
         let packages_root = Arc::new(canon_packages_root);
         let layers_root = Arc::new(canon_layers_root);
         let blobs_root = Arc::new(canon_blobs_root);
 
-        for pkg in &package_dirs {
-            let pkg_dir = canonicalize_or_keep(&pkg.dir);
-            let deps_dir = pkg.refs_deps_dir();
-            let layers_dir = pkg.refs_layers_dir();
-            let blobs_dir = pkg.refs_blobs_dir();
-            let pkgs_root = Arc::clone(&packages_root);
-            let lyrs_root = Arc::clone(&layers_root);
-            let blbs_root = Arc::clone(&blobs_root);
-            let sem = Arc::clone(&sem);
-
-            tasks.spawn(async move {
-                let _permit = sem.acquire_owned().await.expect("semaphore closed");
-                let is_root = has_live_refs(&pkg_dir).await;
-                let dep_refs = read_refs(&deps_dir, &pkgs_root).await;
-                let layer_refs = read_refs(&layers_dir, &lyrs_root).await;
-                let blob_refs = read_refs(&blobs_dir, &blbs_root).await;
-                let mut all_edges = dep_refs;
-                all_edges.extend(layer_refs);
-                all_edges.extend(blob_refs);
-                (pkg_dir, is_root, all_edges)
-            });
-        }
+        let collected: Vec<(PathBuf, bool, Vec<PathBuf>)> = stream::iter(package_dirs.iter())
+            .map(|pkg| {
+                let pkg_dir = canonicalize_or_keep(&pkg.dir);
+                let deps_dir = pkg.refs_deps_dir();
+                let layers_dir = pkg.refs_layers_dir();
+                let blobs_dir = pkg.refs_blobs_dir();
+                let pkgs_root = Arc::clone(&packages_root);
+                let lyrs_root = Arc::clone(&layers_root);
+                let blbs_root = Arc::clone(&blobs_root);
+                async move {
+                    let is_root = has_live_refs(&pkg_dir).await;
+                    let dep_refs = read_refs(&deps_dir, &pkgs_root).await;
+                    let layer_refs = read_refs(&layers_dir, &lyrs_root).await;
+                    let blob_refs = read_refs(&blobs_dir, &blbs_root).await;
+                    let mut all_edges = dep_refs;
+                    all_edges.extend(layer_refs);
+                    all_edges.extend(blob_refs);
+                    (pkg_dir, is_root, all_edges)
+                }
+            })
+            .buffered(BUILD_CONCURRENCY)
+            .collect()
+            .await;
 
         let mut roots = HashSet::new();
         let mut edges = HashMap::new();
         let mut all_entries = HashMap::new();
 
-        while let Some(result) = tasks.join_next().await {
-            let (pkg_dir, is_root, pkg_edges) = result.expect("task panicked");
-
+        for (pkg_dir, is_root, pkg_edges) in collected {
             if is_root || profile_roots.contains(&pkg_dir) {
                 roots.insert(pkg_dir.clone());
             }
-
             edges.insert(pkg_dir.clone(), pkg_edges);
             all_entries.insert(pkg_dir, CasTier::Package);
         }

--- a/crates/ocx_lib/src/package_manager/tasks/pull.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/pull.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::time::Duration;
 
+use futures::stream::{self, StreamExt, TryStreamExt};
 use tokio::task::JoinSet;
 use tracing::{Instrument, info_span};
 
@@ -34,6 +35,30 @@ const PACKAGE_SETUP_TIMEOUT: Duration = Duration::from_mins(10);
 /// to accommodate slow networks and large payloads while still bounding a
 /// hung leader.
 const LAYER_SETUP_TIMEOUT: Duration = Duration::from_mins(30);
+
+/// Maximum number of layer extractions to run concurrently.
+///
+/// Each extraction acquires an exclusive `TempStore` lock, opens an HTTP
+/// connection, writes a staged temp dir, and performs an atomic rename into
+/// `layers/{digest}/`. Unbounded fan-out is bounded here to cap FD usage and
+/// temp-dir churn. This is a *different* resource axis than
+/// `oci::client::LAYER_PUSH_CONCURRENCY`, which caps in-memory archive
+/// buffers — do not collapse the two constants without re-justifying both
+/// rationales.
+const LAYER_PULL_CONCURRENCY: usize = 4;
+
+/// Maximum number of dependency setups to run concurrently.
+///
+/// Each dependency setup itself fans out to layer extraction (capped by
+/// [`LAYER_PULL_CONCURRENCY`]) and may recursively setup its own deps. The cap
+/// bounds fan-out **per node**, not globally across the dep tree: at depth-1
+/// (direct deps only) the worst case is `DEPS_SETUP_CONCURRENCY ×
+/// LAYER_PULL_CONCURRENCY` = 16 concurrent layer extractions; deeper trees
+/// multiply this per level (singleflight dedups duplicate work but does not
+/// cap total in-flight work). Raising this cap multiplies the worst-case
+/// FD / temp-lock pressure and must be considered alongside
+/// `LAYER_PULL_CONCURRENCY`.
+const DEPS_SETUP_CONCURRENCY: usize = 4;
 
 /// Singleflight group keyed by [`PinnedIdentifier`](oci::PinnedIdentifier)
 /// (advisory tag stripped) for in-process dedup of concurrent dependency setups.
@@ -428,26 +453,20 @@ async fn setup_dependencies(
         deps.len(),
     );
 
-    let mut tasks = JoinSet::new();
-
-    for (idx, dep) in deps.iter().enumerate() {
-        let mgr = mgr.clone();
-        let dep_id = dep.identifier.clone();
-        let platforms = platforms.clone();
-        let groups = groups.clone();
-        tasks.spawn(async move {
-            let info = setup_with_tracker(&mgr, &dep_id, platforms, groups).await?;
-            Ok::<_, PackageErrorKind>((idx, info))
-        });
-    }
-
-    let mut results: Vec<Option<InstallInfo>> = vec![None; deps.len()];
-    while let Some(join_result) = tasks.join_next().await {
-        let (idx, info) = join_result.expect("dependency setup task panicked")?;
-        results[idx] = Some(info);
-    }
-
-    Ok(results.into_iter().flatten().collect())
+    // Dispatch dependency setups with bounded concurrency, mirroring
+    // `extract_layers` and the push-side `push_layers_to_repository`.
+    // `.buffered` preserves submission order, so the returned `Vec` is
+    // already in dependency declaration order — no separate reorder step.
+    stream::iter(deps.iter().cloned())
+        .map(|dep| {
+            let mgr = mgr.clone();
+            let platforms = platforms.clone();
+            let groups = groups.clone();
+            async move { setup_with_tracker(&mgr, &dep.identifier, platforms, groups).await }
+        })
+        .buffered(DEPS_SETUP_CONCURRENCY)
+        .try_collect()
+        .await
 }
 
 /// Post processing after download of the package content and all dependencies are fully set up.
@@ -530,27 +549,22 @@ async fn extract_layers(
         parsed.push((layer.clone(), digest));
     }
 
-    // Dispatch extractions in parallel. JoinSet results come back in
-    // completion order, so we tag each task with its index and reorder at
-    // the end to preserve manifest declaration order.
-    let mut tasks: JoinSet<(usize, Result<oci::Digest, PackageErrorKind>)> = JoinSet::new();
-    for (idx, (layer, digest)) in parsed.into_iter().enumerate() {
-        let mgr = mgr.clone();
-        let pinned = pinned.clone();
-        let metadata = metadata.clone();
-        let layer_group = layer_group.clone();
-        tasks.spawn(async move {
-            let res = extract_layer_atomic(&mgr, &pinned, &layer, &digest, &metadata, layer_group).await;
-            (idx, res)
-        });
-    }
-
-    let mut results: Vec<Option<oci::Digest>> = (0..tasks.len()).map(|_| None).collect();
-    while let Some(join_res) = tasks.join_next().await {
-        let (idx, task_res) = join_res.expect("layer extraction task panicked");
-        results[idx] = Some(task_res?);
-    }
-    Ok(results.into_iter().flatten().collect())
+    // Dispatch extractions with bounded concurrency, mirroring the push-side
+    // pattern in `oci/client.rs` (`LAYER_PUSH_CONCURRENCY` declared near the
+    // top of that file, `.buffered` call inside `push_layers_to_repository`).
+    // `.buffered` preserves submission order, so the returned `Vec` is already
+    // in manifest declaration order — no separate reorder step needed.
+    stream::iter(parsed)
+        .map(|(layer, digest)| {
+            let mgr = mgr.clone();
+            let pinned = pinned.clone();
+            let metadata = metadata.clone();
+            let layer_group = layer_group.clone();
+            async move { extract_layer_atomic(&mgr, &pinned, &layer, &digest, &metadata, layer_group).await }
+        })
+        .buffered(LAYER_PULL_CONCURRENCY)
+        .try_collect::<Vec<oci::Digest>>()
+        .await
 }
 
 /// Atomically extracts a single layer into `layers/{digest}/`, dedup-ing
@@ -741,4 +755,89 @@ fn link_layers_in_temp(
         crate::symlink::create(&layer_content, &link_path).map_err(PackageErrorKind::Internal)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod extract_layers_concurrency_tests {
+    //! Regression guards for the `.buffered` combinator shape used by
+    //! `extract_layers` (and now `setup_dependencies`).
+    //!
+    //! These tests assert two properties of the combinator pattern:
+    //! concurrency is capped at the configured constant, and output preserves
+    //! submission order. They do **not** exercise `extract_layer_atomic` or
+    //! `setup_with_tracker` — those code paths (singleflight, post-lock recheck,
+    //! TempStore atomicity, RAII cleanup) are covered by the multi-layer
+    //! install scenarios in the pytest acceptance suite (`test/tests/`).
+    //!
+    //! If the combinator is ever swapped to `.buffer_unordered` or the cap is
+    //! removed, the order/concurrency assertions here fire loudly. Behavioral
+    //! regressions inside the per-layer/per-dep work fall to the acceptance
+    //! tests instead.
+    //!
+    //! Cap coverage: only `LAYER_PULL_CONCURRENCY` is exercised here.
+    //! `DEPS_SETUP_CONCURRENCY` shares the same combinator shape, so a
+    //! `.buffer_unordered` swap there would also break callers, but a regression
+    //! that raises only `DEPS_SETUP_CONCURRENCY` would not be caught at this
+    //! layer — that path is guarded by the multi-dep install scenarios in
+    //! `test/tests/test_dependencies.py`.
+
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use futures::stream::{self, StreamExt, TryStreamExt};
+
+    use super::LAYER_PULL_CONCURRENCY;
+
+    /// Verifies the two contract properties of the `.buffered(N)` shape used by
+    /// `extract_layers`:
+    /// 1. Concurrency is capped at `LAYER_PULL_CONCURRENCY` — guards against an
+    ///    accidental cap-removal or `.buffered(usize::MAX)` regression.
+    /// 2. Output preserves submission order — guards against an accidental swap
+    ///    to `.buffer_unordered`, which would break manifest declaration order.
+    ///
+    /// The futures use strictly *decreasing* latency by index so that under
+    /// `.buffer_unordered` the output would not be `0..N`. Without that, both
+    /// combinators would be observationally indistinguishable for this input
+    /// and Assertion 2 would not be a real regression guard.
+    #[tokio::test(flavor = "current_thread")]
+    async fn buffered_caps_concurrency_and_preserves_order() {
+        const N: usize = 32;
+
+        let current = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+
+        let result: Vec<usize> = stream::iter(0..N)
+            .map(|i| {
+                let current = current.clone();
+                let max_seen = max_seen.clone();
+                async move {
+                    let now = current.fetch_add(1, Ordering::Relaxed) + 1;
+                    max_seen.fetch_max(now, Ordering::Relaxed);
+                    // Strictly decreasing latency with index: within any concurrent
+                    // window, the LAST-submitted future finishes FIRST. Under
+                    // `.buffered` the output is still 0..N (submission order is
+                    // enforced by the combinator). Under `.buffer_unordered` the
+                    // output would start with a higher index and Assertion 2 fails.
+                    tokio::time::sleep(Duration::from_millis((N - i) as u64)).await;
+                    current.fetch_sub(1, Ordering::Relaxed);
+                    Ok::<usize, std::convert::Infallible>(i)
+                }
+            })
+            .buffered(LAYER_PULL_CONCURRENCY)
+            .try_collect()
+            .await
+            .unwrap();
+
+        // Assertion 1: bounded concurrency — catches a raised/removed cap.
+        assert!(
+            max_seen.load(Ordering::Relaxed) <= LAYER_PULL_CONCURRENCY,
+            "max in-flight futures {} exceeded LAYER_PULL_CONCURRENCY {}",
+            max_seen.load(Ordering::Relaxed),
+            LAYER_PULL_CONCURRENCY,
+        );
+
+        // Assertion 2: input-order preservation — catches a `.buffer_unordered` swap.
+        assert_eq!(result, (0..N).collect::<Vec<_>>());
+    }
 }

--- a/crates/ocx_lib/src/reference_manager.rs
+++ b/crates/ocx_lib/src/reference_manager.rs
@@ -3,9 +3,18 @@
 
 use std::path::{Path, PathBuf};
 
+use futures::stream::{self, StreamExt, TryStreamExt};
 use sha2::{Digest, Sha256};
 
 use crate::{Error, Result, file_structure::FileStructure, file_structure::cas_ref_name, log, symlink, utility};
+
+/// Maximum concurrent `refs/symlinks/` scans during [`ReferenceManager::broken_refs`].
+///
+/// Each task does cheap directory I/O (one `read_dir` plus a `read_link` per
+/// entry) so we can fan out widely; the cap is the same baseline used elsewhere
+/// for I/O-bound directory walks (see `utility::fs::dir_walker`) and preserves
+/// the historical bound of 50 in-flight scans.
+const BROKEN_REFS_CONCURRENCY: usize = 50;
 
 /// Manages forward symlinks and their back-references inside the object store.
 ///
@@ -231,27 +240,23 @@ impl ReferenceManager {
             return Ok(Vec::new());
         }
 
-        let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(50));
-        let mut tasks = tokio::task::JoinSet::new();
-
+        // Pre-filter sequentially: skipping inside the stream would waste a
+        // concurrency slot on a cheap probe.
+        let mut to_check: Vec<(PathBuf, PathBuf)> = Vec::new();
         for obj in &package_dirs {
             let refs_dir = obj.refs_symlinks_dir();
             if !utility::fs::path_exists_lossy(&refs_dir).await {
                 continue;
             }
-            let content = obj.content();
-            let sem = std::sync::Arc::clone(&sem);
-            tasks.spawn(async move {
-                let _permit = sem.acquire_owned().await.expect("semaphore closed");
-                check_refs_dir(&refs_dir, &content).await
-            });
+            to_check.push((refs_dir, obj.content()));
         }
 
-        let mut broken = Vec::new();
-        while let Some(result) = tasks.join_next().await {
-            broken.extend(result.expect("task panicked")?);
-        }
-
+        let nested: Vec<Vec<PathBuf>> = stream::iter(to_check)
+            .map(|(refs_dir, content)| async move { check_refs_dir(&refs_dir, &content).await })
+            .buffered(BROKEN_REFS_CONCURRENCY)
+            .try_collect()
+            .await?;
+        let mut broken: Vec<PathBuf> = nested.into_iter().flatten().collect();
         broken.sort();
 
         if broken.is_empty() {


### PR DESCRIPTION
## Summary

Replaces `JoinSet` (with manual `Semaphore` or ad-hoc index-reorder) with `futures::stream::iter(...).buffered(N)` across five fan-out sites, matching the push-side idiom already in `oci/client.rs`.

| Site | Cap |
|---|---|
| `pull::extract_layers` | `LAYER_PULL_CONCURRENCY = 4` |
| `pull::setup_dependencies` | `DEPS_SETUP_CONCURRENCY = 4` |
| `reachability_graph::build` | `BUILD_CONCURRENCY` |
| `reference_manager::broken_refs` | `BROKEN_REFS_CONCURRENCY = 50` |
| `index_catalog --tags` / `index_update` | `8` |

`.buffered` preserves submission order, so the post-join reorder steps in `extract_layers` and `setup_dependencies` drop out entirely. Each cap has a doc-comment citing its resource axis (FD / temp-lock / network rate-limit / directory I/O).

Refs #49.

## Test plan

- [x] `task verify` passes locally
- [x] New unit test `buffered_caps_concurrency_and_preserves_order` guards the combinator shape (cap + order) against a `.buffer_unordered` or cap-removal regression
- [ ] CI green on this branch