### PR TITLE
fix(patches): tolerate empty/unreachable patch server; add --registry override

### DIFF
--- a/.claude/rules/subsystem-cli-commands.md
+++ b/.claude/rules/subsystem-cli-commands.md
@@ -132,8 +132,8 @@ Mutually exclusive with `--project` — combining both is a clap conflict (exit 
 |---------|---------|-----------|
 | `patch freeze` | Write `patches.snapshot.json` pinning companion + descriptor digests beside `ocx.lock` (or `$OCX_HOME/ocx.lock` under `--global`) | — |
 | `patch sync [OPTIONS]` | Re-fetch every patch descriptor for all installed packages, install newly-referenced companions | `-p/--platform` |
-| `patch publish --descriptor <FILE> [--global \| <BASE-ID>]` | Push a patch descriptor to the configured `[patches]` registry | `--descriptor`, `--global` |
-| `patch test --descriptor <FILE> [OPTIONS] <BASE-ID> [-- CMD]` | Compose a descriptor onto a base locally without publishing (maintainer preview) | `--descriptor`, `--companion-archive`, `-p/--platform`, `--script` |
+| `patch publish --descriptor <FILE> [--global \| <BASE-ID>]` | Push a patch descriptor to the configured (or `--registry`) `[patches]` registry | `--descriptor`, `--global`, `--registry` |
+| `patch test --descriptor <FILE> [OPTIONS] <BASE-ID> [-- CMD]` | Compose a descriptor onto a base locally without publishing (maintainer preview) | `--descriptor`, `--companion-archive`, `-p/--platform`, `--script`, `--registry` |
 | `patch why <BASE-ID>` | List which companion, and which descriptor rule, contributes each patched env var to a base | — |
 
 **`patch` group notes:**
@@ -141,6 +141,7 @@ Mutually exclusive with `--project` — combining both is a clap conflict (exit 
 - Only `freeze` reads the root `context.global()` flag — without it, the snapshot lands beside the project's `ocx.lock`; with `--global` (root flag, before the subcommand), beside `$OCX_HOME/ocx.lock`. `sync`, `publish`, `test`, `why` never call `context.global()`.
 - `publish`'s own `--global` (declared on `PatchPublishArgs`) is unrelated to the root toolchain flag: a subcommand-local selector for the reserved `global` descriptor repository, mutually exclusive with a `<BASE-ID>` positional.
 - `publish`, `test`, `why` are registry/maintainer commands against the configured `[patches]` tier; none consult `ocx.toml`. `sync` re-checks whatever is installed locally, not scoped to one project.
+- `publish` and `test` accept `--registry <HOST/PATH>` (via shared `patch_common::effective_patches`) to override — or stand in for a missing — `[patches]` tier, so a maintainer can bootstrap a brand-new patch registry without a config block. No configured tier and no `--registry` → usage error (exit 64).
 
 ### Other Commands
 

--- a/crates/ocx_cli/src/command.rs
+++ b/crates/ocx_cli/src/command.rs
@@ -35,6 +35,7 @@ pub mod package_pull;
 pub mod package_push;
 pub mod package_test;
 pub mod patch;
+pub mod patch_common;
 pub mod patch_freeze;
 pub mod patch_publish;
 pub mod patch_sync;

--- a/crates/ocx_cli/src/command/patch_common.rs
+++ b/crates/ocx_cli/src/command/patch_common.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The OCX Authors
+
+//! Shared helpers for the `ocx patch` maintainer subcommands.
+
+use ocx_lib::{PatchConfig, ResolvedPatchConfig, cli::UsageError};
+
+/// Resolve the effective patch tier for a maintainer command, honouring an
+/// optional ad-hoc `--registry` override.
+///
+/// - `Some(registry)`: target that registry directly. When a `[patches]` tier is
+///   already configured, its `path` template and `required` posture are kept and
+///   only the registry host is replaced; otherwise the tier defaults apply
+///   (default path template, `required = true`). This lets a maintainer bootstrap
+///   a brand-new patch registry (`registry.corp.example/ocx-patches`) without
+///   first writing a `[patches]` config block.
+/// - `None`: fall back to the configured tier; usage error (exit 64) when none.
+pub fn effective_patches(
+    registry_override: Option<&str>,
+    context: &crate::app::Context,
+) -> Result<ResolvedPatchConfig, UsageError> {
+    resolve_effective_patches(registry_override, context.manager().patches().cloned())
+}
+
+/// Pure core of [`effective_patches`], split out so the override/fallback logic
+/// is unit-testable without constructing a `Context`.
+fn resolve_effective_patches(
+    registry_override: Option<&str>,
+    configured: Option<ResolvedPatchConfig>,
+) -> Result<ResolvedPatchConfig, UsageError> {
+    let Some(registry) = registry_override else {
+        return configured.ok_or_else(|| {
+            UsageError::new(
+                "no patch registry configured; pass --registry <HOST/PATH>, set a [patches] config tier, or OCX_PATCHES",
+            )
+        });
+    };
+
+    let registry = registry.trim();
+    if registry.is_empty() {
+        return Err(UsageError::new("--registry value must not be empty"));
+    }
+
+    Ok(match configured {
+        // Keep the configured path template + fail posture; retarget the host.
+        Some(mut tier) => {
+            tier.registry = registry.to_string();
+            tier
+        }
+        // No tier configured — construct one from defaults for the ad-hoc registry.
+        None => ResolvedPatchConfig {
+            registry: registry.to_string(),
+            path_template: PatchConfig::DEFAULT_PATH_TEMPLATE.to_string(),
+            required: PatchConfig::DEFAULT_REQUIRED,
+            system_required: false,
+            no_patches: std::collections::BTreeSet::new(),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn configured_tier() -> ResolvedPatchConfig {
+        ResolvedPatchConfig {
+            registry: "configured.example/patches".to_string(),
+            path_template: "{registry}/custom/{repository}".to_string(),
+            required: false,
+            system_required: false,
+            no_patches: std::collections::BTreeSet::new(),
+        }
+    }
+
+    /// No `--registry` and no configured tier → usage error (exit 64 surface).
+    #[test]
+    fn no_registry_no_config_is_usage_error() {
+        assert!(resolve_effective_patches(None, None).is_err());
+    }
+
+    /// No `--registry` but a configured tier → the configured tier verbatim.
+    #[test]
+    fn no_registry_uses_configured_tier() {
+        let resolved = resolve_effective_patches(None, Some(configured_tier())).expect("configured tier");
+        assert_eq!(resolved, configured_tier());
+    }
+
+    /// `--registry` with no configured tier → a default tier at that registry.
+    /// This is the bootstrap-a-new-registry path.
+    #[test]
+    fn registry_override_without_config_builds_default_tier() {
+        let resolved = resolve_effective_patches(Some("registry.corp.example/ocx-patches"), None)
+            .expect("override must build a tier");
+        assert_eq!(resolved.registry, "registry.corp.example/ocx-patches");
+        assert_eq!(resolved.path_template, PatchConfig::DEFAULT_PATH_TEMPLATE);
+        assert_eq!(resolved.required, PatchConfig::DEFAULT_REQUIRED);
+        assert!(!resolved.system_required);
+    }
+
+    /// `--registry` with a configured tier → retarget the host but keep the
+    /// configured `path` template and `required` posture.
+    #[test]
+    fn registry_override_preserves_configured_path_and_required() {
+        let resolved = resolve_effective_patches(Some("registry.corp.example/ocx-patches"), Some(configured_tier()))
+            .expect("override with config");
+        assert_eq!(resolved.registry, "registry.corp.example/ocx-patches");
+        assert_eq!(resolved.path_template, "{registry}/custom/{repository}");
+        assert!(
+            !resolved.required,
+            "configured required posture must survive the retarget"
+        );
+    }
+
+    /// An empty / whitespace `--registry` value is a usage error, not a silent
+    /// no-op patch tier (same footgun as an empty `[patches].registry`).
+    #[test]
+    fn empty_registry_override_is_usage_error() {
+        assert!(resolve_effective_patches(Some("   "), None).is_err());
+    }
+}

--- a/crates/ocx_cli/src/command/patch_publish.rs
+++ b/crates/ocx_cli/src/command/patch_publish.rs
@@ -15,7 +15,6 @@ use std::process::ExitCode;
 use anyhow::Context as _;
 use clap::Args;
 use ocx_lib::{
-    cli::UsageError,
     oci,
     package_manager::tasks::patch_discovery::{global_descriptor_id, patch_descriptor_id},
 };
@@ -39,20 +38,21 @@ pub struct PatchPublishArgs {
     /// descriptor. Omit with `--global` for the global descriptor.
     #[clap(value_name = "BASE-ID", required_unless_present = "global")]
     base: Option<options::Identifier>,
+
+    /// Patch registry to publish to, as `HOST/PATH`
+    /// (e.g. registry.corp.example/ocx-patches).
+    ///
+    /// Overrides the configured `[patches]` tier for this command, so you can
+    /// publish to (and thereby bootstrap) a new patch registry without first
+    /// adding a `[patches]` config block. Defaults to the configured registry.
+    #[clap(long = "registry", value_name = "HOST/PATH")]
+    registry: Option<String>,
 }
 
 impl PatchPublishArgs {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-        // ── Step 1: The patch tier must be configured. ──
-        let patches = context
-            .manager()
-            .patches()
-            .ok_or_else(|| {
-                UsageError::new(
-                    "no patch registry configured; set a [patches] config tier or OCX_PATCHES before publishing",
-                )
-            })?
-            .clone();
+        // ── Step 1: Resolve the effective patch tier (honours --registry). ──
+        let patches = crate::command::patch_common::effective_patches(self.registry.as_deref(), &context)?;
 
         // ── Step 2: Read + validate the descriptor JSON file. ──
         let descriptor_bytes = tokio::fs::read(&self.descriptor)
@@ -183,6 +183,29 @@ mod tests {
         };
         assert_eq!(args.descriptor, PathBuf::from("p.json"));
         assert!(args.global);
+    }
+
+    /// `--registry` overrides the target patch registry and threads through to
+    /// the args struct — the ad-hoc bootstrap path.
+    #[test]
+    fn registry_flag_parses() {
+        use clap::Parser as _;
+
+        let cli = crate::app::Cli::try_parse_from([
+            "ocx",
+            "patch",
+            "publish",
+            "--descriptor",
+            "p.json",
+            "--global",
+            "--registry",
+            "registry.corp.example/ocx-patches",
+        ])
+        .expect("--registry must parse");
+        let Some(crate::command::Command::Patch(crate::command::patch::PatchGroup::Publish(args))) = cli.command else {
+            panic!("expected Patch(Publish(..)) subcommand");
+        };
+        assert_eq!(args.registry.as_deref(), Some("registry.corp.example/ocx-patches"));
     }
 
     /// `--descriptor-file` is the OLD flag name — it must be an unknown flag

--- a/crates/ocx_cli/src/command/patch_test.rs
+++ b/crates/ocx_cli/src/command/patch_test.rs
@@ -42,6 +42,15 @@ pub struct PatchTestArgs {
     #[clap(value_name = "BASE-ID", required = true)]
     base: options::Identifier,
 
+    /// Patch registry to compose against, as `HOST/PATH`
+    /// (e.g. registry.corp.example/ocx-patches).
+    ///
+    /// Overrides the configured `[patches]` tier for this command, so you can
+    /// preview a descriptor against a new patch registry without first adding a
+    /// `[patches]` config block. Defaults to the configured registry.
+    #[clap(long = "registry", value_name = "HOST/PATH")]
+    registry: Option<String>,
+
     /// Path to a Starlark test script to run in the composed environment.
     /// Mutually exclusive with a trailing command.
     #[clap(long, conflicts_with = "command")]
@@ -68,6 +77,7 @@ impl PatchTestArgs {
 fn build_scratch_manager(
     context: &crate::app::Context,
     scratch_root: &std::path::Path,
+    patches: &ocx_lib::ResolvedPatchConfig,
 ) -> ocx_lib::package_manager::PackageManager {
     use ocx_lib::oci::index::{ChainMode, Index, LocalConfig, LocalIndex};
 
@@ -91,7 +101,7 @@ fn build_scratch_manager(
     let index = Index::from_chained(local_index, sources, mode);
 
     ocx_lib::package_manager::PackageManager::new(file_structure, index, client, context.default_registry())
-        .with_patches(context.manager().patches().cloned())
+        .with_patches(Some(patches.clone()))
 }
 
 /// Implementation of `ocx patch test`.
@@ -103,14 +113,8 @@ fn build_scratch_manager(
 /// Finally either runs a Starlark script, runs a trailing command, or prints the
 /// composed environment.
 async fn run_patch_test(args: &PatchTestArgs, context: crate::app::Context) -> anyhow::Result<ExitCode> {
-    // ── Step 0: Patch tier must be configured. ──
-    let patches = context
-        .manager()
-        .patches()
-        .ok_or_else(|| {
-            UsageError::new("no patch registry configured; set a [patches] config tier or OCX_PATCHES before testing")
-        })?
-        .clone();
+    // ── Step 0: Resolve the effective patch tier (honours --registry). ──
+    let patches = crate::command::patch_common::effective_patches(args.registry.as_deref(), &context)?;
 
     let platform = args
         .platform
@@ -136,7 +140,7 @@ async fn run_patch_test(args: &PatchTestArgs, context: crate::app::Context) -> a
         .map_err(|e| ocx_lib::error::file_error(&temp_root, e))?;
     let scratch_root = scratch.path().to_path_buf();
 
-    let manager = build_scratch_manager(&context, &scratch_root);
+    let manager = build_scratch_manager(&context, &scratch_root, &patches);
 
     // ── Step 3: Materialize the base into the scratch store. ──
     //
@@ -381,6 +385,29 @@ mod tests {
             panic!("expected Patch(Test(..)) subcommand");
         };
         assert_eq!(args.descriptor, PathBuf::from("p.json"));
+    }
+
+    /// `--registry` overrides the target patch registry and threads through to
+    /// the args struct — the ad-hoc bootstrap/preview path.
+    #[test]
+    fn registry_flag_parses() {
+        use clap::Parser as _;
+
+        let cli = crate::app::Cli::try_parse_from([
+            "ocx",
+            "patch",
+            "test",
+            "--descriptor",
+            "p.json",
+            "--registry",
+            "registry.corp.example/ocx-patches",
+            "cmake:1.0",
+        ])
+        .expect("--registry must parse");
+        let Some(crate::command::Command::Patch(crate::command::patch::PatchGroup::Test(args))) = cli.command else {
+            panic!("expected Patch(Test(..)) subcommand");
+        };
+        assert_eq!(args.registry.as_deref(), Some("registry.corp.example/ocx-patches"));
     }
 
     /// `--descriptor-file` is the OLD flag name — it must be an unknown flag

--- a/crates/ocx_lib/src/package_manager/tasks/install.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/install.rs
@@ -47,7 +47,19 @@ impl PackageManager {
         // materialized. This is the user-requested-install boundary — the only
         // site that triggers discovery. Companion installs (install_companion)
         // and transitive-dep pulls (setup_dependencies) do NOT call this.
-        self.discover_and_install_patches(package, &platforms).await?;
+        //
+        // Discovery is a side effect of the install, so a non-required patch tier
+        // whose server is empty or unreachable must not abort the base install:
+        // gate the failure on the tier posture (see `install_discovery_error_is_fatal`).
+        if let Err(error) = self.discover_and_install_patches(package, &platforms).await {
+            if super::patch_discovery::install_discovery_error_is_fatal(self.patches(), &error) {
+                return Err(error);
+            }
+            crate::log::warn!(
+                "patch discovery for '{package}' failed (patch tier not required): {error}; \
+                 continuing without companions"
+            );
+        }
 
         Ok(install_info)
     }
@@ -174,7 +186,21 @@ impl PackageManager {
                     // after the await returns, releasing the slot for the
                     // next queued discovery task.
                     let _permit = concurrency::acquire_permit(&sem).await;
-                    let result = mgr.discover_and_install_patches(&pkg, &platforms).await;
+                    // Gate discovery failure on the tier posture: a non-required
+                    // patch tier whose server is empty/unreachable warns and
+                    // continues without companions rather than failing the install.
+                    let result = match mgr.discover_and_install_patches(&pkg, &platforms).await {
+                        Err(error)
+                            if !super::patch_discovery::install_discovery_error_is_fatal(mgr.patches(), &error) =>
+                        {
+                            crate::log::warn!(
+                                "patch discovery for '{pkg}' failed (patch tier not required): {error}; \
+                                 continuing without companions"
+                            );
+                            Ok(0)
+                        }
+                        other => other,
+                    };
                     (index, result)
                 });
             }

--- a/crates/ocx_lib/src/package_manager/tasks/patch_discovery.rs
+++ b/crates/ocx_lib/src/package_manager/tasks/patch_discovery.rs
@@ -751,6 +751,35 @@ pub fn global_descriptor_id(patches: &ResolvedPatchConfig) -> Identifier {
     Identifier::new_registry(GLOBAL_PATCH_REPOSITORY, &patches.registry).clone_with_tag(InternalTag::PATCH_TAG)
 }
 
+/// Whether a lazy patch-discovery failure must abort a user-requested base install.
+///
+/// Lazy discovery is a side effect of `install` / `install_all`, not an explicit
+/// user action. Its fatality is gated on the patch tier's fail posture, mirroring
+/// the compose-time gating in
+/// [`build_site_patch_set`](PackageManager::build_site_patch_set) and the
+/// best-effort model of [`sync_patches`](PackageManager::sync_patches):
+///
+/// - **Required tier** (`patches.required == true`): fatal. An unreachable or
+///   erroring patch server means we cannot confirm that no mandated companion
+///   (e.g. a corporate CA overlay) applies to this base, so the install fails
+///   closed rather than silently proceed without the overlay (C7).
+/// - **`RequiredCompanionFailed`**: fatal regardless of the tier posture — a
+///   rule-level `required = true` companion that failed to install is a
+///   fail-closed event even under a non-required tier.
+/// - **Otherwise** (non-required tier, e.g. a descriptor fetch/parse failure
+///   against an empty or unreachable patch server): NOT fatal. The caller warns
+///   and continues installing the base without companions.
+///
+/// `patches` is `None` only when no tier is configured, in which case discovery
+/// short-circuits before it can error; the `false` result then keeps the
+/// function total.
+pub(super) fn install_discovery_error_is_fatal(
+    patches: Option<&ResolvedPatchConfig>,
+    error: &PackageErrorKind,
+) -> bool {
+    patches.is_some_and(|patches| patches.required) || matches!(error, PackageErrorKind::RequiredCompanionFailed { .. })
+}
+
 /// A deferred `LookedHasDescriptor` tag-store advance (A1 hybrid commit — deferred leg).
 ///
 /// A re-sync over an existing `LookedHasDescriptor` records its pointer advance
@@ -1035,6 +1064,48 @@ mod tests {
     }
 
     // ── Three-state TagStore helper ───────────────────────────────────────────
+
+    /// `install_discovery_error_is_fatal` gates install-time discovery fatality
+    /// on the patch tier's fail posture — the empty/unreachable patch-server bug.
+    ///
+    /// A non-required tier tolerates a descriptor-fetch failure (warn + continue),
+    /// a required tier fails closed (C7), and a `RequiredCompanionFailed` is fatal
+    /// under either posture. Deleting the `patches.required` clause makes the
+    /// non-required assertion fail (regression guard for the fix).
+    #[test]
+    fn install_discovery_fatality_gated_on_required() {
+        use crate::patch::PatchError;
+
+        // A descriptor fetch/parse failure — the class raised against an empty or
+        // unreachable patch server (stands in for `FetchFailed`, which needs a
+        // network error to construct).
+        let fetch_error = PackageErrorKind::PatchDiscovery(PatchError::UnsupportedVersion { version: 999 });
+        let required_companion = PackageErrorKind::RequiredCompanionFailed {
+            companion: Identifier::parse("patches.corp.com/corp-ca:1.0").expect("valid identifier"),
+            source: Box::new(PackageErrorKind::NotFound),
+        };
+
+        let required_tier = ResolvedPatchConfig {
+            required: true,
+            ..test_patch_config()
+        };
+        let optional_tier = ResolvedPatchConfig {
+            required: false,
+            ..test_patch_config()
+        };
+
+        // Required tier: any discovery error is fatal (fail-closed).
+        assert!(install_discovery_error_is_fatal(Some(&required_tier), &fetch_error));
+        // Non-required tier: a descriptor-fetch failure is tolerated (the fix).
+        assert!(!install_discovery_error_is_fatal(Some(&optional_tier), &fetch_error));
+        // RequiredCompanionFailed is fatal even under a non-required tier.
+        assert!(install_discovery_error_is_fatal(
+            Some(&optional_tier),
+            &required_companion
+        ));
+        // No tier configured → nothing can fail (defensive totality).
+        assert!(!install_discovery_error_is_fatal(None, &fetch_error));
+    }
 
     /// State (a): file absent → `NeverLooked`.
     ///

--- a/test/tests/test_patches.py
+++ b/test/tests/test_patches.py
@@ -358,6 +358,57 @@ def test_required_false_missing_companion_fails_open(
 
 
 # ---------------------------------------------------------------------------
+# Scenario 4c: unreachable/empty patch registry — the descriptor *fetch* failure
+# is gated on the tier `required` posture, not fatal unconditionally.
+# ---------------------------------------------------------------------------
+
+# A patch registry host with nothing listening: the descriptor fetch fails to
+# connect (connection refused), which is DISTINCT from a reachable-but-empty
+# registry that returns a clean 404 (recorded as "no patch", never an error).
+# Port 1 is privileged and unused, so the connect fails immediately.
+_UNREACHABLE_PATCH_REGISTRY = "127.0.0.1:1"
+
+
+def test_unreachable_patch_registry_required_false_installs(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path, registry: str
+) -> None:
+    """Regression: a non-required patch tier whose registry is unreachable must NOT
+    abort the base install. Discovery is a side effect of install, so a
+    descriptor-fetch failure under `required = false` warns and continues.
+
+    Before the fix, the fetch error propagated through `install` and failed the
+    base install regardless of `required` — the empty/unreachable patch-server bug.
+    """
+    # Publish + index the base BEFORE writing the patch config, so the only
+    # discovery pass that probes the unreachable registry is our explicit install.
+    base_pkg = make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=True)
+    _write_config(ocx, _UNREACHABLE_PATCH_REGISTRY, required=False)
+
+    result = ocx.run("package", "install", base_pkg.short, format=None, check=False)
+    assert result.returncode == 0, (
+        "Installing a base with a non-required, unreachable patch registry must "
+        f"succeed (warn + continue). Got exit {result.returncode}.\nstderr: {result.stderr}"
+    )
+
+
+def test_unreachable_patch_registry_required_true_fails_closed(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path, registry: str
+) -> None:
+    """Counterpart: a required patch tier whose registry is unreachable fails the
+    install closed — OCX cannot confirm that no mandated companion applies, so it
+    must not silently install the base without the overlay (C7).
+    """
+    base_pkg = make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=True)
+    _write_config(ocx, _UNREACHABLE_PATCH_REGISTRY, required=True)
+
+    result = ocx.run("package", "install", base_pkg.short, format=None, check=False)
+    assert result.returncode != 0, (
+        "Installing a base with a required, unreachable patch registry must fail "
+        f"closed. Got exit 0.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Scenario 4b: explicit `ocx patch sync` fails closed on a required companion (F-A)
 # ---------------------------------------------------------------------------
 

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -2654,6 +2654,7 @@ ocx patch publish --descriptor <FILE> [--global | <BASE-ID>]
 |------|-------|-------------|
 | `--descriptor <FILE>` | | Path to the patch descriptor JSON file. Required. |
 | `--global` | | Publish the descriptor to the reserved `global` repository under the patch registry so it applies to every base. Mutually exclusive with `<BASE-ID>`. |
+| `--registry <HOST/PATH>` | | Patch registry to publish to, e.g. `registry.corp.example/ocx-patches`. Overrides the configured [`[patches]`][config-patches] tier, so you can bootstrap a brand-new patch registry without first adding a config block. Defaults to the configured registry. |
 | `-h`, `--help` | | Print help information. |
 
 **Exit codes**
@@ -2661,7 +2662,7 @@ ocx patch publish --descriptor <FILE> [--global | <BASE-ID>]
 | Code | Meaning |
 |------|---------|
 | 0 | Descriptor published. |
-| 64 | No `[patches]` tier configured; set `[patches]` or `OCX_PATCHES` before publishing. |
+| 64 | No patch registry available — pass `--registry <HOST/PATH>`, configure a `[patches]` tier, or set `OCX_PATCHES` before publishing. |
 | 65 | Descriptor JSON is malformed or the version is unsupported. |
 | 69 | Registry unreachable. |
 | 81 | `--offline` blocked the publish — `patch publish` requires network access. |
@@ -2699,6 +2700,7 @@ ocx patch test --descriptor <FILE> [OPTIONS] <BASE-ID> [-- COMMAND [ARGS...]]
 | `--descriptor <FILE>` | | Path to the patch descriptor JSON file. Required. |
 | `--companion-archive <PATH>` | | Local archive for a companion package; avoids a registry round-trip. Repeatable for multiple companions. |
 | `--platform <PLATFORM>` | `-p` | Target platform for composing the environment. Defaults to host platform. |
+| `--registry <HOST/PATH>` | | Patch registry to compose against, e.g. `registry.corp.example/ocx-patches`. Overrides the configured [`[patches]`][config-patches] tier, so you can preview a descriptor against a new patch registry without a config block. Defaults to the configured registry. |
 | `--script <FILE>` | | Starlark test script to run in the composed environment. Mutually exclusive with `-- COMMAND`. |
 | `-h`, `--help` | | Print help information. |
 
@@ -2708,7 +2710,7 @@ ocx patch test --descriptor <FILE> [OPTIONS] <BASE-ID> [-- COMMAND [ARGS...]]
 |------|---------|
 | 0 | Environment printed, or the trailing command/script exited 0. |
 | *(child's exit code)* | With a trailing command, the child's exit code is forwarded unchanged — a command that exits 7 makes `patch test` exit 7. |
-| 64 | No `[patches]` tier configured; set `[patches]` or `OCX_PATCHES` before testing. |
+| 64 | No patch registry available — pass `--registry <HOST/PATH>`, configure a `[patches]` tier, or set `OCX_PATCHES` before testing. |
 | 65 | Descriptor JSON is malformed or the version is unsupported. |
 | 81 | `--offline` blocked resolving the base or a required companion. |
 | *other* | A required companion could not be resolved; the exit code reflects the underlying cause — see [Exit codes][exit-codes] (e.g. 79 not found, 69 registry unreachable, 80 authentication failure). |

--- a/website/src/docs/user-guide/patches.md
+++ b/website/src/docs/user-guide/patches.md
@@ -274,6 +274,13 @@ The `required` field controls what happens when a matched companion is unavailab
 | `true` (default) | Execution aborts with an error. Use for CA bundles, proxy config — anything that makes running without the companion unsafe. |
 | `false` | OCX logs a warning and continues. Use for convenience overlays (metrics endpoints, license server hints) where running without the companion is acceptable. |
 
+The same posture governs patch **discovery** at install time. Installing a base package
+triggers a lazy lookup of the patch descriptors on the registry. If that registry is empty
+or unreachable, a non-required tier (`required = false`) logs a warning and installs the base
+without companions; a required tier fails the install closed, because OCX cannot confirm that
+no mandated companion applies. A registry that simply carries no descriptor yet is not an
+error under either posture — discovery records "no patch" and moves on.
+
 System administrators can set `required = true` in `/etc/ocx/config.toml` to make the
 entire patch tier non-overridable. A system-level required tier cannot be redirected or
 suppressed by a user-level config file.

--- a/website/src/docs/user-guide/patches.md
+++ b/website/src/docs/user-guide/patches.md
@@ -216,6 +216,22 @@ ocx patch publish \
   java:21
 ```
 
+:::tip Bootstrapping a new patch registry
+You do not need a `[patches]` config block to publish the first descriptor. Pass
+`--registry <HOST/PATH>` to target a patch registry ad-hoc — it overrides the configured
+tier, or stands in when none is configured:
+
+```sh
+ocx patch publish \
+  --descriptor ./my-descriptor.json \
+  --registry registry.corp.example/ocx-patches \
+  --global
+```
+
+`ocx patch test --registry …` composes against the same ad-hoc registry for a local preview.
+Roll out the `[patches]` config to consumers once the registry is seeded.
+:::
+
 ### 4. Freeze for reproducible builds {#patches-maintainer-freeze}
 
 OCI tags are mutable. The same `ca-bundle:latest` tag may point to a different digest


### PR DESCRIPTION
Fixes two patch-tier issues.

## 1. Empty/unreachable patch server aborted install regardless of \`required\` (bug)

Install propagated every \`discover_and_install_patches\` error via \`?\`, and \`required\` only ever gated matched-companion failures — never descriptor *fetch* failures. So a patch server returning anything but a clean 404 (auth, unreachable, corp-registry error) killed the whole base install even at \`required = false\`.

New \`install_discovery_error_is_fatal\` gate, applied at both install sites:
- \`required = false\` + fetch error → warn + continue (base installs, no companions)
- \`required = true\` → fail closed (cannot confirm no mandated CA overlay applies, C7)
- \`RequiredCompanionFailed\` → fatal under either posture (per-rule override)

Mirrors the compose-path gating and \`sync_patches\` best-effort model. A clean 404 from a reachable-but-empty registry is unchanged (recorded as no-patch, never an error).

## 2. No way to set the patch registry on the CLI (feature)

The registry only came from the \`[patches]\` config tier or \`OCX_PATCHES\` (a forwarding wire format), so bootstrapping a new patch registry meant writing a config block first. Added \`--registry <HOST/PATH>\` to \`patch publish\` and \`patch test\` via shared \`patch_common::effective_patches\` — overrides the configured tier (keeping its path template + required posture) or stands in when none is configured. No tier and no \`--registry\` stays exit 64.

## Verification

- \`task verify\` → 1438 passed, 39 skipped, 3 xfailed, 2 xpassed
- New regression tests: unreachable-registry × required true/false (acceptance), \`install_discovery_fatality_gated_on_required\` (unit), \`effective_patches\` (unit), \`--registry\` clap parse (both commands)
- Docs updated: command-line reference, patches user guide, CLI-commands rule catalog