### PR TITLE
fix(oci): seed CA roots at the fork's ClientConfig::default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "unicase",
+ "webpki-root-certs",
 ]
 
 [[package]]

--- a/crates/ocx_lib/Cargo.toml
+++ b/crates/ocx_lib/Cargo.toml
@@ -30,7 +30,6 @@ schemars.workspace = true
 tokio.workspace = true
 
 oci-client.workspace = true
-webpki-root-certs.workspace = true
 lzma-rust2.workspace = true
 serde_json.workspace = true
 serde_json_canonicalizer.workspace = true
@@ -107,6 +106,10 @@ windows-sys.workspace = true
 # runtime `use anyhow` a compile error. Placement locked by
 # `script::dependency_hygiene_tests::anyhow_is_dev_dependency_only`.
 anyhow.workspace = true
+# Test-only. `oci::client::builder` tests assert the client inherits the fork's
+# bundled Mozilla CA roots; the roots themselves are seeded by the vendored
+# `oci-client` fork's `ClientConfig::default()`, not by ocx_lib at runtime.
+webpki-root-certs.workspace = true
 
 [lints]
 workspace = true

--- a/crates/ocx_lib/src/oci.rs
+++ b/crates/ocx_lib/src/oci.rs
@@ -5,8 +5,6 @@
 pub mod native {
     pub use oci_client;
 
-    pub use oci_client::client::Certificate;
-    pub use oci_client::client::CertificateEncoding;
     pub use oci_client::client::Client;
     pub use oci_client::client::ClientConfig;
     pub use oci_client::client::ClientProtocol;

--- a/crates/ocx_lib/src/oci/client/builder.rs
+++ b/crates/ocx_lib/src/oci/client/builder.rs
@@ -26,7 +26,9 @@ impl ClientBuilder {
                 // 128 KiB progress-frame size in `native_transport::progress_body_stream`
                 // — that governs progress granularity, this governs request count.
                 push_chunk_size: 16 * 1024 * 1024,
-                extra_root_certificates: bundled_root_certificates(),
+                // CA roots are seeded by the fork's `ClientConfig::default()`
+                // (self-contained on hosts with no system trust store), inherited
+                // here via `..Default::default()`. Single source of truth: the fork.
                 ..Default::default()
             },
             lock_timeout: None,
@@ -135,32 +137,6 @@ impl Default for ClientBuilder {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Mozilla's CA root set, compiled into the binary.
-///
-/// The vendored `oci-client` builds its reqwest client with rustls, which under
-/// reqwest 0.13 delegates trust to `rustls-platform-verifier`. With no explicit
-/// roots the verifier loads roots *only* from the system store and hard-errors
-/// (`No CA certificates were loaded from the system`) when that store is empty —
-/// a minimal container, a CI runner without `ca-certificates`, or an
-/// `SSL_CERT_FILE` pointing at a bundle that yields no certificates. `Client::new`
-/// then "falls back" to `reqwest::Client::default()`, whose internal `.expect()`
-/// re-triggers the identical failure as a process-crashing panic.
-///
-/// Seeding these bundled roots makes the client self-contained: reqwest takes the
-/// `Verifier::new_with_extra_roots` path, which never errors on an empty system
-/// store and still *merges* whatever the native store provides — so an operator's
-/// corporate root (via `SSL_CERT_FILE`/`SSL_CERT_DIR`) keeps working alongside the
-/// public roots.
-fn bundled_root_certificates() -> Vec<oci::native::Certificate> {
-    webpki_root_certs::TLS_SERVER_ROOT_CERTS
-        .iter()
-        .map(|cert| oci::native::Certificate {
-            encoding: oci::native::CertificateEncoding::Der,
-            data: cert.as_ref().to_vec(),
-        })
-        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Registry operations panic on a host with no system trust store (minimal/distroless container, CI runner without `ca-certificates`):

```
Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

The v0.4.2 fix (`3066edd1`) seeded bundled CA roots only in ocx's `ClientBuilder::new()` funnel, so any oci-client client built **directly** from a `ClientConfig` stayed rootless. The reported crash fires at **context creation / auth ping**, not just a single command: any `ClientConfig { ..Default::default() }` (e.g. the `ocx login` verify ping, `auth/login.rs`) has empty `extra_root_certificates` → reqwest 0.13 rustls takes `Verifier::new()` → empty-store error → `Client::new` falls back to `reqwest::Client::default()` → panic.

## Fix

Seed the bundled Mozilla root set at the **real chokepoint** — the vendored fork's `ClientConfig::default()` (`ocx-sh/rust-oci-client@ocx/integration`). Every client now inherits roots by construction (funnel, login, internal fallback alike).

- ocx side: drop the now-redundant duplicate seed (`bundled_root_certificates()` + unused `native::Certificate`/`CertificateEncoding` re-exports); builder inherits via `..Default::default()`. `webpki-root-certs` → dev-dependencies (test-only).
- `SSL_CERT_FILE` / `SSL_CERT_DIR` still **merge** on top of the bundled roots (rustls-native-certs via `openssl_probe`) — corporate roots keep working alongside the public set.

## Tests

- Fork: `default_config_seeds_bundled_ca_roots` — `ClientConfig::default()` carries the full DER-encoded root set.
- ocx: `new_seeds_full_der_encoded_ca_root_set` — builder inherits the roots.
- `task rust:verify` green (fmt, clippy, license, 2831 tests). Acceptance suite runs in CI (needs live registry).

Submodule bump: `ocx-sh/rust-oci-client` `ocx/integration` → `7d27d20`.