### PR TITLE
feat(push): record OCI annotations on the published image index

### DIFF
--- a/crates/ocx_cli/src/command/package_push.rs
+++ b/crates/ocx_cli/src/command/package_push.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The OCX Authors
 
+use std::collections::BTreeMap;
 use std::process::ExitCode;
 
 use anyhow::Context as _;
@@ -59,6 +60,23 @@ pub struct PackagePush {
     /// when no file layers are provided.
     #[clap(short, long)]
     metadata: Option<std::path::PathBuf>,
+
+    /// Record an OCI annotation on the published image index. Repeatable.
+    ///
+    /// Written verbatim onto the index of every tag this push writes,
+    /// including cascade tags. A repeated key keeps the last value. Omitting
+    /// the flag writes no annotations and leaves any the registry already
+    /// holds untouched.
+    ///
+    /// Set `org.opencontainers.image.source` to the HTTPS URL of the source
+    /// repository: on GHCR this is what links the package to its repository
+    /// and lets it inherit that repository's permissions. Registries derive
+    /// nothing from the repository path, so state it explicitly - for example
+    /// in GitHub Actions:
+    ///
+    ///   --annotation org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY
+    #[clap(long = "annotation", value_name = "KEY=VALUE", value_parser = parse_annotation)]
+    annotation: Vec<(String, String)>,
 
     /// After a successful push, append the pushed tag and any cascade tags
     /// to this file (creating it if absent), so `ocx package announce
@@ -158,6 +176,9 @@ impl PackagePush {
 
         let build_meta: Option<String> = self.build_timestamp.as_ref().and_then(build_timestamp);
         let canonical_tag = self.canonical_tag.enabled();
+        // Last-wins on a repeated key, matching the POSIX convention for
+        // repeated flags.
+        let annotations: BTreeMap<String, String> = self.annotation.iter().cloned().collect();
 
         let outcome = if self.cascade {
             let existing_tags = match publisher.list_tags(identifier.clone()).await {
@@ -183,11 +204,12 @@ impl PackagePush {
                     existing_versions,
                     build_meta.as_deref(),
                     canonical_tag,
+                    &annotations,
                 )
                 .await?
         } else {
             publisher
-                .push(infos, &self.layers, build_meta.as_deref(), canonical_tag)
+                .push(infos, &self.layers, build_meta.as_deref(), canonical_tag, &annotations)
                 .await?
         };
 
@@ -222,6 +244,22 @@ impl PackagePush {
     }
 }
 
+/// Splits a `KEY=VALUE` annotation argument at the first `=`.
+///
+/// The value may contain `=` (URLs with query strings do) and may be empty;
+/// the key may not be empty. Beyond that OCX does not police annotation keys —
+/// the OCI spec only *recommends* reverse-domain notation, and a registry is
+/// free to define its own.
+fn parse_annotation(argument: &str) -> anyhow::Result<(String, String)> {
+    let (key, value) = argument
+        .split_once('=')
+        .ok_or_else(|| anyhow::anyhow!("expected KEY=VALUE, got '{argument}'"))?;
+    if key.is_empty() {
+        return Err(anyhow::anyhow!("annotation key is empty in '{argument}'"));
+    }
+    Ok((key.to_string(), value.to_string()))
+}
+
 /// Appends `tags` onto the announce-file at `path` (created if absent),
 /// deduping against whatever is already there (design register C2).
 async fn append_to_announce_file(path: &std::path::Path, tags: &[String]) -> anyhow::Result<()> {
@@ -234,6 +272,48 @@ async fn append_to_announce_file(path: &std::path::Path, tags: &[String]) -> any
     tokio::fs::write(path, merged)
         .await
         .with_context(|| format!("writing announce file {}", path.display()))
+}
+
+#[cfg(test)]
+mod annotation_tests {
+    use std::collections::BTreeMap;
+
+    use super::parse_annotation;
+
+    #[test]
+    fn splits_at_the_first_equals_sign() {
+        let (key, value) =
+            parse_annotation("org.opencontainers.image.source=https://github.com/ocx-sh/ocx?ref=main").expect("parses");
+        assert_eq!(key, "org.opencontainers.image.source");
+        assert_eq!(value, "https://github.com/ocx-sh/ocx?ref=main");
+    }
+
+    #[test]
+    fn accepts_an_empty_value() {
+        let (key, value) = parse_annotation("org.opencontainers.image.source=").expect("parses");
+        assert_eq!(key, "org.opencontainers.image.source");
+        assert_eq!(value, "");
+    }
+
+    #[test]
+    fn rejects_an_argument_without_an_equals_sign() {
+        let error = parse_annotation("org.opencontainers.image.source").expect_err("must reject");
+        assert!(error.to_string().contains("expected KEY=VALUE"), "got: {error}");
+    }
+
+    #[test]
+    fn rejects_an_empty_key() {
+        let error = parse_annotation("=https://github.com/ocx-sh/ocx").expect_err("must reject");
+        assert!(error.to_string().contains("annotation key is empty"), "got: {error}");
+    }
+
+    #[test]
+    fn a_repeated_key_keeps_the_last_value() {
+        let parsed = ["a=first", "b=x", "a=second"].map(|argument| parse_annotation(argument).expect("parses"));
+        let collected: BTreeMap<String, String> = parsed.into_iter().collect();
+        assert_eq!(collected.get("a").map(String::as_str), Some("second"));
+        assert_eq!(collected.get("b").map(String::as_str), Some("x"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/ocx_lib/src/managed_config/publish.rs
+++ b/crates/ocx_lib/src/managed_config/publish.rs
@@ -17,6 +17,7 @@
 //! | [`validate_managed_config_payload`] | Pure: size cap, TOML parse as [`crate::config::Config`], `[managed]` rejection | Unit-testable with synthetic bytes |
 //! | [`publish_managed_config`] | I/O + network: stage, bundle, push (cascade-aware) | Acceptance test |
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::oci::{Identifier, Platform};
@@ -266,16 +267,18 @@ pub async fn publish_managed_config(
         // Canonical tagging (`adr_index_indirection.md` Decision E) is a
         // `ocx package push` CLI contract; managed-config publishing has no
         // `--[no-]canonical-tag` surface of its own, so it opts out to keep
-        // today's tag set unchanged.
+        // today's tag set unchanged. Index annotations are likewise a
+        // `ocx package push --annotation` contract with no `ocx config push`
+        // surface, so none are written.
         publisher
-            .push_cascade(vec![info], &layers, existing_versions, None, false)
+            .push_cascade(vec![info], &layers, existing_versions, None, false, &BTreeMap::new())
             .await
             .map_err(|source| ManagedConfigPublishError::PushFailed {
                 source: Box::new(source),
             })?
     } else {
         publisher
-            .push(vec![info], &layers, None, false)
+            .push(vec![info], &layers, None, false, &BTreeMap::new())
             .await
             .map_err(|source| ManagedConfigPublishError::PushFailed {
                 source: Box::new(source),

--- a/crates/ocx_lib/src/oci/client.rs
+++ b/crates/ocx_lib/src/oci/client.rs
@@ -8,6 +8,8 @@ use crate::{
     package::{self, info::Info, tag::InternalTag},
 };
 
+use std::collections::BTreeMap;
+
 use futures::stream::{self, StreamExt, TryStreamExt};
 
 use super::{Algorithm, Digest, Identifier, native};
@@ -239,6 +241,13 @@ impl Client {
     /// Used by `package push --cascade` to merge a single-platform manifest into
     /// each rolling tag without destroying entries for other platforms.
     ///
+    /// `annotations` are the publisher-stated index-level annotations (`ocx
+    /// package push --annotation`). They are merged into whatever the index
+    /// already carries — an empty map leaves the index's `annotations` field
+    /// exactly as found, so a push without the flag produces byte-identical
+    /// bytes to before the flag existed and never clears a link an earlier
+    /// push established.
+    ///
     /// Returns the digest and data of the pushed index.
     pub(crate) async fn merge_platform_into_index(
         &self,
@@ -247,6 +256,7 @@ impl Client {
         platform: &oci::Platform,
         manifest_sha256: &str,
         manifest_size: i64,
+        annotations: &BTreeMap<String, String>,
     ) -> Result<(Digest, oci::ImageIndex)> {
         let target_identifier = source_identifier.clone_with_tag(target_tag);
         // Push stays canonical (mirror-free): remote/proxy mirrors are read-only.
@@ -311,6 +321,13 @@ impl Client {
             artifact_type: None,
             annotations: None,
         });
+
+        if !annotations.is_empty() {
+            index
+                .annotations
+                .get_or_insert_default()
+                .extend(annotations.iter().map(|(key, value)| (key.clone(), value.clone())));
+        }
 
         let index_data = serde_json::to_vec(&index).map_err(ClientError::Serialization)?;
         let index_digest = Algorithm::Sha256.hash(&index_data);
@@ -806,8 +823,11 @@ impl Client {
         &self,
         package_info: Info,
         layers: &[crate::publisher::LayerRef],
+        annotations: &BTreeMap<String, String>,
     ) -> Result<(Digest, oci::Manifest)> {
-        let (index_digest, index) = self.push_manifest_and_merge_tags(&package_info, layers, &[]).await?;
+        let (index_digest, index) = self
+            .push_manifest_and_merge_tags(&package_info, layers, &[], annotations)
+            .await?;
         Ok((index_digest, oci::Manifest::ImageIndex(index)))
     }
 
@@ -820,12 +840,17 @@ impl Client {
     /// the rolling/cascade tag set (e.g. `["3.28", "3", "latest"]`);
     /// pass `&[]` for a plain single-tag push.
     ///
+    /// `annotations` are written onto every index this call touches — the
+    /// primary tag and each of `extra_tags` — so a cascade never leaves a
+    /// rolling tag with weaker provenance than the version tag it mirrors.
+    ///
     /// Returns the digest + data of the primary tag's image index.
     pub(crate) async fn push_manifest_and_merge_tags(
         &self,
         package_info: &Info,
         layers: &[crate::publisher::LayerRef],
         extra_tags: &[String],
+        annotations: &BTreeMap<String, String>,
     ) -> Result<(Digest, oci::ImageIndex)> {
         log::debug!(
             "Pushing package {} with {} layer(s)",
@@ -850,6 +875,7 @@ impl Client {
                 &package_info.platform,
                 &manifest_sha256,
                 manifest_size,
+                annotations,
             )
             .await?;
 
@@ -861,6 +887,7 @@ impl Client {
                 &package_info.platform,
                 &manifest_sha256,
                 manifest_size,
+                annotations,
             )
             .await?;
         }
@@ -3290,7 +3317,14 @@ mod tests {
             let id = test_identifier("3.28");
 
             client
-                .merge_platform_into_index(&id, "3.28", &platform("linux/amd64"), "sha256:abc", 100)
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:abc",
+                    100,
+                    &BTreeMap::new(),
+                )
                 .await
                 .unwrap();
 
@@ -3330,7 +3364,14 @@ mod tests {
 
             let client = stub_with_capture(&data);
             client
-                .merge_platform_into_index(&id, "3.28", &platform("linux/amd64"), "sha256:amd64_new", 200)
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:amd64_new",
+                    200,
+                    &BTreeMap::new(),
+                )
                 .await
                 .unwrap();
 
@@ -3368,7 +3409,14 @@ mod tests {
 
             let client = stub_with_capture(&data);
             client
-                .merge_platform_into_index(&id, "3.28", &platform("linux/amd64"), "sha256:new_amd64", 200)
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:new_amd64",
+                    200,
+                    &BTreeMap::new(),
+                )
                 .await
                 .unwrap();
 
@@ -3405,7 +3453,14 @@ mod tests {
 
             let client = stub_with_capture(&data);
             client
-                .merge_platform_into_index(&id, "3.28", &platform("linux/amd64"), "sha256:new_manifest", 300)
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:new_manifest",
+                    300,
+                    &BTreeMap::new(),
+                )
                 .await
                 .unwrap();
 
@@ -3438,7 +3493,14 @@ mod tests {
             let id = test_identifier("3.28");
 
             let result = client
-                .merge_platform_into_index(&id, "3.28", &platform("linux/amd64"), "sha256:abc", 100)
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:abc",
+                    100,
+                    &BTreeMap::new(),
+                )
                 .await;
 
             assert!(result.is_err(), "expected error to propagate, got Ok");
@@ -3447,6 +3509,169 @@ mod tests {
             assert!(
                 inner.manifests.is_empty(),
                 "no manifest should have been pushed on error"
+            );
+        }
+
+        // ── index annotations (`ocx package push --annotation`) ───────
+
+        /// Seed the stub with an index carrying `annotations` at `tag`.
+        fn seed_index_with_annotations(
+            data: &StubTransportData,
+            tag: &str,
+            annotations: Option<BTreeMap<String, String>>,
+        ) {
+            let id = test_identifier(tag);
+            let existing = oci::ImageIndex {
+                schema_version: 2,
+                media_type: Some(MEDIA_TYPE_OCI_IMAGE_INDEX.to_string()),
+                artifact_type: Some(MEDIA_TYPE_PACKAGE_V1.to_string()),
+                manifests: vec![oci::ImageIndexEntry {
+                    media_type: MEDIA_TYPE_OCI_IMAGE_MANIFEST.to_string(),
+                    digest: "sha256:arm64_digest".to_string(),
+                    size: 50,
+                    platform: Some(platform("linux/arm64").into()),
+                    artifact_type: None,
+                    annotations: None,
+                }],
+                annotations,
+            };
+            let bytes = serde_json::to_vec(&oci::Manifest::ImageIndex(existing)).unwrap();
+            let digest = oci::Algorithm::Sha256.hash(&bytes).to_string();
+            data.write()
+                .manifests
+                .insert(id.canonical_reference().to_string(), (bytes, digest));
+        }
+
+        fn source_annotation(url: &str) -> BTreeMap<String, String> {
+            BTreeMap::from([(oci::annotations::SOURCE.to_string(), url.to_string())])
+        }
+
+        #[tokio::test]
+        async fn supplied_annotations_land_on_a_fresh_index() {
+            let data = StubTransportData::new();
+            let client = stub_with_capture(&data);
+            let id = test_identifier("3.28");
+
+            client
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:abc",
+                    100,
+                    &source_annotation("https://github.com/ocx-sh/ocx"),
+                )
+                .await
+                .unwrap();
+
+            let index = read_pushed_index(&data, "3.28");
+            assert_eq!(
+                index
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.get(oci::annotations::SOURCE))
+                    .map(String::as_str),
+                Some("https://github.com/ocx-sh/ocx"),
+            );
+        }
+
+        /// The absent-value case: no `--annotation` must leave the field
+        /// absent, so a manifest-less push stays byte-identical to what
+        /// ocx produced before the flag existed.
+        #[tokio::test]
+        async fn no_annotations_leaves_a_fresh_index_field_absent() {
+            let data = StubTransportData::new();
+            let client = stub_with_capture(&data);
+            let id = test_identifier("3.28");
+
+            client
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:abc",
+                    100,
+                    &BTreeMap::new(),
+                )
+                .await
+                .unwrap();
+
+            let index = read_pushed_index(&data, "3.28");
+            assert!(index.annotations.is_none(), "got: {:?}", index.annotations);
+        }
+
+        /// A later annotation-less push must not un-link a repository an
+        /// earlier push already linked.
+        #[tokio::test]
+        async fn no_annotations_preserves_what_the_index_already_carries() {
+            let data = StubTransportData::new();
+            seed_index_with_annotations(&data, "3.28", Some(source_annotation("https://github.com/ocx-sh/ocx")));
+            let client = stub_with_capture(&data);
+            let id = test_identifier("3.28");
+
+            client
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:abc",
+                    100,
+                    &BTreeMap::new(),
+                )
+                .await
+                .unwrap();
+
+            let index = read_pushed_index(&data, "3.28");
+            assert_eq!(
+                index
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.get(oci::annotations::SOURCE))
+                    .map(String::as_str),
+                Some("https://github.com/ocx-sh/ocx"),
+            );
+        }
+
+        #[tokio::test]
+        async fn supplied_annotations_merge_over_the_existing_ones() {
+            let data = StubTransportData::new();
+            seed_index_with_annotations(
+                &data,
+                "3.28",
+                Some(BTreeMap::from([
+                    (
+                        oci::annotations::SOURCE.to_string(),
+                        "https://example.invalid".to_string(),
+                    ),
+                    (oci::annotations::VENDOR.to_string(), "OCX".to_string()),
+                ])),
+            );
+            let client = stub_with_capture(&data);
+            let id = test_identifier("3.28");
+
+            client
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:abc",
+                    100,
+                    &source_annotation("https://github.com/ocx-sh/ocx"),
+                )
+                .await
+                .unwrap();
+
+            let index = read_pushed_index(&data, "3.28");
+            let annotations = index.annotations.expect("annotations present");
+            assert_eq!(
+                annotations.get(oci::annotations::SOURCE).map(String::as_str),
+                Some("https://github.com/ocx-sh/ocx"),
+                "the supplied key overwrites",
+            );
+            assert_eq!(
+                annotations.get(oci::annotations::VENDOR).map(String::as_str),
+                Some("OCX"),
+                "an unrelated key another tool set is left alone",
             );
         }
     }
@@ -3749,7 +3974,7 @@ mod tests {
                 path: archive_path,
                 layout: oci::LayerLayoutSpec::default(),
             }];
-            let _ = client.push_package(info, &layers).await;
+            let _ = client.push_package(info, &layers, &BTreeMap::new()).await;
             let calls = auth_calls(&data);
             // Must authenticate with Push before any blob/manifest operations.
             assert!(!calls.is_empty(), "push_package must call ensure_auth");
@@ -3794,7 +4019,14 @@ mod tests {
             let id = test_identifier("3.28");
 
             let _ = client
-                .merge_platform_into_index(&id, "3.28", &platform("linux/amd64"), "sha256:abc", 100)
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &platform("linux/amd64"),
+                    "sha256:abc",
+                    100,
+                    &BTreeMap::new(),
+                )
                 .await;
             let calls = auth_calls(&data);
             assert!(!calls.is_empty(), "merge_platform_into_index must call ensure_auth");
@@ -3868,7 +4100,7 @@ mod tests {
                 path: archive_path,
                 layout: oci::LayerLayoutSpec::default(),
             }];
-            let _ = client.push_package(info, &layers).await;
+            let _ = client.push_package(info, &layers, &BTreeMap::new()).await;
 
             // Verify auth happened before any transport method calls.
             let inner = data.read();
@@ -4087,7 +4319,7 @@ mod tests {
             }];
             let extra_tags = ["3".to_string(), "latest".to_string()];
             client
-                .push_manifest_and_merge_tags(&info("1.2.3"), &layers, &extra_tags)
+                .push_manifest_and_merge_tags(&info("1.2.3"), &layers, &extra_tags, &BTreeMap::new())
                 .await
                 .expect("push should succeed");
 
@@ -4116,6 +4348,44 @@ mod tests {
                 "push_manifest_raw", // extra_tags[1] push
             ];
             assert_eq!(relevant, expected, "cascade calls must follow input tag order");
+        }
+
+        /// A cascade must not leave a rolling tag with weaker provenance than
+        /// the version tag it mirrors — every index the push writes carries
+        /// the same annotations.
+        #[tokio::test(flavor = "multi_thread")]
+        async fn annotations_land_on_the_primary_tag_and_every_cascade_tag() {
+            let data = StubTransportData::new();
+            let client = stub_with_capture(&data);
+
+            let extra_tags = ["3".to_string(), "latest".to_string()];
+            let annotations = BTreeMap::from([(
+                oci::annotations::SOURCE.to_string(),
+                "https://github.com/ocx-sh/ocx".to_string(),
+            )]);
+            client
+                .push_manifest_and_merge_tags(&info("1.2.3"), &[], &extra_tags, &annotations)
+                .await
+                .expect("push should succeed");
+
+            let inner = data.read();
+            for tag in ["1.2.3", "3", "latest"] {
+                let key = format!("example.com/test/pkg:{tag}");
+                let (bytes, _) = inner.manifests.get(&key).unwrap_or_else(|| panic!("no index at {key}"));
+                let manifest: oci::Manifest = serde_json::from_slice(bytes).expect("index parses");
+                let oci::Manifest::ImageIndex(index) = manifest else {
+                    panic!("{key} is not an image index");
+                };
+                assert_eq!(
+                    index
+                        .annotations
+                        .as_ref()
+                        .and_then(|a| a.get(oci::annotations::SOURCE))
+                        .map(String::as_str),
+                    Some("https://github.com/ocx-sh/ocx"),
+                    "missing source annotation at {key}",
+                );
+            }
         }
     }
 
@@ -5274,7 +5544,7 @@ mod tests {
                 os_features: vec!["libc.glibc".to_string(), "libc.x".to_string()],
             };
             client
-                .merge_platform_into_index(&id, "3.28", &first_platform, "sha256:first_push", 100)
+                .merge_platform_into_index(&id, "3.28", &first_platform, "sha256:first_push", 100, &BTreeMap::new())
                 .await
                 .unwrap();
 
@@ -5288,7 +5558,14 @@ mod tests {
                 os_features: vec!["libc.x".to_string(), "libc.glibc".to_string()],
             };
             client
-                .merge_platform_into_index(&id, "3.28", &second_platform, "sha256:second_push", 200)
+                .merge_platform_into_index(
+                    &id,
+                    "3.28",
+                    &second_platform,
+                    "sha256:second_push",
+                    200,
+                    &BTreeMap::new(),
+                )
                 .await
                 .unwrap();
 

--- a/crates/ocx_lib/src/package/cascade.rs
+++ b/crates/ocx_lib/src/package/cascade.rs
@@ -11,7 +11,7 @@
 //! composes the algebra with [`Client`](crate::oci::Client) OCI transport
 //! to implement cascade pushes that correctly handle multi-platform registries.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Bound::{Excluded, Unbounded};
 
 use crate::{
@@ -200,6 +200,9 @@ pub async fn resolve_cascade_tags(
 /// Decision E) — looked up once from the primary tag's merged index, so a
 /// cascade never retags a pre-existing entry for a platform this call did
 /// not push.
+///
+/// `annotations` land on the primary tag's index and on every cascade tag's
+/// index alike.
 pub async fn push_with_cascade(
     client: &oci::Client,
     package_info: package::info::Info,
@@ -207,6 +210,7 @@ pub async fn push_with_cascade(
     other_versions: BTreeSet<Version>,
     version: &Version,
     canonical_tag: bool,
+    annotations: &BTreeMap<String, String>,
 ) -> Result<(oci::Digest, Vec<String>)> {
     let (cascade_tags, _) = resolve_cascade_tags(
         client,
@@ -218,7 +222,7 @@ pub async fn push_with_cascade(
     .await?;
 
     let (manifest_digest, index) = client
-        .push_manifest_and_merge_tags(&package_info, layers, &cascade_tags)
+        .push_manifest_and_merge_tags(&package_info, layers, &cascade_tags, annotations)
         .await?;
 
     if canonical_tag {
@@ -958,7 +962,7 @@ mod tests {
             let info = test_info("3.28.1", "linux/amd64");
             let version = Version::new_patch(3, 28, 1);
 
-            push_with_cascade(&client, info, &[], BTreeSet::new(), &version, true)
+            push_with_cascade(&client, info, &[], BTreeSet::new(), &version, true, &BTreeMap::new())
                 .await
                 .expect("cascade push succeeds");
 
@@ -980,7 +984,7 @@ mod tests {
             let info = test_info("3.28.1", "linux/amd64");
             let version = Version::new_patch(3, 28, 1);
 
-            push_with_cascade(&client, info, &[], BTreeSet::new(), &version, false)
+            push_with_cascade(&client, info, &[], BTreeSet::new(), &version, false, &BTreeMap::new())
                 .await
                 .expect("cascade push succeeds");
 

--- a/crates/ocx_lib/src/publisher.rs
+++ b/crates/ocx_lib/src/publisher.rs
@@ -14,7 +14,7 @@ pub mod publish_gate;
 pub use layer_ref::{ArchiveMediaType, LayerRef, LayerRefParseError};
 pub use publish_gate::{PublishGateError, verify_dependency_pins};
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use crate::{
@@ -88,12 +88,17 @@ impl Publisher {
     /// deletion safety net (`adr_index_indirection.md` Decision E). Applies
     /// only to the platform manifest pushed by this call, never to
     /// pre-existing entries the merge picks up from the registry.
+    ///
+    /// `annotations` are publisher-stated OCI annotations (`ocx package push
+    /// --annotation`) written onto the image index of every tag this push
+    /// touches. An empty map writes nothing at all.
     pub async fn push(
         &self,
         infos: Vec<Info>,
         layers: &[LayerRef],
         build_meta: Option<&str>,
         canonical_tag: bool,
+        annotations: &BTreeMap<String, String>,
     ) -> Result<PushOutcome> {
         let infos = apply_build_meta_all(infos, build_meta)?;
         let mut manifest_digest: Option<oci::Digest> = None;
@@ -105,7 +110,7 @@ impl Publisher {
             );
             let identifier = info.identifier.clone();
             let platform = info.platform.clone();
-            let (digest, manifest) = self.client.push_package(info, layers).await?;
+            let (digest, manifest) = self.client.push_package(info, layers, annotations).await?;
             if canonical_tag {
                 self.client
                     .push_canonical_tag(&identifier, &manifest, &platform)
@@ -126,8 +131,8 @@ impl Publisher {
     /// used to compute which rolling tags each platform's push should update
     /// (cascade blocker checks are platform-aware). The same `build_meta`
     /// semantics as [`Self::push`] apply. The outcome's `cascade_tags` is the
-    /// ordered union across platforms. `canonical_tag` has the same meaning
-    /// as [`Self::push`].
+    /// ordered union across platforms. `canonical_tag` and `annotations` have
+    /// the same meaning as in [`Self::push`].
     pub async fn push_cascade(
         &self,
         infos: Vec<Info>,
@@ -135,6 +140,7 @@ impl Publisher {
         existing_versions: BTreeSet<Version>,
         build_meta: Option<&str>,
         canonical_tag: bool,
+        annotations: &BTreeMap<String, String>,
     ) -> Result<PushOutcome> {
         let infos = apply_build_meta_all(infos, build_meta)?;
         let mut manifest_digest: Option<oci::Digest> = None;
@@ -155,6 +161,7 @@ impl Publisher {
                 existing_versions.clone(),
                 &version,
                 canonical_tag,
+                annotations,
             )
             .await?;
             manifest_digest = Some(digest);
@@ -313,7 +320,7 @@ mod tests {
             StubTransportData::new(),
         ))));
         let err = publisher
-            .push(Vec::new(), &[], None, false)
+            .push(Vec::new(), &[], None, false, &BTreeMap::new())
             .await
             .expect_err("empty set");
         assert!(err.to_string().contains("at least one target platform"), "got: {err}");
@@ -330,7 +337,7 @@ mod tests {
         let mut mac = test_info("1.0.0");
         mac.platform = "darwin/arm64".parse().expect("platform parses");
         let outcome = publisher
-            .push(vec![test_info("1.0.0"), mac], &[], None, false)
+            .push(vec![test_info("1.0.0"), mac], &[], None, false, &BTreeMap::new())
             .await
             .expect("fan-out push succeeds");
 
@@ -374,7 +381,7 @@ mod tests {
         let publisher = Publisher::new(oci::Client::with_transport(Box::new(StubTransport::new(data.clone()))));
 
         publisher
-            .push(vec![test_info("1.0.0")], &[], None, true)
+            .push(vec![test_info("1.0.0")], &[], None, true, &BTreeMap::new())
             .await
             .expect("push succeeds");
 
@@ -395,7 +402,7 @@ mod tests {
         let publisher = Publisher::new(oci::Client::with_transport(Box::new(StubTransport::new(data.clone()))));
 
         publisher
-            .push(vec![test_info("1.0.0")], &[], None, false)
+            .push(vec![test_info("1.0.0")], &[], None, false, &BTreeMap::new())
             .await
             .expect("push succeeds");
 

--- a/test/tests/test_package_push_annotations.py
+++ b/test/tests/test_package_push_annotations.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The OCX Authors
+"""`ocx package push --annotation` writes OCI annotations on the image index.
+
+`org.opencontainers.image.source` is the only mechanism by which a registry
+links a published package back to its source repository, so these tests pin
+the wire effect end-to-end against a live registry: the annotation reaches
+the index of the primary tag and of every cascade tag, and a push without the
+flag leaves the index annotation-free.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.helpers import make_package
+from src.registry import fetch_manifest_from_registry
+from src.runner import OcxRunner
+
+SOURCE = "org.opencontainers.image.source"
+REVISION = "org.opencontainers.image.revision"
+SOURCE_URL = "https://github.com/ocx-sh/ocx"
+
+
+def index_annotations(ocx: OcxRunner, repo: str, tag: str) -> dict[str, str]:
+    manifest = fetch_manifest_from_registry(ocx.registry, repo, tag)
+    return manifest.get("annotations") or {}
+
+
+def test_annotation_lands_on_the_primary_tag_and_every_cascade_tag(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    make_package(
+        ocx,
+        unique_repo,
+        "1.2.3",
+        tmp_path,
+        new=True,
+        cascade=True,
+        extra_push_args=["--annotation", f"{SOURCE}={SOURCE_URL}", "--annotation", f"{REVISION}=deadbeef"],
+    )
+
+    # A cascading push must not leave a rolling alias with weaker provenance
+    # than the version tag it points at.
+    for tag in ("1.2.3", "1.2", "1", "latest"):
+        annotations = index_annotations(ocx, unique_repo, tag)
+        assert annotations.get(SOURCE) == SOURCE_URL, f"missing source annotation on {tag}: {annotations}"
+        assert annotations.get(REVISION) == "deadbeef", f"missing revision annotation on {tag}: {annotations}"
+
+
+def test_push_without_the_flag_writes_no_index_annotations(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """The absent-value case: no flag, no annotations, no behaviour change."""
+    make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=False)
+
+    assert index_annotations(ocx, unique_repo, "1.0.0") == {}
+
+
+def test_a_later_plain_push_does_not_unlink_the_source_repository(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """Merging into an existing index preserves annotations it already holds,
+    so a pipeline that forgets the flag on one release does not silently
+    unlink the package from its repository."""
+    make_package(
+        ocx,
+        unique_repo,
+        "1.0.0",
+        tmp_path,
+        new=True,
+        cascade=True,
+        extra_push_args=["--annotation", f"{SOURCE}={SOURCE_URL}"],
+    )
+    make_package(ocx, unique_repo, "1.0.1", tmp_path, new=False, cascade=True)
+
+    # `latest` was re-pointed by the second, annotation-less push.
+    assert index_annotations(ocx, unique_repo, "latest").get(SOURCE) == SOURCE_URL

--- a/website/src/docs/authoring/building-pushing.md
+++ b/website/src/docs/authoring/building-pushing.md
@@ -66,6 +66,22 @@ Cascade is a publisher convention, not a registry-enforced rule. The registry se
 
 <Terminal src="/casts/authoring/package-cascade.cast" title="Cascading rolling tags across releases" collapsed />
 
+## Linking the Source Repository {#source-annotation}
+
+A published package tells a consumer nothing about where it came from. Registries do not infer it: the path `ghcr.io/acme/tools/widget` names a package, not a repository, and a registry that guessed otherwise would be wrong the moment a publisher mirrors someone else's software under their own namespace — which is exactly what a mirror repository does.
+
+The [OCI image spec][oci-annotations] reserves `org.opencontainers.image.source` for the answer, and [GHCR][ghcr-repo-link] reads it: set it and the package page shows the repository link and the package inherits that repository's permissions; omit it and neither happens, whatever the path looks like. State it at push time with `--annotation`:
+
+```shell
+ocx package push -c -p linux/amd64 -i ghcr.io/acme/tools/widget:1.2.3 \
+  --annotation org.opencontainers.image.source=https://github.com/acme/widget \
+  widget-1.2.3-linux-amd64.tar.xz
+```
+
+In CI the value is already in the environment — on [GitHub Actions][github-actions-docs] it is `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY`. OCX deliberately does not read that variable itself: a package built anywhere other than the forge you assumed would then silently claim provenance it does not have, and OCX publishes to any registry from any forge.
+
+The annotation lands on the [image index][oci-image-index] of every tag the push writes, cascade tags included, so a rolling alias never advertises weaker provenance than the version tag it points at. Repeat the flag for other keys — `org.opencontainers.image.revision` for the commit, `org.opencontainers.image.licenses` for the SPDX expression. Leaving the flag off writes nothing and leaves any annotation an earlier push set in place.
+
 ## Reusing Layers Across Packages {#layer-reuse}
 
 A package's content is the union of its layers — a base, optional middle layers, a top layer with the binary. Re-pushing a layer that already exists in the target registry is wasteful: the registry GC will dedupe in the background, but the publisher already spent the upload bandwidth and the consumer pays the download cost on first install.
@@ -93,6 +109,7 @@ If a file in your working directory is literally named `sha256:abc….tar.gz`, p
 ## See Also {#see-also}
 
 - [`ocx package push` reference][cmd-package-push]
+- [`ocx package push --annotation` reference][cmd-package-push-annotations]
 - [Versioning in depth — cascades][in-depth-versioning-cascades]
 - [Storage in depth — layers][in-depth-storage-layers]
 - [Declaring dependencies][authoring-dependencies] — when to depend, visibility, `name` overrides
@@ -101,11 +118,15 @@ If a file in your working directory is literally named `sha256:abc….tar.gz`, p
 
 <!-- external -->
 [oci-image-index]: https://github.com/opencontainers/image-spec/blob/main/image-index.md
+[oci-annotations]: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+[ghcr-repo-link]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
+[github-actions-docs]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-pre-written-building-blocks-in-your-workflow
 [mirror-pipeline]: https://github.com/ocx-sh/ocx/tree/main/crates/ocx_mirror
 
 <!-- commands -->
 [cmd-package-create]: ../reference/command-line.md#package-create
 [cmd-package-push]: ../reference/command-line.md#package-push
+[cmd-package-push-annotations]: ../reference/command-line.md#package-push-annotations
 [cmd-package-describe]: ../reference/command-line.md#package-describe
 [arg-remote]: ../reference/command-line.md#arg-remote
 [arg-offline]: ../reference/command-line.md#arg-offline

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -2256,6 +2256,7 @@ ocx package push [OPTIONS] --identifier <IDENTIFIER> <LAYERS>...
 - `--build-timestamp [<FORMAT>]`: Append a UTC build-metadata segment to the published tag. `datetime` (default when flag passed bare) appends `_YYYYMMDDhhmmss`, `date` appends `_YYYYMMDD`, `none` is a no-op. The identifier's tag must already be `X.Y.Z` (optionally with a variant prefix or pre-release suffix) and must not already carry build metadata. Use this in continuous-deploy pipelines that publish rolling pre-release versions like `dev.ocx.sh/ocx/cli:0.3.0-dev_20260514120000`. The wire-format tag uses `_` (OCI tags forbid `+`); semver `+` is accepted on input and normalized. When the flag is omitted entirely, no build-metadata segment is appended. Passing `--build-timestamp=none` is the explicit equivalent.
 - `--canonical-tag` / `--no-canonical-tag`: `--canonical-tag` (default) also pushes a digest-named `sha256.<hex>` tag for each platform manifest pushed in this invocation; `--no-canonical-tag` skips it. This is a pure registry-side deletion safety net — a stray tag delete cannot orphan a digest still referenced by a lock, since the canonical tag itself keeps the manifest reachable. It has no effect on [`index.ocx.sh`][in-depth-indices-public] resolution, which ignores canonical tags entirely.
 - `--announce-file <PATH>`: After a successful push, append the pushed tag and any cascade tags to this file (creating it if absent), so [`ocx package announce --tags-file`][cmd-package-announce] can pick them up. This is a scratch file for one pipeline run, not a persistent list — a stale file left over from an earlier run could re-add a tag that was deliberately dropped from a later announce.
+- `--annotation <KEY=VALUE>`: Record an [OCI annotation][oci-annotations] on the published [image index][oci-image-index]. Repeatable; see [Annotations](#package-push-annotations) below.
 - `-h`, `--help`: Print help information.
 
 ::: tip Layer reuse
@@ -2274,6 +2275,27 @@ ocx package push -p linux/amd64 -i mytool:1.0.1 sha256:<hex>.tar.gz newtool.tar.
 
 ::: warning Bring your own archives
 `ocx package push` does not bundle a directory for you. Each file layer must be a pre-built archive. Re-bundling the same content yields a non-deterministic digest (timestamps, compression entropy) and defeats layer reuse — use [`ocx package create`](#package-create) to produce a stable archive once, then push and reference it by digest from later commands.
+:::
+
+#### Annotations {#package-push-annotations}
+
+`--annotation KEY=VALUE` records an [OCI annotation][oci-annotations] on the [image index][oci-image-index] of every tag the push writes — the primary tag and, under `--cascade`, each rolling tag it re-points. The flag is repeatable, splits at the first `=` (so values may contain `=`), and keeps the last value for a repeated key. A key that is empty, or an argument with no `=` at all, is a usage error (exit 64).
+
+Values are written verbatim: OCX never derives an annotation from the environment or from the repository path. Omitting the flag writes nothing and leaves whatever the index already carries untouched, so an earlier annotation survives a later plain push. Supplying a key overwrites that one key and leaves the rest of the index's annotations alone.
+
+The annotation that matters in practice is `org.opencontainers.image.source`. It is the documented mechanism by which a registry links a package back to its source repository — on [GHCR][ghcr-repo-link] this is what produces the repository link on the package page and what makes the package inherit that repository's permissions. Registries derive nothing from the repository path, so a package published to `ghcr.io/acme/tools/widget` links to nothing until the annotation says otherwise:
+
+```shell
+# In GitHub Actions, the runner already knows the answer.
+ocx package push -c -p linux/amd64 -i ghcr.io/acme/tools/widget:1.2.3 \
+  --annotation org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
+  widget-1.2.3-linux-amd64.tar.xz
+```
+
+Any other annotation key works the same way — `org.opencontainers.image.revision` for the commit that produced the build, `org.opencontainers.image.licenses` for the SPDX expression. The [OCI annotation spec][oci-annotations] lists the pre-defined keys and the reverse-domain convention for custom ones; OCX does not validate keys beyond rejecting an empty one.
+
+::: tip Catalog display lives elsewhere
+Title, description, and keywords shown in a catalog come from [`ocx package describe`](#package-describe), which publishes them on the separate `__ocx.desc` tag. `--annotation` is for facts about a *published build* that a registry reads off the index itself.
 :::
 
 #### Layer layout {#package-push-layout}
@@ -3392,6 +3414,9 @@ or a registry error) — the report then degrades to a local-state-only summary
 [nixos]: https://nixos.org/
 [nix-ld]: https://github.com/nix-community/nix-ld
 [gentoo-prefix]: https://wiki.gentoo.org/wiki/Project:Prefix
+[oci-annotations]: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+[oci-image-index]: https://github.com/opencontainers/image-spec/blob/main/image-index.md
+[ghcr-repo-link]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 
 <!-- in-depth -->
 [exec-modes]: ../in-depth/environments.md#visibility-views


### PR DESCRIPTION
## Why

`crates/ocx_lib/src/oci/annotations.rs` defines `org.opencontainers.image.source` and **nothing ever wrote it** — published packages return `annotations: null` on their image index.

That annotation is the only documented mechanism by which a registry links a package back to its source repository. On GHCR it drives both the repository link on the package page and the package's permission inheritance from that repository. Registries derive nothing from the repository path, so no OCX package has ever been linked. This is about to matter at scale: the `ocx-contrib` mirror repos move to nested paths like `ghcr.io/ocx-contrib/bazelbuild/bazelisk`, where no path segment corresponds to a repository at all.

## What

`ocx package push --annotation KEY=VALUE`, repeatable.

The value is written verbatim onto the image index of **every tag the push writes** — the primary tag and, under `--cascade`, each rolling tag it re-points — so a rolling alias never advertises weaker provenance than the version tag it points at.

```shell
ocx package push -c -p linux/amd64 -i ghcr.io/acme/tools/widget:1.2.3 \
  --annotation org.opencontainers.image.source=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY \
  widget-1.2.3-linux-amd64.tar.xz
```

## Design notes

**Why a generic flag, not `--source`.** Of the ten OCI annotation constants OCX defines, only `TITLE`, `DESCRIPTION`, and `KEYWORDS` are written anywhere — and only by `ocx package describe`, onto the separate `__ocx.desc` tag. `VERSION`, `SOURCE`, `CREATED`, `URL`, `REVISION`, `VENDOR`, `AUTHORS`, and `LICENSES` are all dead constants. The push-time subset (`source`, `revision`, `licenses`) all wants the same treatment, so one passthrough flag beats N bespoke ones — and it is a smaller diff than either. This is the `oras push --annotation` / `docker buildx --annotation` idiom.

**Why publisher-stated, never derived.** Reading `GITHUB_REPOSITORY` would make published wire content depend on invisible ambient state — a local push from a shell that happens to have it exported would silently stamp the wrong repository — and OCX publishes to any registry from any forge. Callers expand the variable themselves; it costs one shell expansion and is explicit.

**Why not the metadata sidecar.** The source repository is a property of *who published this build*, not of the package content. `ocx package create` produces the sidecar from content; a mirror repository URL is not content. It would also force the value into the config blob, changing every package's config digest.

**Why index-level only.** Every OCX push resolves its tag to an image index (the merge creates one even for a single platform), so index-level covers 100% of packages. Leaving the platform manifest alone keeps `build_package_manifest` shared byte-for-byte with the local `pull_local` path and keeps the frozen manifest golden intact.

## Backward compatibility

Absent flag ⇒ absent annotation. An empty map leaves the index's `annotations` field exactly as found, so:

- a plain push produces byte-identical bytes to before this change;
- a later annotation-less push never clears a link an earlier push established;
- a supplied key overwrites only itself, leaving annotations another tool set alone.

No metadata or schema change. `ocx config push` (which shares `Publisher`) passes an empty map and is unaffected.

## Tests

Unit (`oci/client.rs`, stub transport): fresh-index write, **absent-value case** (field stays `None`), preservation across an annotation-less merge, key-level merge over existing annotations, and every-cascade-tag coverage. CLI (`package_push.rs`): `KEY=VALUE` splitting at the first `=`, empty value accepted, missing `=` and empty key rejected (exit 64, verified), repeated-key last-wins.

Acceptance (`test/tests/test_package_push_annotations.py`, live registry): annotation on primary + all cascade tags, no-flag → no annotations, and a later plain push not un-linking the repository.

## Verification

```
task --force verify exit status: 0
====== 1684 passed, 41 skipped, 2 xfailed, 2 xpassed in 226.50s (0:03:46) ======
```

## Docs

- `website/src/docs/reference/command-line.md` — `--annotation` option entry + new `#### Annotations {#package-push-annotations}` section
- `website/src/docs/authoring/building-pushing.md` — new `## Linking the Source Repository` section
- CLI `--help` (long help with the GitHub Actions example)

## Deliberately left alone

- The other seven dead annotation constants are not wired up — the flag makes them reachable without OCX taking a position on any of them.
- The platform image manifest and the canonical `sha256.<hex>` tag carry no annotations (see design note above).
- `ocx config push` gets no annotation surface of its own.
