### PR TITLE
ci(release): release-readiness gate + portable macOS shell activation

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,64 @@
+name: Release Readiness
+
+# One pre-release GO/NO-GO gate. Dispatch this on the ref you intend to release
+# (e.g. `gh workflow run release-readiness.yml --ref main` before tagging vX.Y.Z).
+# It runs the full cross-platform deep coverage as reusable workflows and rolls
+# their results into a single verdict:
+#
+#   - Verify Deep            — build + unit test on Linux/macOS/Windows, plus
+#                              Windows ARM64 cross-compile and Linux acceptance.
+#   - Shell Activation Deep  — `ocx self setup` activation on macOS + Windows.
+#
+# Linux per-PR gates (verify-basic.yml, shell-activation.yml) already cover the
+# Linux surface on every change; this gate adds the expensive macOS/Windows
+# coverage on demand so a green run means "safe to cut the release". It is NOT
+# wired into the cargo-dist release.yml — run it yourself before tagging.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  deep:
+    name: Verify Deep
+    uses: ./.github/workflows/verify-deep.yml
+
+  shells:
+    name: Shell Activation Deep
+    uses: ./.github/workflows/shell-activation-deep.yml
+
+  gate:
+    name: Verdict
+    needs: [deep, shells]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report GO/NO-GO
+        env:
+          DEEP_RESULT: ${{ needs.deep.result }}
+          SHELLS_RESULT: ${{ needs.shells.result }}
+        run: |
+          {
+            echo "## Release Readiness"
+            echo ""
+            echo "| Check | Result |"
+            echo "| --- | --- |"
+            echo "| Verify Deep (Linux/macOS/Windows unit + Linux acceptance) | \`${DEEP_RESULT}\` |"
+            echo "| Shell Activation Deep (macOS + Windows) | \`${SHELLS_RESULT}\` |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "${DEEP_RESULT}" = "success" ] && [ "${SHELLS_RESULT}" = "success" ]; then
+            echo "**Verdict: GO - safe to release.**" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Verdict: NO-GO - do not release.**" >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Release readiness NO-GO (verify-deep=${DEEP_RESULT}, shell-activation-deep=${SHELLS_RESULT})"
+            exit 1
+          fi

--- a/.github/workflows/shell-activation-deep.yml
+++ b/.github/workflows/shell-activation-deep.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     # Weekly, Monday 06:00 UTC — catches platform drift without per-PR cost.
     - cron: "0 6 * * 1"
+  # Reusable: composed into the pre-release `release-readiness.yml` gate so a
+  # single dispatch reports one GO/NO-GO across all platforms.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/verify-deep.yml
+++ b/.github/workflows/verify-deep.yml
@@ -2,6 +2,9 @@ name: Verify Deep
 
 on:
   workflow_dispatch:
+  # Reusable: composed into the pre-release `release-readiness.yml` gate so a
+  # single dispatch reports one GO/NO-GO across all platforms.
+  workflow_call:
 
 permissions:
   contents: read

--- a/test/tests/test_shell_activation.py
+++ b/test/tests/test_shell_activation.py
@@ -236,13 +236,31 @@ def test_nushell_dedicated_activation_survives_unset_ocx_home(tmp_path: Path) ->
     _assert_activation("nu", result, bin_seg)
 
 
+def _script_pty_command(script_abs: str, command: list[str]) -> list[str]:
+    """Wrap ``command`` in a ``script(1)`` pty invocation, portable across flavors.
+
+    elvish only sources ``rc.elv`` for an *interactive* shell, so it must run on a
+    tty; ``script(1)`` supplies one. The two ``script`` flavors disagree on how the
+    command is passed, so the invocation cannot be shared verbatim:
+
+    * util-linux (Linux):  ``script -qec "<cmd string>" <typescript-file>``
+    * BSD (macOS):         ``script -q <typescript-file> <cmd> [args...]``
+
+    The Linux form is preserved byte-for-byte (the shell-zoo matrix runs it); macOS
+    gets the trailing-argv form because BSD ``script`` has no ``-c`` flag.
+    """
+    if sys.platform == "darwin":
+        return [script_abs, "-q", "/dev/null", *command]
+    return [script_abs, "-qec", " ".join(command), "/dev/null"]
+
+
 def test_elvish_fence_activation_survives_unset_ocx_home(tmp_path: Path) -> None:
     shell_abs = shutil.which("elvish")
     if shell_abs is None:
         pytest.skip("elvish not installed on this host")
     script_abs = shutil.which("script")
     if script_abs is None:
-        pytest.skip("util-linux script(1) is needed to drive elvish in a pty")
+        pytest.skip("script(1) is needed to drive elvish in a pty")
 
     home = tmp_path / "home"
     home.mkdir()
@@ -257,7 +275,7 @@ def test_elvish_fence_activation_survives_unset_ocx_home(tmp_path: Path) -> None
     env = _clean_env(home, shell_abs)
     env["TERM"] = "dumb"
     result = subprocess.run(
-        [script_abs, "-qec", f"{shell_abs} -rc {rc}", "/dev/null"],
+        _script_pty_command(script_abs, [shell_abs, "-rc", str(rc)]),
         input="print $E:PATH\nexit\n",
         capture_output=True,
         text=True,

--- a/test/tests/test_shell_activation.py
+++ b/test/tests/test_shell_activation.py
@@ -246,12 +246,17 @@ def _script_pty_command(script_abs: str, command: list[str]) -> list[str]:
     * util-linux (Linux):  ``script -qec "<cmd string>" <typescript-file>``
     * BSD (macOS):         ``script -q <typescript-file> <cmd> [args...]``
 
-    The Linux form is preserved byte-for-byte (the shell-zoo matrix runs it); macOS
-    gets the trailing-argv form because BSD ``script`` has no ``-c`` flag.
+    The Linux form keeps the original ``-c`` shape; macOS gets the trailing-argv
+    form because BSD ``script`` has no ``-c`` flag.
     """
     if sys.platform == "darwin":
         return [script_abs, "-q", "/dev/null", *command]
     return [script_abs, "-qec", " ".join(command), "/dev/null"]
+
+
+# Marker the appended elvish probe prints so the PATH line is unambiguous amid any
+# terminal-init escapes the interactive pty session emits.
+_ELVISH_PATH_PROBE = "OCX_ELVISH_PATH_PROBE:"
 
 
 def test_elvish_fence_activation_survives_unset_ocx_home(tmp_path: Path) -> None:
@@ -268,15 +273,22 @@ def test_elvish_fence_activation_survives_unset_ocx_home(tmp_path: Path) -> None
     bin_seg = str(ocx_home / _BIN_REL)
     rc = _dedicated_setup("elvish", shell_abs, home, ocx_home)
 
-    # rc.elv is only sourced for an *interactive* elvish (its completion block
-    # needs the interactive-only `edit:` module), so the fence cannot be tested
-    # with `-c`. Drive a real interactive elvish in a pty via script(1) with `-rc`
-    # so it sources the fence exactly as a login shell would, with OCX_HOME unset.
+    # rc.elv is sourced top-to-bottom during elvish's *interactive* startup (its
+    # completion block needs the interactive-only `edit:` module), before the REPL
+    # begins. Rather than drive the REPL with fed keystrokes — racy across script(1)
+    # flavors, since BSD script forwards a closed stdin as an immediate Ctrl-D so the
+    # line editor never runs the input — append a PATH probe plus `exit` to the rc.
+    # The managed fence above sets PATH; the probe echoes it and elvish exits before
+    # any REPL/paste/EOF timing matters. A tty is still required for rc.elv to be
+    # sourced at all, so it runs under script(1).
+    with rc.open("a", encoding="utf-8") as handle:
+        handle.write(f'\necho "{_ELVISH_PATH_PROBE}" $E:PATH\nexit\n')
+
     env = _clean_env(home, shell_abs)
     env["TERM"] = "dumb"
     result = subprocess.run(
         _script_pty_command(script_abs, [shell_abs, "-rc", str(rc)]),
-        input="print $E:PATH\nexit\n",
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         env=env,
@@ -291,6 +303,11 @@ def test_elvish_fence_activation_survives_unset_ocx_home(tmp_path: Path) -> None
     assert "arity mismatch" not in combined, (
         f"elvish: global-env eval must not raise an arity mismatch (pipe-to-eval bug); "
         f"got:\n{combined}"
+    )
+    # The probe runs only if rc.elv was actually sourced in the pty session.
+    assert _ELVISH_PATH_PROBE in result.stdout, (
+        f"elvish: the appended rc probe did not run — rc.elv was not sourced; "
+        f"got:\n{result.stdout}\nstderr:\n{result.stderr}"
     )
     assert bin_seg in result.stdout, (
         f"elvish: the ocx bin dir must land on PATH after the fence sources env.elv "


### PR DESCRIPTION
## What

Two coupled changes surfaced while validating shell activation on the deep CI matrix:

### 1. Fix macOS shell-activation (test-harness portability)
The first-ever macOS dispatch of **Shell Activation (Deep)** failed only on `test_elvish_fence_activation_*`. Root cause was the **pty driver**, not elvish activation (every other shell passed on macOS; elvish passes on Linux + Windows):
- The test drove elvish through `script -qec "<cmd>" /dev/null` — **util-linux** syntax. macOS ships **BSD** `script` (no `-c`; command is trailing argv) → `illegal option -- c`, elvish never launched.
- Fixing the argv exposed a second layer: feeding `print $E:PATH\nexit` to interactive elvish is racy across `script` flavors — BSD `script` forwards the closed stdin pipe as an immediate `^D`, so the line editor saw EOF before running the input.

Fix: drive the probe **in-file**. `rc.elv` is sourced top-to-bottom during interactive startup (before the REPL), so append `echo "<marker>" $E:PATH` + `exit` to the rc and run with stdin closed. The fence sets PATH, the probe echoes it, elvish exits before any REPL/paste/EOF timing matters — identical on util-linux and BSD `script`.

### 2. Release-readiness gate (single GO/NO-GO)
One pre-release workflow that rolls the expensive cross-platform deep coverage into a single verdict:
- `verify-deep.yml` + `shell-activation-deep.yml` gain a `workflow_call` trigger (keeping their existing `workflow_dispatch` / weekly `schedule`, so they stay independently dispatchable).
- `release-readiness.yml` (`workflow_dispatch`) composes both as reusable workflows; a final `gate` job aggregates `needs.*.result` into a **GO / NO-GO** verdict in the run summary (NO-GO fails the run).
- Not wired into the cargo-dist `release.yml` — run it yourself before tagging.

## Usage
```
gh workflow run release-readiness.yml --ref main   # before tagging vX.Y.Z
```
One dispatch → one verdict across Linux/macOS/Windows unit, Linux acceptance, and macOS+Windows shell activation. Linux per-PR gates (`verify-basic`, `shell-activation`) still cover Linux on every change.

## Validation
- `task verify` green (1335 passed).
- shell-zoo locally (debian + alpine, real elvish): all pass.
- **Shell Activation (Deep) re-dispatched on this branch → macOS arm64 ✅ + Windows x64 ✅** (run 27899864303).
- actionlint clean on all three workflows.
- `release-readiness.yml` cannot be test-dispatched until it lands on `main` (GitHub dispatches `workflow_dispatch` only from the default branch); structure is lint-validated and both called workflows are proven green.

## Cost
`release-readiness` is on-demand only. One run ≈ macOS+Windows deep build/test ≈ ~\$1.5-2 (macOS minutes dominate). No per-PR cost added.

## Post-merge
`release-readiness.yml` becomes dispatchable from `main`; dispatch it to confirm the rolled-up GO verdict end-to-end.