### PR TITLE
test(announce-e2e): land the Track D live drivers and evidence module

### DIFF
--- a/.claude/artifacts/e2e_results_announce.md
+++ b/.claude/artifacts/e2e_results_announce.md
@@ -1,0 +1,44 @@
+# Announce E2E Results (Track D, gate G-D)
+
+Durable evidence that the fork-PR announce lane works end to end against the
+real `ocx-sh/index`. Consumed by Track E's rollout handover and Track F's
+doc-accuracy check.
+
+**Status:** template — no run recorded yet. Every cell reads `MISSING` until an
+operator executes the drivers in `test/manual/announce-e2e/` and pastes the
+rollup in. An incomplete evidence set is meant to look incomplete.
+
+## How to fill this in
+
+```sh
+cd test && PYTHONPATH=src uv run python -m announce_e2e.evidence render \
+    --records-dir manual/announce-e2e/results
+```
+
+Replace the table below with that output, then commit. The renderer redacts
+`OCX_ANNOUNCE_TOKEN` out of every free-text field on the way in, and
+`EvidenceRecord` refuses text that has not been through redaction — this file
+is committed and durable, so it must never carry a live credential.
+
+## Results
+
+<!-- BEGIN evidence table — byte-identical to `render_evidence_markdown([])`
+     while empty; pinned by test_announce_e2e_evidence.py -->
+| Scenario | Status | Pull Request | Runs | Latency (s) | Captured At | Notes |
+|---|---|---|---|---|---|---|
+| sequenced | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
+| idempotency | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
+| machine_lane | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
+| update_union | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
+| clean_install | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
+<!-- END evidence table -->
+
+## What each row proves
+
+| Scenario | Design-spec §7 bullet | Driver |
+|---|---|---|
+| `sequenced` | tag → build → announce → fork PR → validate green → merge → served → clean install | `run_sequence.sh` |
+| `idempotency` | second identical run: `status: "unchanged"`, zero PRs, zero commits (C6) | `run_idempotency.sh` |
+| `machine_lane` | tag-refresh announce auto-merges via G-19 with no human click | `run_machine_lane.sh` |
+| `update_union` | two announces, first PR unmerged → one PR carrying both tag sets (C4) | `run_update_union.sh` |
+| `clean_install` | `ocx install` resolves from a machine that has never seen ocx | `clean_install_check.sh` |

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,12 @@ venv/
 # =============================================================================
 *.pid
 *.sock
+
+# =============================================================================
+# Announce E2E per-run evidence (real PR URLs, live timestamps, container logs
+# — scratch). Everything, not just *.json: a `.log` left tracked is one
+# `git add -A` away from being committed. The durable record is
+# .claude/artifacts/e2e_results_announce.md.
+# =============================================================================
+test/manual/announce-e2e/results/*
+!test/manual/announce-e2e/results/.gitkeep

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -20,9 +20,20 @@ test/manual/
 │   ├── env.sh                ← source to point at localhost:5000
 │   ├── bootstrap.sh          ← idempotent build + push of every package
 │   └── teardown.sh           ← rm -rf $OCX_HOME (with confirm)
+├── announce-e2e/             ← Track D announce gate against the REAL index
+│   ├── README.md             ← runbook, prerequisites, per-driver walkthrough
+│   ├── PLAYBOOKS.md          ← three failure playbooks
+│   ├── scripts/              ← five live drivers + shared env.sh
+│   └── docker/               ← clean-machine image for the install proof
 └── adversarial/
     └── README.md             ← test-implementer vs loophole-searcher process
 ```
+
+`announce-e2e/` is the one rig here that does **not** point at
+`localhost:5000`. It drives the real `ocx-sh/index`, the real publisher repo
+and live DNS, because the exit gate it proves is explicitly not allowed to be
+sandboxed. Every run costs GitHub API budget and CI minutes and leaves real
+pull requests behind — read its README before running anything in it.
 
 ## Prerequisites
 

--- a/test/manual/announce-e2e/CLAIM.md
+++ b/test/manual/announce-e2e/CLAIM.md
@@ -1,0 +1,172 @@
+# Claim the pilot namespace (owner action, one human click)
+
+The Track D live sequence is blocked on exactly one thing:
+`p/michael-herwig/ocx-e2e-hello.json` does not exist on `ocx-sh/index`. This
+file is everything needed to open that pull request, ready to paste.
+
+Nothing here has been executed. The root has not been created and no pull
+request has been opened.
+
+## 1. The entry
+
+Path in the index repo: `p/michael-herwig/ocx-e2e-hello.json`
+
+```json
+{
+  "name": "ocx.sh/michael-herwig/ocx-e2e-hello",
+  "repository": "oci://ghcr.io/michael-herwig/ocx-e2e-hello",
+  "owners": [
+    {
+      "github": "michael-herwig",
+      "github_id": 3511590
+    }
+  ],
+  "status": "active",
+  "deprecated_message": null,
+  "created": "2026-07-25",
+  "desc": null,
+  "tags": {}
+}
+```
+
+Where each value comes from — authority, not memory:
+
+| Field | Value | Source |
+|---|---|---|
+| `name` | `ocx.sh/michael-herwig/ocx-e2e-hello` | `schema/root.schema.json` requires it to equal the path-derived logical name (G-02) |
+| `repository` | `oci://ghcr.io/michael-herwig/ocx-e2e-hello` | the publisher's own push target: `identifier="ghcr.io/michael-herwig/ocx-e2e-hello:${TAG}"`, `.github/workflows/e2e-publish.yml:140` in `ocx-e2e-publisher` @ `76e24e2`. `ghcr.io` is the only host in `REPOSITORY_HOST_ALLOWLIST` (`bot/src/indexbot/core/validate_entry.py:59`), so G-03 passes |
+| `owners[].github_id` | `3511590` | `gh api users/michael-herwig --jq .id`. The numeric id is the ownership key — a login is renameable and recyclable |
+| `status` | `active` | schema enum; `active` is what a new claim uses |
+| `deprecated_message` | `null` | required by schema even when unset |
+| `created` | `2026-07-25` | today. Set once, never updated |
+| `desc` | `null` | nothing observed yet; the bot fills this from `__ocx.desc` on the first announce |
+| `tags` | `{}` | claiming ahead of the first announce. **Do not hand-write tag entries** — `content`/`observed` are bot-regenerated fields |
+| `upstream` | *omitted* | governance requires it only where the namespace names a real third-party vendor. This is the owner's own test package, not a vendor mirror — same shape as `schema/fixtures/valid/root-valid-first-party-no-upstream-null-desc.json` |
+
+Field order matches the bot's own serializer, so the first announce produces a
+clean diff (only `tags` changes) rather than a reformat.
+
+### Validation already run against the real schema
+
+From `.agents/worktrees/index-integration` (branch `announce/b`, what merged as
+index main `98f9aa32`), against a scratch copy — nothing was written into `p/`:
+
+```
+check-jsonschema --schemafile schema/root.schema.json <scratch>   ok -- validation done
+G-02 name matches path          : ok
+reserved-segment check          : ok
+G-03 repository host allowlisted: ok
+byte-identical to bot serializer: True
+```
+
+Negative control, to prove the validator was actually checking: dropping
+`github_id` from the owner fails with
+`$.owners[0]: 'github_id' is a required property`.
+
+## 2. Opening the pull request
+
+```sh
+# From a checkout of your ocx-sh/index fork.
+git checkout main && git pull
+git checkout -b claim/michael-herwig-ocx-e2e-hello
+
+mkdir -p p/michael-herwig
+cat > p/michael-herwig/ocx-e2e-hello.json <<'JSON'
+{
+  "name": "ocx.sh/michael-herwig/ocx-e2e-hello",
+  "repository": "oci://ghcr.io/michael-herwig/ocx-e2e-hello",
+  "owners": [
+    {
+      "github": "michael-herwig",
+      "github_id": 3511590
+    }
+  ],
+  "status": "active",
+  "deprecated_message": null,
+  "created": "2026-07-25",
+  "desc": null,
+  "tags": {}
+}
+JSON
+
+git add p/michael-herwig/ocx-e2e-hello.json
+git commit -m "feat(index): claim michael-herwig/ocx-e2e-hello"
+git push -u origin claim/michael-herwig-ocx-e2e-hello
+
+gh pr create \
+  --repo ocx-sh/index \
+  --base main \
+  --title "Claim michael-herwig/ocx-e2e-hello" \
+  --body "First claim for the Track D announce E2E pilot package.
+
+Physical mirror: ghcr.io/michael-herwig/ocx-e2e-hello (pushed by
+michael-herwig/ocx-e2e-publisher). Claiming ahead of the first announce, so
+tags is {} — the bot populates it.
+
+Validated locally against schema/root.schema.json plus the bot's own
+check_name_matches_path / check_namespace_not_reserved /
+check_repository_allowlisted."
+```
+
+Expect `schema-validate` green and `governance-gate` to apply the
+`new-package` label with a red `governance/review-required` status. That red
+status is correct and does not auto-resolve — approve and merge by hand.
+
+## 3. Why a human has to click this
+
+Ratified ruling **R3**: announce refuses an unclaimed namespace and never
+creates roots itself, so the first claim is a human-lane (G-04) prerequisite
+that no driver in this directory can satisfy. Automating it would defeat the
+one governance control the whole exercise exists to prove — a reviewer
+judging whether the claimed namespace plausibly belongs to the entity it
+names, which is not automatable by construction.
+
+## 4. What unblocks the moment it merges
+
+```sh
+export GH_REPO_PUBLISHER=michael-herwig/ocx-e2e-publisher
+export GH_REPO_INDEX=ocx-sh/index
+export INDEX_FORK=michael-herwig/index
+export E2E_NAMESPACE=michael-herwig
+export E2E_PACKAGE=ocx-e2e-hello
+export E2E_INDEX_PREFIX=ocx.sh
+export BOT_ACTOR_IDS=41898282
+
+./scripts/run_sequence.sh <tag>
+```
+
+`BOT_ACTOR_IDS=41898282` is `github-actions[bot]` (`gh api
+users/github-actions[bot] --jq .id`). G-19 auto-merge is armed with the default
+`GITHUB_TOKEN` (`.github/workflows/validate.yml:208`,
+`gh pr merge --auto --squash`), so that is the identity a machine-lane merge is
+recorded under. **Verify it against the first real merged PR before trusting
+the machine-lane proof** — if the index later moves to a PAT-backed machine
+account, this id changes and `classify_lane` would report `human` for a
+genuine bot merge.
+
+G-19 also requires the announcing identity to own every touched root. The
+announce runs under `OCX_ANNOUNCE_TOKEN`, the owner's PAT, and `owners[]`
+above carries `3511590` — so that precondition is satisfied by this entry as
+written.
+
+## 5. Still blocked after the merge
+
+- **The clean-install leg needs an ocx carrying index-kind config.** Released
+  ocx 0.4.3 rejects the config the clean-machine image writes:
+  `unknown field 'index', expected 'url'` — proven in-container. Point
+  `OCX_BINARY` at a dev-channel-equivalent build before running
+  `clean_install_check.sh`; the default `target/release/ocx` works only if it
+  is such a build.
+- **The publisher's announce step passes no `--package`.**
+  `ocx-e2e-publisher` `.github/workflows/e2e-publish.yml:228` invokes
+  `ocx package announce --tags-file … --fork … --index-repo …`, but the
+  shipped CLI declares `--package` as `required = true`
+  (`crates/ocx_cli/src/command/package_announce.rs:38`). That is a clap usage
+  error, not a soft skip. Track C's repo owns the fix; the sequenced and
+  machine-lane drivers both depend on that step producing a pull request.
+- **Everything downstream of "the HTTPS request leaves the container"** is
+  unproven — that `index.ocx.sh` serves the rendered root, that a real root
+  resolves through to a registry pull, and that
+  `clean_install_check.sh`'s `grep -q "$E2E_PACKAGE"` matches a real success
+  payload. That last one is the most likely false negative on the first run;
+  it now greps the redacted log stream, not the raw one.

--- a/test/manual/announce-e2e/PLAYBOOKS.md
+++ b/test/manual/announce-e2e/PLAYBOOKS.md
@@ -1,0 +1,167 @@
+# Announce E2E Failure Playbooks
+
+What to do when a driver in [README.md](./README.md) exits non-zero. Each
+playbook names the diagnosis, the fix, and the thing not to do.
+
+## Playbook: Floating Tag Not Advanced
+
+**Symptom.** The publisher's CI runs against a stale ocx: a fix you deployed is
+not in the announce it produces, or `ocx update` in the publisher keeps
+resolving the same old digest.
+
+**Diagnosis.** The publisher's `ocx.toml` pins the floating tag
+`dev.ocx.sh/ocx/cli:<next>-dev` — never a `_<TS>` build segment. Compare what
+that tag resolves to now against what the last Deploy Dev run published:
+
+```sh
+source ./scripts/env.sh
+check_floating_tag dev.ocx.sh/ocx/cli:0.5.0-dev
+```
+
+That prints the currently-resolved digest and the `gh run list` command for the
+Deploy Dev history. Digests differ → the deploy did not advance the floating
+tag.
+
+**Fix.** Re-run Deploy Dev:
+
+```sh
+gh workflow run "Deploy Dev" --repo ocx-sh/ocx --ref <branch>
+```
+
+`workflow_dispatch` only, and only for a branch that exists on `origin` — the
+branch has to be pushed first.
+
+**Do not** hand-pin a timestamped `<next>-dev_<TS>` tag to work around it, and
+do not hand-edit `ocx.lock`. Refresh with `ocx update` only. A stuck floating
+tag is a broken deploy; pinning around it hides the break and every later run
+inherits it (register §7 step 5, verbatim rule).
+
+## Playbook: validate.yml Red
+
+**Symptom.** `run_sequence.sh` exits at phase (d): "validate.yml is not green".
+
+**Diagnosis.** The index bot surfaces a structured reason for every
+publisher-visible failure — never a bare exit (register §5, the observability
+floor). Read it, in this order:
+
+1. The failing check run's **step summary** on the pull request's Checks tab —
+   this is where the bot writes the reason.
+2. The bot's **comment on the pull request**, if it posted one.
+3. Only then the raw job log:
+   `gh run view <run-id> --repo ocx-sh/index --log-failed`.
+
+The reason text is free-form by design, so there is no script here — read it
+and route on what it says.
+
+| Reason names | Route |
+|---|---|
+| a schema or field error in the rebuilt root | Track A — the client produced it |
+| an unresolvable tag or digest | check the tag still exists on the registry; announce observes, it does not create |
+| an SSRF-forbidden physical host | the root's `oci://<host>` pointer; `trusted_hosts` on the namespace's `[registries]` entry |
+| a governance rule (owners, upstream, lane) | Track B — the index bot owns it |
+
+**Do not** re-run the announce hoping it turns green. A red `validate.yml` on a
+deterministic input stays red.
+
+## Playbook: Registry Byte Identity
+
+**Symptom.** `run_sequence.sh` exits at phase (g2): a committed
+`o/sha256/<hex>.json` did not match what the registry serves under that digest.
+
+**Read the taxonomy before concluding anything.** These four outcomes look
+alike in a log and mean entirely different things. Reading a transport artefact
+as a format regression sends the next hour into the wrong repository, which is
+why (g2) exits with a distinct message per row.
+
+| Observation | Verdict | Next step |
+|---|---|---|
+| **1.** 404 / `MANIFEST_UNKNOWN` | **The bug class** — the index locked a digest no registry serves | Pre-change: this is the reproduction, capture it (that is the whole point of the `1.0.3` run). Post-change: **this is also where a format regression lands** — a re-serialization in the announce path commits an object that hashes to its own filename and then 404s, because no registry ever stored those bytes. Look for a parse-then-write path; announce must copy `fetch_manifest_raw_bytes` verbatim |
+| **2.** 200, `Docker-Content-Digest` ≠ requested | The registry content-negotiated | A **registry-behaviour** finding, not a mapping defect. **Do not** conclude a format regression. Re-request with a single `Accept` and compare |
+| **3.** 200, header matches, bytes ≠ committed | **Registry integrity failure** — the registry advertised digest H and served bytes that do not hash to H | Not the announce path: the hash anchor below already proved `sha256(committed) == H`, and step 3 proved the registry claims H, so only the registry can be lying. Re-fetch; if it persists, escalate to the registry operator |
+| **4.** 200, header matches, bytes == committed | **Proof** | Nothing to do; the digest lands in the evidence notes |
+
+Row 3 is the rare one, and rows 1 and 3 are **not** two flavours of the same
+defect: a re-serialization can only produce row 1, because the whole point is
+that the committed digest exists nowhere but the index. Read the routing in row
+1, not row 3, when you suspect the client.
+
+A status that is neither 200 nor 404 — 401, 403, 429, 5xx — is a transport or
+credential failure and gets its own message. It is **not** a row above. Re-run
+after fixing the credential; a rate-limited GET says nothing about the format.
+
+**Two earlier anchors fire before the registry is contacted**, so a failure
+there is not a registry problem at all:
+
+- *"nothing is committed at `o/sha256/<hex>.json`"* — a D2/D3 violation: the
+  root names a `tags[].content` with no object behind it. Track B (the index
+  bot renders `o/`), not the client.
+- *"does not hash to its own filename"* — the CAS disagrees with itself.
+  Everything downstream of that is meaningless; stop and escalate.
+
+**And four refusals fire before even those**, on the served root itself. Each
+says (g2) declined to judge, not that the mapping is wrong:
+
+- *"malformed content digest"*, *"is not a host"*, *"is not an OCI repository
+  name"*, *"does not name a usable physical repository"* — the root carries
+  something that would have gone into a URL unvalidated. The root is
+  publisher-controlled; a `?` in the repository path silently truncates the
+  request into one that never asked for a manifest, and its 404 would read as
+  row 1. Fix the root, or find out who wrote it.
+- *"failed to parse"* / *"would pass vacuously"* / *"would attest D7
+  vacuously"* — the served root did not parse, or committed no tags. A render
+  regression or a CDN error page served with 200 both land here. Check what
+  `/p/<ns>/<pkg>.json` actually returns before suspecting anything else.
+
+**Do not** re-run (g2) hoping it turns green. Every input is a committed digest
+and a content-addressed GET; a red (g2) on the same root stays red.
+
+## Playbook: Lane Misclassification
+
+Checklist only — no diagnostic script. This playbook fires when the automation
+disagreed with what you expected, which is a human judgment call by
+construction; the corrective action is an issue against the classifier, not a
+script that "fixes" the lane (Key Decision D-6).
+
+**What looks wrong.**
+
+- A routine tag refresh sat waiting for human review when you expected G-19
+  auto-merge.
+- A first-claim or `owners[]`-changing pull request auto-merged when you
+  expected human review. **This is the serious direction** — treat it as a
+  governance incident, not a convenience bug.
+- `run_machine_lane.sh` failed with `human_click_detected: true` on a pull
+  request nobody touched.
+
+**Check the benign causes first.**
+
+1. **Path allowlist (most common, and new since this plan was written).** The
+   hardened bot forces `human-review-required` on any pull request whose
+   changed paths leave the touched roots plus those roots' own CAS objects at
+   `p/<ns>/<pkg>/o/sha256/<64hex>.{json,md,svg,png}`. This is fail-closed and
+   correct. A machine-lane scenario whose diff strays outside that scope — a
+   stray file, a second package, anything under a different root — will
+   correctly *not* auto-merge. Check the pull request's Files tab before
+   suspecting the classifier.
+2. **`owners[]` membership.** G-19 auto-merge needs the announcer's numeric
+   `github_id` already in the claimed root's `owners[]`. Absent → human lane,
+   correctly.
+3. **`BOT_ACTOR_IDS` is wrong.** If the id in your environment is not the id
+   that actually merged, `classify_lane` reports `human` for a genuine bot
+   merge. Confirm with:
+   ```sh
+   gh api repos/ocx-sh/index/issues/<pr>/events --jq '.[] | {event, id: .actor.id, login: .actor.login}'
+   ```
+   Compare the **numeric id**, never the login. A matching login with a
+   different id is exactly the recycled-login case the numeric check exists to
+   catch — that is a correct `human` verdict, not a false positive.
+
+**Escalate** when none of those explain it. Open an issue against the index
+repository with:
+
+- the pull request URL and the numeric actor ids off its events,
+- the `evidence classify-lane` output,
+- the lane you expected and why (`owners[]` state, the diff's paths).
+
+**Non-goal.** Nothing in Track D auto-corrects a lane. Do not merge a pull
+request by hand to "unblock" a machine-lane run — that destroys the evidence
+the run exists to produce, and the recorded proof would be a lie.

--- a/test/manual/announce-e2e/README.md
+++ b/test/manual/announce-e2e/README.md
@@ -1,0 +1,344 @@
+# Announce E2E Gate (Track D)
+
+Five drivers that prove the fork-PR announce lane works end to end against the
+**real** `ocx-sh/index` — not a sandbox. They are run by hand against live
+infrastructure and verified by checklist; nothing here is pytest-collected. The
+two surfaces that do run unattended are the pure logic in
+`test/src/announce_e2e/` (`cd test && uv run pytest
+tests/test_announce_e2e_evidence.py`) and the (g2) gate's own decision logic
+(`./scripts/selfcheck_g2.sh` — no network, no credentials).
+
+Each run leaves per-scenario evidence under `results/` (gitignored — real pull
+request URLs and live timestamps are scratch). The curated rollup lives in
+`.claude/artifacts/e2e_results_announce.md`.
+
+## Prerequisites
+
+**Tools.** `gh` authenticated (`gh auth status`) with a classic PAT scoped
+`public_repo`; Docker running; `uv` on `PATH`; an `ocx` binary carrying
+`package announce` (a dev-channel build — set `OCX_BIN` to point at it, or put
+it on `PATH`).
+
+**A claimed namespace.** Announce refuses an unclaimed namespace and never
+creates a root itself (ruling R3). Before the first run, open a
+claim-a-namespace pull request against `ocx-sh/index` committing
+`p/<ns>/<pkg>.json` with your numeric `github_id` in `owners[]`, and get it
+merged through the human lane (G-04). `run_sequence.sh` checks for this and
+waits rather than failing — see "this step waits on you" below.
+
+**Environment.** No script carries a default namespace or package: announcing
+into the real index under a wrong default is not recoverable.
+
+| Variable | Meaning |
+|---|---|
+| `GH_REPO_PUBLISHER` | `michael-herwig/ocx-e2e-publisher` |
+| `GH_REPO_INDEX` | `ocx-sh/index` |
+| `INDEX_FORK` | the fork announce opens its pull request from, `<owner>/index` |
+| `E2E_NAMESPACE` / `E2E_PACKAGE` | the claimed pilot package |
+| `BOT_ACTOR_IDS` | comma-separated **numeric** actor ids of the index bot |
+| `PUBLISHER_WORKTREE` | optional; a publisher checkout to push tags from |
+| `OCX_ANNOUNCE_TOKEN` | see below — needed only by the two local-announce drivers |
+| `POLL_DEADLINE_SECONDS` | optional, default 600 |
+| `CLAIM_DEADLINE_SECONDS` | optional, default 3600 |
+| `OCX_BINARY` | optional; the ocx staged into the clean-machine image, default `target/release/ocx` |
+| `E2E_INDEX_PREFIX` | optional; the identifier prefix the clean-machine config keys on, default `ocx.sh` |
+
+`BOT_ACTOR_IDS` is numeric on purpose. A login is renameable and recyclable, so
+proving "no human clicked" from a login string would reintroduce exactly the
+threat the index bot is hardened against (Key Decision D-3, register X7). Read
+the ids off the claimed root's `owners[].github_id`, or
+`gh api users/<bot-login> --jq .id`.
+
+**Where the announce credential lives.** `OCX_ANNOUNCE_TOKEN` is a repo secret
+on `michael-herwig/ocx-e2e-publisher`; it is **not** on this machine. That
+splits the drivers in two:
+
+- `run_sequence.sh` and `run_machine_lane.sh` push a tag and then *observe*.
+  The announce runs inside the publisher's CI, which holds the secret. They
+  need no local token.
+- `run_idempotency.sh` and `run_update_union.sh` run `ocx package announce`
+  locally, so they need `OCX_ANNOUNCE_TOKEN` exported in your shell. Use **your
+  own** classic PAT scoped `public_repo` — Track D does not need the shared
+  `ocx-bot` PAT (that is Track E's). Without it they exit immediately with a
+  pointer back here; they never run half a scenario.
+
+Every captured artifact — announce reports, evidence records, the clean-machine
+container log — goes through `redact_secrets` before it touches disk, and
+`EvidenceRecord` refuses free text that has not been redacted, so a token
+cannot reach the committed results artifact.
+
+The secret reaches the evidence module by variable **name**
+(`--secrets-env OCX_ANNOUNCE_TOKEN`), never by value. A value on argv is
+readable from `/proc/<pid>/cmdline` by any local process for the life of the
+call — the same leak the ocx CLI refuses for `--password`. An invocation with
+no credential in scope passes `--no-secrets`, so an unredacted artifact is
+always a stated choice rather than an empty string nobody noticed.
+
+**Cost.** Every rehearsal spends real GitHub API budget and real CI minutes on
+two repositories, and leaves real pull requests behind. Run them deliberately;
+do not loop them.
+
+## Before each run — the tag budget and the branch trap
+
+**Each run needs a fresh tag.** `push_publisher_tag` in `scripts/run_sequence.sh`
+hard-fails on a tag that already exists rather than silently re-pointing one.
+`1.0.1` and `1.0.2` are consumed. The budget for the OCI-index alignment:
+
+| Tag | Purpose | Pull request disposition |
+|---|---|---|
+| `1.0.3` | E1-pre — the live failing-first run against the **pre-change** stack, up to phase (f) | **close unmerged** |
+| `1.0.4` | E1 / E2a — the post-change proof, the full `run_sequence.sh` | merge |
+| `1.0.5` | machine-lane proof — `run_machine_lane.sh` needs a tag distinct from the sequenced run | auto-merge (that *is* the proof) |
+
+`1.0.3` must not be merged: merging would write an old-format CAS object into
+`main`, which is the thing the change exists to remove. If E1-pre is skipped,
+shift the other two down one.
+
+**The `1.0.3` run never reaches (g2), and that is not a defect.** (g2) runs
+after (f), which needs the merge and the render-deploy; a pull request that by
+design will never merge leaves the driver blocked in `poll_merge` until the
+deadline. So (g2) will not have been observed red before the `1.0.4` run —
+capture the E1-pre 404 by hand instead, off the unmerged pull request's own
+root, using the gate's own taxonomy rather than a hand-rolled `curl`:
+
+```sh
+bash -c 'source ./scripts/run_sequence.sh   # sourcing never pushes a tag
+    assert_bytes_identical "$(gh api \
+        "repos/$INDEX_FORK/contents/p/$E2E_NAMESPACE/$E2E_PACKAGE.json?ref=$ANNOUNCE_BRANCH" \
+        --header "Accept: application/vnd.github.raw")"'
+```
+
+Against the pre-change stack that exits with the row 1 message. **That output is
+the reproduction** — paste it into the evidence artifact, then close the pull
+request.
+
+**The branch trap — check this before `1.0.4` and before `1.0.5`.** The announce
+branch is **per-package, not per-tag** (`ANNOUNCE_BRANCH` in `scripts/env.sh`
+is `indexbot-announce-<ns>-<pkg>`). A fresh tag therefore reuses the same branch
+and lands on the **same open pull request** if one is still open — and the run
+then measures that older pull request's timeline, not this run's. Confirm no
+announce pull request is open for the package first:
+
+```sh
+gh pr list --repo ocx-sh/index --state open \
+    --json number,headRefName --jq '.[] | select(.headRefName | startswith("indexbot-announce-"))'
+```
+
+Empty output, or nothing naming your package, means the run measures itself.
+
+## Sequenced Scenario
+
+`./scripts/run_sequence.sh <tag>` — design-spec §7's exit gate, in order.
+
+Proves: tag release → build → dev-ocx push + announce → fork PR on the real
+index → `validate.yml` green → lane classification → merge → rendered
+`index.ocx.sh` serves the root → `ocx package install` resolves from a clean
+machine.
+
+Phases, each printing a numbered banner:
+
+- **(a0)** the namespace is claimed. If it is not, the script prints what to
+  open and polls for up to `CLAIM_DEADLINE_SECONDS`. **This step waits on
+  you** — a paused driver here is the design, not an error state.
+- **(a)** tags `origin/main` in the publisher checkout and pushes the tag.
+- **(b)** waits for the publisher's build + push + announce run to conclude.
+- **(c)** waits for the pull request on `indexbot-announce-<ns>-<pkg>`. This is
+  a *tag refresh* against an already-claimed namespace, not a first claim.
+- **(d)** waits for every check on that pull request to settle, then requires
+  them all green.
+- **(e)** prints the governance checklist. The lane outcome is read off live
+  state: a tag refresh auto-merges via G-19 when your `github_id` is already in
+  the root's `owners[]`, and routes to the human lane otherwise. Both are
+  legitimate outcomes here.
+- **(f)** waits for the merge, then for render-deploy at the merge commit.
+- **(g)** `curl`s `/p/<ns>/<pkg>.json` and `/c/index.json`, requiring the root
+  to name **this run's tag** — asserting on a `sha256:` digest instead would
+  pass against a root an earlier rehearsal populated, so a no-op render would
+  still report a served render.
+- **(g2)** the acceptance gate — see below.
+- **(h)** calls `clean_install_check.sh`.
+
+Writes `EvidenceRecord(scenario="sequenced")` with the pull request URL, three
+run URLs, tag-push-to-merge latency, and what (g2) proved: the number of
+tag→object bindings it checked **and** the number of distinct `o/` objects
+those bindings cover. Under `--cascade` the first is several times the second,
+and only the second says how much of `o/` was actually read.
+
+### (g2) The committed objects are the registry's own bytes
+
+The claim under test, as a falsifiable assertion:
+
+> The index committed a digest **no registry can serve**, so the
+> platform→digest mapping was an assertion, not a copy.
+
+Before this change `tags[].content` was `sha256(serialize_observation(...))` —
+a digest the announcer minted, not one that exists on any registry. So
+`GET /v2/<physical-repo>/manifests/sha256:<content-hex>` returns **404
+`MANIFEST_UNKNOWN`**, and that 404 is the reproduction. After it, the same GET
+returns 200 and its body is byte-identical to the committed
+`o/sha256/<hex>.json`. This is the ADR's Validation bullet 2, executed.
+
+**E1 — for every tag in the served root, not only this run's.** `--cascade`
+aliases `1.0.4` / `1.0` / `1` / `latest` onto one image index, so a per-tag
+divergence is exactly what a single-tag check would let through. Per tag:
+
+1. the committed CAS object hashes to its own filename;
+2. the registry serves it **by digest**;
+3. the response's `Docker-Content-Digest` **equals the requested digest**;
+4. `cmp` against the committed object is byte-identical.
+
+Step 3 is not redundant with step 4. It is what separates a content-negotiating
+registry — which answered a question nobody asked — from a registry whose bytes
+disagree with the digest it just advertised. Each outcome exits with its own
+message; the taxonomy is in [PLAYBOOKS.md](./PLAYBOOKS.md) "Registry Byte
+Identity".
+
+The registry is read from the root's own `repository` field, never assumed from
+`<ns>/<pkg>`: the ADR names that field as the thing to check against, and the
+physical path is a convention a publisher is free not to follow. That field is
+publisher-controlled, so its host and path are validated before either reaches
+a URL — the same boundary treatment `tags[].content` gets. A root naming a host
+nobody constrained could otherwise serve the committed bytes straight back and
+turn the gate green.
+
+**E2a — reserved tags never reach the index.** The served root's `tags` carry
+no key matching `__ocx*` (case-insensitive) or `sha256.<64hex>` (D7). Free,
+because the pilot repository genuinely carries both classes:
+`push_canonical_tag` is default-on, and the publisher's `Describe package` step
+writes `__ocx.desc`.
+
+**What E2a does not prove.** The publisher announces via `--announce-file`,
+which under D7 never carries a canonical tag — so a clean root is consistent
+with **no filter at all**. E2a is a cheap regression tripwire. E2b (the index
+repo's reconcile sweep) and the local acceptance cases are the proof that the
+filter fired. Do not read a green E2a as more than it is.
+
+**No new tools.** `curl`, `python3`, `sha256sum`, `cmp`, `mktemp` — `python3`
+is already a hard prerequisite. Deliberately not `jq`: it is not in `ocx.toml`'s
+toolchain list, and nothing here transforms JSON, it only reads fields.
+
+**The gate's own logic has a test.** `./scripts/selfcheck_g2.sh` sources
+`run_sequence.sh` (the guard at its foot keeps sourcing from pushing a tag) and
+drives every (g2) verdict against fixture roots and a stubbed `curl`: each
+taxonomy row, both pre-network anchors, the boundary guards on `tags[].content`
+and `repository`, the parse and vacuity refusals, and the binding-vs-object
+counting. No network, no credentials, no live state — run it after any edit to
+(g2). It does **not** test TLS, real registry auth, or whether the announce path
+writes a registry digest at all; the `1.0.4` run is the only thing that can
+prove that.
+
+## Idempotency Proof
+
+`./scripts/run_idempotency.sh` — requirement (2), design register C6.
+
+Re-announces the identical inputs (`--refresh`: re-observe every
+already-committed tag) and asserts all three of: the report says
+`status: "unchanged"`, the pull request count did not move, and the announce
+branch head did not move. Any one failing exits 1 with the diff printed — an
+`"updated"` here means the C6 contract broke, which is a Track A escalation,
+not something to retry.
+
+Needs `OCX_ANNOUNCE_TOKEN`.
+
+## Machine-Lane Proof
+
+`./scripts/run_machine_lane.sh <tag>` — requirement (3), G-19.
+
+Push a tag **distinct** from the sequenced scenario's, so this is independent
+evidence rather than a re-read of the same pull request. The script waits for
+auto-merge, then classifies the lane from the merged pull request's reviews and
+issue events by **numeric actor id**, and fails if `lane != "machine"` or any
+human click is detected. A human acting on the pull request falsifies the proof
+this driver exists to make; it does not "pass anyway".
+
+Records both latency legs: tag-push → merge, and tag-push → served by
+`index.ocx.sh`.
+
+Needs no local token — the publisher's CI announces.
+
+## Update-Union Proof
+
+`./scripts/run_update_union.sh <tag-a> <tag-b>` — requirement (4), design
+register C4.
+
+Both tags must already exist on the registry; announce observes tags, it does
+not create them. Runs announce twice with the first pull request deliberately
+left unmerged (the script refuses to continue if someone merged it mid-run),
+then asserts the second announce **updated** the same pull request rather than
+opening a second one, and that its committed tag set is a superset of both
+runs' tags.
+
+Both runs use `--tags-file`, which adds to the committed curated set. `--tags`
+*replaces* it, so run #2 would drop tag-a and the scenario would prove nothing.
+
+Needs `OCX_ANNOUNCE_TOKEN`.
+
+## Clean-Install Proof
+
+`./scripts/clean_install_check.sh` — the last phase of the sequenced scenario,
+also runnable alone.
+
+Builds `docker/clean-machine.Dockerfile` (Debian trixie-slim, CA roots and
+nothing else) with `$OCX_BINARY` staged into the build context, and runs
+`ocx --format json package install <ns>/<pkg>` inside it. On failure the script
+dumps the container's `config.toml`; the per-run image and staged context are
+removed on exit.
+
+Two things about this image are load-bearing and easy to get wrong:
+
+**It stages a binary rather than downloading a release.** Index-kind resolution
+is not in a release yet: ocx 0.4.3 rejects the config below with
+`unknown field 'index', expected 'url'`, and `ocx self setup` would pull that
+same released copy over anything staged. Point `OCX_BINARY` at a
+dev-channel-equivalent build (`target/release/ocx` by default) — **not**
+`test/bin/ocx`, whose `__testing` feature unlocks internal seams and would stop
+the proof from reflecting a real user's machine (Key Decision D-7). A plain
+`--release` build is a real user's artifact; that is what D-7 rules out
+`__testing` in favour of. Base image is trixie because a locally- or CI-built
+binary links against the builder's glibc, which bookworm's 2.36 cannot load.
+
+**The config keys on the registry prefix, not the namespace.** The image
+writes:
+
+```toml
+[registries."ocx.sh"]
+index = "https://index.ocx.sh"
+```
+
+`ocx.sh` is not index-kind by default yet (register §6), so this says so
+explicitly. Override the key with `E2E_INDEX_PREFIX` if the pilot package resolves
+under a different registry. Keying it on `<ns>` instead parses fine and then
+never matches — a `[registries]` key is compared against the registry component
+of the resolved identifier, and `<ns>/<pkg>` resolves to `ocx.sh/<ns>/<pkg>`.
+The failure is silent: ocx falls back to plain-OCI against `ocx.sh/v2/`, which
+reads like "the index did not serve the root".
+
+## Evidence Artifact
+
+Each driver writes one `results/<run-id>-<scenario>.record.json` through
+`evidence record`, which redacts on the way in. Roll them up with:
+
+```sh
+cd test && PYTHONPATH=src uv run python -m announce_e2e.evidence render \
+    --records-dir manual/announce-e2e/results
+```
+
+That prints the same table as `.claude/artifacts/e2e_results_announce.md`, with
+a `MISSING` row for every scenario no record covers — an incomplete evidence
+set stays visibly incomplete. Paste the output into that artifact and commit it
+as part of closing G-D; Track E's handover and Track F's doc-accuracy check
+both read it.
+
+`results/*.json` is gitignored. The rollup is the durable record.
+
+## Cleaning up a rehearsal
+
+A rehearsal leaves real state behind, and `git revert` undoes none of it.
+
+```sh
+gh pr close <n> --repo ocx-sh/index --delete-branch     # unwanted pull request
+git tag -d <tag> && git push origin :refs/tags/<tag>    # retract a rehearsal tag
+```
+
+The tag lives in a Track C repository — coordinate before deleting anything
+that repository's own CI may depend on.

--- a/test/manual/announce-e2e/docker/clean-machine.Dockerfile
+++ b/test/manual/announce-e2e/docker/clean-machine.Dockerfile
@@ -1,0 +1,51 @@
+# Clean-machine proof for the Track D announce E2E gate: a host that has never
+# seen ocx resolves `<ns>/<pkg>` from the rendered index.ocx.sh.
+#
+# Deliberately NOT `test/docker/*.Dockerfile`'s `__testing` binary — that build
+# unlocks internal seams for this repo's acceptance suite, so using it here
+# would stop proving what a real user's machine does (Key Decision D-7).
+#
+# The binary is staged into the build context by `clean_install_check.sh`
+# rather than downloaded from a GitHub release, because index-kind resolution
+# is not in a release yet: ocx 0.4.3 rejects the config this image writes with
+# `unknown field 'index', expected 'url'`, and `ocx self setup` would pull that
+# same released copy over the staged one. A plain `--release` build is still a
+# real user's artifact — the `__testing` prohibition is what D-7 is about.
+# trixie, not bookworm: a locally- or CI-built ocx links against the builder's
+# glibc (2.39 on a current runner), and bookworm's 2.36 cannot load it.
+# Released artifacts are built for older glibc and would run on either.
+FROM debian:trixie-slim
+
+ARG E2E_NAMESPACE
+ARG E2E_PACKAGE
+ARG INDEX_SITE=https://index.ocx.sh
+# The identifier prefix `<ns>/<pkg>` resolves under, which is what a
+# `[registries]` key matches — see the config note below.
+ARG E2E_INDEX_PREFIX=ocx.sh
+
+# TLS roots for index.ocx.sh and the registry it points at. Nothing else: a
+# clean machine is the point.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ocx /usr/local/bin/ocx
+
+# Resolve through the ocx-index protocol. `ocx.sh` is not index-kind by
+# default yet (register §6), so this says so explicitly.
+#
+# The key is the IDENTIFIER PREFIX (`ocx.sh`), not the namespace: a
+# `[registries]` key is matched against the registry component of the resolved
+# identifier, and `<ns>/<pkg>` resolves to `ocx.sh/<ns>/<pkg>`. Keying it on
+# `<ns>` parses fine and then never matches — zero index sources get built and
+# ocx falls back to plain-OCI against `ocx.sh/v2/` with no error, which reads
+# as "the index did not serve". Field name/shape per
+# website/src/docs/reference/configuration.md § [registries.<name>] / index.
+RUN mkdir -p /root/.ocx \
+    && printf '[registries."%s"]\nindex = "%s"\n' "$E2E_INDEX_PREFIX" "$INDEX_SITE" \
+    > /root/.ocx/config.toml
+
+ENV E2E_NAMESPACE=${E2E_NAMESPACE} E2E_PACKAGE=${E2E_PACKAGE}
+
+# `--format` is a root flag; `install` lives under the `package` group.
+ENTRYPOINT ["sh", "-c", "ocx --format json package install \"$E2E_NAMESPACE/$E2E_PACKAGE\""]

--- a/test/manual/announce-e2e/scripts/clean_install_check.sh
+++ b/test/manual/announce-e2e/scripts/clean_install_check.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Clean-machine proof: build docker/clean-machine.Dockerfile and resolve
+# `ocx package install <ns>/<pkg>` inside it, against the rendered index.ocx.sh,
+# with the namespace configured index-kind. Uses a release-shaped ocx binary —
+# never test/bin/ocx, whose __testing feature unlocks internal seams
+# (Key Decision D-7).
+#
+# Usage: clean_install_check.sh
+#
+# Stages the ocx binary into the build context from OCX_BINARY (default
+# target/release/ocx). It must be a dev-channel-equivalent build: index-kind
+# resolution is not released yet, and ocx 0.4.3 rejects this image's config
+# with `unknown field 'index', expected 'url'`.
+#
+# Consumes from env.sh: E2E_NAMESPACE, E2E_PACKAGE.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck source=./env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
+
+IMAGE_TAG="ocx-announce-e2e-clean:$RUN_ID"
+LOG_FILE="$RESULTS_DIR/${RUN_ID}-clean_install.log"
+OCX_BINARY="${OCX_BINARY:-$E2E_REPO_ROOT/target/release/ocx}"
+BUILD_CONTEXT="$(mktemp -d)"
+
+# The image and the staged context are per-run scratch; leaving them behind
+# would accumulate one layer stack and one 40MB binary copy per rehearsal.
+cleanup() {
+    rm -rf "$BUILD_CONTEXT"
+    docker image rm -f "$IMAGE_TAG" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+main() {
+    local secret_args=()
+    local build_args=(
+        --build-arg "E2E_NAMESPACE=$E2E_NAMESPACE"
+        --build-arg "E2E_PACKAGE=$E2E_PACKAGE"
+        --build-arg "INDEX_SITE=$INDEX_SITE"
+        --build-arg "E2E_INDEX_PREFIX=$E2E_INDEX_PREFIX"
+    )
+    mapfile -t secret_args < <(evidence_secret_args)
+
+    [[ -x $OCX_BINARY ]] ||
+        ocx_fail "no ocx binary at $OCX_BINARY — build one (cargo build --release -p ocx) or set OCX_BINARY"
+    install -m 0755 "$OCX_BINARY" "$BUILD_CONTEXT/ocx"
+    cp "$E2E_SCRIPT_DIR/../docker/clean-machine.Dockerfile" "$BUILD_CONTEXT/"
+
+    ocx_step "building $IMAGE_TAG from $OCX_BINARY ($("$OCX_BINARY" version))"
+    docker build "${build_args[@]}" \
+        -f "$BUILD_CONTEXT/clean-machine.Dockerfile" \
+        -t "$IMAGE_TAG" "$BUILD_CONTEXT"
+
+    # The container log lands in a committed-adjacent directory, so it goes
+    # through the same redaction every other captured artifact does — a
+    # registry auth error can echo a credential back.
+    ocx_step "resolving $E2E_NAMESPACE/$E2E_PACKAGE on a machine that has never seen ocx"
+    if ! docker run --rm "$IMAGE_TAG" 2>&1 |
+        evidence redact "${secret_args[@]}" | tee "$LOG_FILE"; then
+        ocx_warn "container config dump follows for debugging:"
+        docker run --rm --entrypoint sh "$IMAGE_TAG" -c 'cat ~/.ocx/config.toml' >&2 || true
+        ocx_fail "clean-machine install failed; full log at $LOG_FILE"
+    fi
+
+    grep -q "$E2E_PACKAGE" "$LOG_FILE" ||
+        ocx_fail "install output never named $E2E_PACKAGE; full log at $LOG_FILE"
+
+    evidence record --scenario clean_install --status pass \
+        --notes "resolved $E2E_NAMESPACE/$E2E_PACKAGE from $INDEX_SITE in a clean debian container" \
+        "${secret_args[@]}" \
+        --out "$RESULTS_DIR/${RUN_ID}-clean_install.record.json"
+
+    ocx_done "clean-machine install resolved $E2E_NAMESPACE/$E2E_PACKAGE"
+}
+
+main "$@"

--- a/test/manual/announce-e2e/scripts/env.sh
+++ b/test/manual/announce-e2e/scripts/env.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# Shared configuration and helpers for the Track D announce E2E drivers.
+# Sourced (never executed) by run_sequence.sh, run_idempotency.sh,
+# run_update_union.sh, run_machine_lane.sh, clean_install_check.sh.
+#
+# Required environment (no defaults — the pilot namespace/package is Track C's
+# choice, made at execution time, and a wrong default would announce into the
+# real index):
+#   GH_REPO_PUBLISHER   michael-herwig/ocx-e2e-publisher
+#   GH_REPO_INDEX       ocx-sh/index
+#   INDEX_FORK          <owner>/index — the fork announce opens its PR from
+#   E2E_NAMESPACE       claimed pilot namespace
+#   E2E_PACKAGE         package inside that namespace
+#   BOT_ACTOR_IDS       comma-separated numeric GitHub actor ids of the index
+#                       bot — never logins (Key Decision D-3)
+#
+# OCX_ANNOUNCE_TOKEN is required only by announce_capture(), which guards it
+# itself: the polling-only drivers authenticate through `gh` and must stay
+# runnable on a machine that carries no announce credential at all. See
+# README.md "Prerequisites".
+
+# shellcheck shell=bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+: "${GH_REPO_PUBLISHER:?set GH_REPO_PUBLISHER before running}"
+: "${GH_REPO_INDEX:?set GH_REPO_INDEX before running}"
+: "${INDEX_FORK:?set INDEX_FORK before running}"
+: "${E2E_NAMESPACE:?set E2E_NAMESPACE before running}"
+: "${E2E_PACKAGE:?set E2E_PACKAGE before running}"
+: "${BOT_ACTOR_IDS:?set BOT_ACTOR_IDS before running (numeric ids, comma-separated)}"
+
+E2E_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_REPO_ROOT="$(cd "$E2E_SCRIPT_DIR/../../../.." && pwd)"
+RESULTS_DIR="${RESULTS_DIR:-$E2E_SCRIPT_DIR/../results}"
+RUN_ID="${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
+ANNOUNCE_BRANCH="indexbot-announce-${E2E_NAMESPACE}-${E2E_PACKAGE}"
+INDEX_SITE="${INDEX_SITE:-https://index.ocx.sh}"
+
+# The identifier prefix a `[registries]` key matches. NOT the namespace:
+# `<ns>/<pkg>` resolves to `<prefix>/<ns>/<pkg>`, and both Context's index-source
+# build and announce's own lookup key on the identifier's registry component.
+# Keying config on `<ns>` parses fine, matches nothing, and silently degrades to
+# plain-OCI resolution.
+E2E_INDEX_PREFIX="${E2E_INDEX_PREFIX:-ocx.sh}"
+
+# The single workflow-run observation poll_run polls on: "<conclusion>|<url>".
+# The separator is a pipe, not a tab, because `read` collapses runs of IFS
+# whitespace: on a tab-separated record an absent conclusion would shift the
+# URL into the conclusion's slot. No conclusion or run URL contains a pipe.
+# Assigned by _run_concluded, read by poll_run — see both below.
+E2E_RUN_RECORD=""
+
+# Secrets reach the evidence module by env var NAME, never by value — a value
+# on argv is readable from /proc/<pid>/cmdline for the life of the call.
+# Callers with no credential in scope pass EVIDENCE_NO_SECRETS instead.
+EVIDENCE_SECRETS=(--secrets-env OCX_ANNOUNCE_TOKEN)
+EVIDENCE_NO_SECRETS=(--no-secrets)
+
+# Which of the two above a driver should use, decided once: redact when a token
+# is actually in scope, state "nothing to redact" when it is not.
+evidence_secret_args() {
+    if [[ -n ${OCX_ANNOUNCE_TOKEN:-} ]]; then
+        printf '%s\n' "${EVIDENCE_SECRETS[@]}"
+    else
+        printf '%s\n' "${EVIDENCE_NO_SECRETS[@]}"
+    fi
+}
+
+# Colors, the `ocx` echo-wrapper, ocx_step / ocx_warn / ocx_done / ocx_fail.
+# shellcheck source=../../scripts/_lib.sh
+source "$E2E_SCRIPT_DIR/../../scripts/_lib.sh"
+
+mkdir -p "$RESULTS_DIR"
+
+# Poll deadlines, seconds. Ten minutes is the ceiling for anything a machine
+# drives; the namespace claim waits on a human review click, so it gets an
+# hour. ponytail: two constants, not a per-call policy object — raise them
+# through the environment if a run needs longer.
+POLL_DEADLINE_SECONDS="${POLL_DEADLINE_SECONDS:-600}"
+CLAIM_DEADLINE_SECONDS="${CLAIM_DEADLINE_SECONDS:-3600}"
+
+# Run the pure-logic evidence module. PYTHONPATH points at test/src so the
+# module imports without dragging src/__init__.py's registry helpers in.
+evidence() {
+    (cd "$E2E_REPO_ROOT/test" && PYTHONPATH=src uv run python -m announce_e2e.evidence "$@")
+}
+
+# Retry a command until it succeeds or the deadline passes. Backoff 2s,
+# doubling, capped at 30s. Args: <deadline-seconds> <description> <command...>
+poll_until() {
+    local deadline="$1" what="$2"
+    shift 2
+    local delay=2 elapsed=0
+    while true; do
+        if "$@"; then
+            return 0
+        fi
+        if ((elapsed >= deadline)); then
+            ocx_warn "gave up waiting for $what after ${elapsed}s"
+            return 1
+        fi
+        sleep "$delay"
+        elapsed=$((elapsed + delay))
+        delay=$((delay * 2))
+        ((delay > 30)) && delay=30
+        true # keep the arithmetic test above from tripping `set -e`
+    done
+}
+
+# Run an announce and capture its report, redacted, under results/.
+# Args: <step-label> <announce args...>. Echoes the captured path.
+#
+# `--format` is a ROOT flag on ocx, never a subcommand flag.
+announce_capture() {
+    : "${OCX_ANNOUNCE_TOKEN:?announce needs OCX_ANNOUNCE_TOKEN — see README.md Prerequisites}"
+    local step="$1"
+    shift
+    local out="$RESULTS_DIR/${RUN_ID}-${step}.json"
+    # pipefail carries an announce failure through the redaction filter, so a
+    # failed run never leaves an empty-but-successful capture behind.
+    ocx --format json package announce "$@" |
+        evidence redact "${EVIDENCE_SECRETS[@]}" >"$out"
+    printf '%s\n' "$out"
+}
+
+# The publisher checkout tags are pushed from. Track C may already have one
+# under .agents/worktrees/ — reuse it rather than creating a second checkout of
+# a foreign repo (plan Risks). Its worktree may carry a `-<slug>` suffix, hence
+# the glob rather than a fixed path.
+publisher_checkout() {
+    local candidate
+    if [[ -n ${PUBLISHER_WORKTREE:-} ]]; then
+        printf '%s\n' "$PUBLISHER_WORKTREE"
+        return 0
+    fi
+    for candidate in "$E2E_REPO_ROOT/.agents/worktrees/ocx-e2e-publisher"*; do
+        if [[ -e $candidate/.git ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    ocx_fail "no publisher checkout found — set PUBLISHER_WORKTREE to a clone of $GH_REPO_PUBLISHER"
+}
+
+# Echo the number of the pull request whose head is the announce branch on the
+# fork, or return 1. Matches head repository owner as well as branch name — a
+# same-named branch on another fork is a different pull request.
+pr_number() {
+    local number
+    number="$(gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
+        --json number,headRefName,headRepositoryOwner \
+        --jq "[.[] | select(.headRefName == \"$ANNOUNCE_BRANCH\" and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\")] | first | .number // empty")"
+    [[ -n $number ]] || return 1
+    printf '%s\n' "$number"
+}
+
+# Wait for the announce branch's pull request to exist. Echoes its number.
+poll_pr() {
+    poll_until "$POLL_DEADLINE_SECONDS" "a pull request on $ANNOUNCE_BRANCH" \
+        pr_number >/dev/null
+    pr_number
+}
+
+# Wait for every check on a pull request to settle, then require them all
+# green. Args: <pr-number>.
+poll_check() {
+    local pr="$1" pending
+    poll_until "$POLL_DEADLINE_SECONDS" "checks on PR #$pr" _checks_settled "$pr" || return 1
+    pending="$(gh pr checks "$pr" --repo "$GH_REPO_INDEX" --json name,state \
+        --jq '[.[] | select(.state != "SUCCESS" and .state != "SKIPPED") | .name] | join(", ")')"
+    if [[ -n $pending ]]; then
+        ocx_warn "PR #$pr checks not green: $pending"
+        return 1
+    fi
+}
+
+_checks_settled() {
+    # grep exits 1 when no check is still PENDING — that is the success case.
+    ! gh pr checks "$1" --repo "$GH_REPO_INDEX" --json state --jq '.[].state' |
+        grep -qx 'PENDING'
+}
+
+# Wait for one workflow run to conclude. Args: <repo> <workflow> <ref> <sha>.
+# Echoes the run URL, and only on success; returns 1 otherwise.
+#
+# <workflow> and <ref> are part of a run's identity because a commit sha alone
+# is not: a tag push and a branch push at one sha are two runs, and a merge on
+# the index's main is one run per workflow. <ref> is the run's headBranch,
+# which for a tag push is the tag name. Every field comes from one observation,
+# because two `gh` calls can select different runs.
+poll_run() {
+    local repo="$1" workflow="$2" ref="$3" sha="$4" conclusion url
+    E2E_RUN_RECORD=""
+    poll_until "$POLL_DEADLINE_SECONDS" "$workflow to conclude at ${sha:0:7} ($ref) in $repo" \
+        _run_concluded "$repo" "$workflow" "$ref" "$sha" || return 1
+    IFS='|' read -r conclusion url <<<"$E2E_RUN_RECORD"
+    if [[ $conclusion != "success" ]]; then
+        ocx_warn "$workflow at ${sha:0:7} ($ref) in $repo concluded $conclusion — $url"
+        return 1
+    fi
+    printf '%s\n' "$url"
+}
+
+# Assigns E2E_RUN_RECORD in the caller's shell: poll_until invokes probes as
+# `"$@"` in the current shell, so only the `gh` call is a subshell.
+#
+# The gate is a non-empty conclusion — the field poll_run judges on — not a
+# `completed` status: a run is briefly `completed` with a null conclusion, and
+# polling through that window is what keeps the read unambiguous. `first // {}`
+# keeps the not-started case (no run matches) a valid empty record rather than
+# a jq error; it, the in-progress case, and a failed `gh` all leave the
+# conclusion empty and are all polled on.
+_run_concluded() {
+    E2E_RUN_RECORD="$(gh run list --repo "$1" --workflow "$2" --branch "$3" --limit 50 \
+        --json headSha,conclusion,url \
+        --jq "[.[] | select(.headSha == \"$4\")] | first // {} |
+              [.conclusion // \"\", .url // \"\"] | join(\"|\")")"
+    [[ $E2E_RUN_RECORD == ?*"|"* ]]
+}
+
+# Wait for a pull request to merge. Args: <pr-number>. Echoes
+# "<merge-commit-sha> <mergedAt>".
+poll_merge() {
+    poll_until "$POLL_DEADLINE_SECONDS" "PR #$1 to merge" _pr_merged "$1" || return 1
+    gh pr view "$1" --repo "$GH_REPO_INDEX" --json mergeCommit,mergedAt \
+        --jq '"\(.mergeCommit.oid) \(.mergedAt)"'
+}
+
+_pr_merged() {
+    [[ "$(gh pr view "$1" --repo "$GH_REPO_INDEX" --json state --jq '.state')" == "MERGED" ]]
+}
+
+# Tag names committed in the root on a ref of the fork. Args: <ref>.
+# One tag per line.
+committed_tags() {
+    gh api "repos/$INDEX_FORK/contents/p/$E2E_NAMESPACE/$E2E_PACKAGE.json?ref=$1" \
+        --header 'Accept: application/vnd.github.raw' --jq '.tags | keys[]'
+}
+
+# Merge a pull request's reviews and issue events into the single JSON array
+# `evidence classify-lane` consumes. Args: <pr-number>.
+pr_events() {
+    local objects
+    objects="$(
+        {
+            gh api "repos/$GH_REPO_INDEX/pulls/$1/reviews" --jq '.[]'
+            gh api "repos/$GH_REPO_INDEX/issues/$1/events" --jq '.[]'
+        } | paste -sd, -
+    )"
+    printf '[%s]' "$objects"
+}
+
+# Playbook 1: show the digest the floating dev tag currently resolves to, next
+# to where the published digest is recorded. Args: <reference>, e.g.
+# dev.ocx.sh/ocx/cli:0.5.0-dev.
+check_floating_tag() {
+    ocx_step "resolving $1"
+    ocx --format json package inspect "$1"
+    ocx_warn "compare that digest against the latest Deploy Dev run's published digest:"
+    printf '  gh run list --repo ocx-sh/ocx --workflow "Deploy Dev" --limit 5\n' >&2
+    ocx_warn "if they differ, the deploy failed to advance the floating tag — re-run"
+    ocx_warn "Deploy Dev. Never hand-pin a _<TS> build segment (register §7 step 5)."
+}

--- a/test/manual/announce-e2e/scripts/run_idempotency.sh
+++ b/test/manual/announce-e2e/scripts/run_idempotency.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Requirement (2): idempotency proof (C6) — an immediate re-run of the
+# identical announce reports status "unchanged", opens zero pull requests and
+# adds zero commits to the announce branch.
+#
+# Usage: run_idempotency.sh [extra announce args...]
+#
+# Runs announce locally with `--refresh` — "re-observe every already-committed
+# tag" is exactly the identical-inputs re-run C6 is about. Needs
+# OCX_ANNOUNCE_TOKEN in the environment; see README.md "Prerequisites".
+#
+# Consumes from env.sh: GH_REPO_INDEX, INDEX_FORK, E2E_NAMESPACE, E2E_PACKAGE.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck source=./env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
+
+# Pull request count on the announce branch: 0 or 1 by construction, but a
+# second PR is precisely the C4/C6 failure this counts.
+pr_count() {
+    gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
+        --json headRefName,headRepositoryOwner \
+        --jq "[.[] | select(.headRefName == \"$ANNOUNCE_BRANCH\" and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\")] | length"
+}
+
+# Head commit of the announce branch on the fork, or "absent".
+branch_head() {
+    gh api "repos/$INDEX_FORK/git/ref/heads/$ANNOUNCE_BRANCH" --jq '.object.sha' 2>/dev/null ||
+        printf 'absent\n'
+}
+
+main() {
+    local prs_before head_before capture status prs_after head_after failures=()
+
+    prs_before="$(pr_count)"
+    head_before="$(branch_head)"
+    ocx_step "before: $prs_before pull request(s), branch head ${head_before:0:7}"
+
+    ocx_step "re-announcing $E2E_NAMESPACE/$E2E_PACKAGE with identical inputs"
+    capture="$(announce_capture idempotency \
+        --package "$E2E_NAMESPACE/$E2E_PACKAGE" \
+        --refresh \
+        --fork "$INDEX_FORK" \
+        --index-repo "$GH_REPO_INDEX" \
+        "$@")"
+
+    status="$(evidence classify-report --file "$capture")"
+    prs_after="$(pr_count)"
+    head_after="$(branch_head)"
+
+    [[ $status == "unchanged" ]] ||
+        failures+=("status is \"$status\", not \"unchanged\" — the C6 contract broke, escalate to Track A")
+    [[ $prs_after == "$prs_before" ]] ||
+        failures+=("pull request count moved $prs_before -> $prs_after")
+    [[ $head_after == "$head_before" ]] ||
+        failures+=("branch head moved ${head_before:0:7} -> ${head_after:0:7}")
+
+    if ((${#failures[@]} > 0)); then
+        printf 'idempotency assertion failed: %s\n' "${failures[@]}" >&2
+        evidence record --scenario idempotency --status fail \
+            --notes "${failures[*]}" \
+            "${EVIDENCE_SECRETS[@]}" \
+            --out "$RESULTS_DIR/${RUN_ID}-idempotency.record.json"
+        exit 1
+    fi
+
+    evidence record --scenario idempotency --status pass \
+        --notes "status=unchanged; $prs_before PR(s) unchanged; branch head ${head_before:0:7} unchanged" \
+        "${EVIDENCE_SECRETS[@]}" \
+        --out "$RESULTS_DIR/${RUN_ID}-idempotency.record.json"
+
+    ocx_done "idempotency proved: unchanged, zero new PRs, zero new commits"
+}
+
+main "$@"

--- a/test/manual/announce-e2e/scripts/run_machine_lane.sh
+++ b/test/manual/announce-e2e/scripts/run_machine_lane.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Requirement (3): machine-lane proof (G-19) — a new tag's announce
+# auto-merges with zero human clicks; tag-push-to-merge and tag-push-to-served
+# latency measured and recorded.
+#
+# Usage: run_machine_lane.sh <tag>
+#
+# Use a tag distinct from run_sequence.sh's, so this is independent evidence
+# rather than a re-read of the same pull request.
+#
+# Consumes from env.sh: GH_REPO_PUBLISHER, GH_REPO_INDEX, INDEX_FORK,
+# E2E_NAMESPACE, E2E_PACKAGE, BOT_ACTOR_IDS.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck source=./env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
+
+# Fail the proof, recording why. Args: <notes>.
+fail_proof() {
+    local secret_args=()
+    mapfile -t secret_args < <(evidence_secret_args)
+    evidence record --scenario machine_lane --status fail \
+        --notes "$1" \
+        "${secret_args[@]}" \
+        --out "$RESULTS_DIR/${RUN_ID}-machine_lane.record.json"
+    ocx_fail "$1"
+}
+
+# Wait until the served root names this tag — the t0 -> t_serve leg.
+_serves_tag() {
+    curl -fsS "$INDEX_SITE/p/$E2E_NAMESPACE/$E2E_PACKAGE.json" | grep -q "\"$1\""
+}
+
+main() {
+    local tag="${1:?usage: run_machine_lane.sh <tag>}"
+    local checkout sha t0 pr merge_line merged_at lane latency_merge latency_serve t_serve
+    local secret_args=()
+
+    checkout="$(publisher_checkout)"
+
+    ocx_step "pushing new tag $tag to $GH_REPO_PUBLISHER"
+    t0="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    git -C "$checkout" fetch origin
+    git -C "$checkout" tag "$tag" origin/main ||
+        ocx_fail "tag $tag already exists — pick a new one, or retract it per README 'Cleaning up a rehearsal'"
+    git -C "$checkout" push origin "refs/tags/$tag"
+    sha="$(git -C "$checkout" rev-parse "refs/tags/$tag^{commit}")"
+
+    ocx_step "waiting for the publisher's announce at ${sha:0:7}"
+    poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" >/dev/null ||
+        fail_proof "publisher CI did not conclude successfully for tag $tag"
+
+    pr="$(poll_pr)" || fail_proof "no pull request appeared on $ANNOUNCE_BRANCH for tag $tag"
+    ocx_step "waiting for PR #$pr to auto-merge — take no action, that is the proof"
+    merge_line="$(poll_merge "$pr")" ||
+        fail_proof "PR #$pr did not auto-merge within ${POLL_DEADLINE_SECONDS}s — see PLAYBOOKS.md playbook 3"
+    merged_at="${merge_line##* }"
+
+    # The lane verdict comes from numeric actor ids on the merged PR's reviews
+    # and events, never from a login string (Key Decision D-3). --require-machine
+    # turns the verdict into an exit code, so this assertion never depends on
+    # how the JSON happens to be spaced.
+    local events
+    events="$(pr_events "$pr")"
+    lane="$(printf '%s' "$events" | evidence classify-lane --bot-actor-ids "$BOT_ACTOR_IDS")"
+    ocx_step "lane classification: $lane"
+    printf '%s' "$events" |
+        evidence classify-lane --bot-actor-ids "$BOT_ACTOR_IDS" --require-machine >/dev/null ||
+        fail_proof "PR #$pr did not merge through the machine lane with zero human clicks: $lane"
+
+    ocx_step "waiting for $INDEX_SITE to serve tag $tag"
+    poll_until "$POLL_DEADLINE_SECONDS" "$INDEX_SITE to serve $tag" _serves_tag "$tag" ||
+        fail_proof "$INDEX_SITE never served tag $tag after the merge"
+    t_serve="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    latency_merge="$(evidence latency --start "$t0" --end "$merged_at")"
+    latency_serve="$(evidence latency --start "$t0" --end "$t_serve")"
+
+    mapfile -t secret_args < <(evidence_secret_args)
+    evidence record --scenario machine_lane --status pass \
+        --pr-url "$(gh pr view "$pr" --repo "$GH_REPO_INDEX" --json url --jq '.url')" \
+        --latency "$latency_merge" \
+        --notes "tag $tag; $lane; tag-push to merge ${latency_merge}s, tag-push to served ${latency_serve}s" \
+        "${secret_args[@]}" \
+        --out "$RESULTS_DIR/${RUN_ID}-machine_lane.record.json"
+
+    ocx_done "machine lane proved: PR #$pr auto-merged, zero human clicks, ${latency_merge}s to merge / ${latency_serve}s to served"
+}
+
+main "$@"

--- a/test/manual/announce-e2e/scripts/run_sequence.sh
+++ b/test/manual/announce-e2e/scripts/run_sequence.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# Requirement (1): the sequenced end-to-end scenario — claimed-namespace
+# prerequisite check, publisher tag push, CI build, dev-ocx push + announce,
+# fork PR on the real index, validate.yml green, lane classification, merge,
+# render-deploy, index.ocx.sh serves the root, the committed objects are the
+# registry's own bytes, clean-machine install.
+#
+# Usage: run_sequence.sh <tag>
+#
+# The announce itself runs inside the publisher's CI, which holds the
+# OCX_ANNOUNCE_TOKEN repo secret; this driver pushes the tag and then observes.
+#
+# Consumes from env.sh: GH_REPO_PUBLISHER, GH_REPO_INDEX, INDEX_FORK,
+# E2E_NAMESPACE, E2E_PACKAGE, BOT_ACTOR_IDS.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck source=./env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
+
+# Scratch for (g2). Both payloads go to disk so `cmp` compares bytes rather
+# than a shell-mangled string: a command substitution strips trailing newlines
+# and mangles any NUL, which is exactly the difference a format regression
+# would show up as.
+WORK_DIR="$(mktemp -d)"
+cleanup() { rm -rf -- "$WORK_DIR"; }
+trap cleanup EXIT
+
+# Both OCI manifest media types. Requesting by digest constrains the content to
+# exactly that digest whatever the Accept says; the header only decides whether
+# the registry answers at all, and a 406 from a too-narrow Accept would read as
+# a mapping defect it is not.
+MANIFEST_ACCEPT='Accept: application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json'
+
+# The physical repository (g2) checks against, and its anonymous pull token —
+# read once per run from the served root, then read per tag by
+# _assert_tag_identical. Assigned by assert_bytes_identical; see both below.
+E2E_REG_HOST=""
+E2E_REG_PATH=""
+E2E_REG_TOKEN=""
+
+# What (g2) proved, for the evidence notes. --cascade aliases several tags onto
+# one image index, so the two numbers differ and only the second says how much
+# of `o/` was actually read — a binding count reported as an object count
+# overstates the gate's reach by exactly the cascade factor.
+E2E_BINDINGS_VERIFIED=0
+E2E_OBJECTS_VERIFIED=0
+
+# (a0) Ruling R3: announce refuses an unclaimed namespace and never creates a
+# root itself. The claim is a manual claim-a-namespace PR the operator opens
+# and the human lane (G-04) merges. This step waits on you; it does not fail
+# fast.
+require_claimed_namespace() {
+    ocx_step "(a0) checking that $E2E_NAMESPACE/$E2E_PACKAGE is claimed on $GH_REPO_INDEX"
+    if ! _namespace_claimed; then
+        ocx_warn "root p/$E2E_NAMESPACE/$E2E_PACKAGE.json is not on $GH_REPO_INDEX main yet."
+        ocx_warn "Open a claim-a-namespace PR committing that root with your numeric"
+        ocx_warn "github_id in owners[], and get it merged through the human lane (G-04)."
+        ocx_warn "This step waits on you — polling for up to ${CLAIM_DEADLINE_SECONDS}s."
+        poll_until "$CLAIM_DEADLINE_SECONDS" "the namespace claim to merge" _namespace_claimed ||
+            ocx_fail "namespace still unclaimed; announce would hard-error"
+    fi
+    ocx_done "(a0) namespace claimed"
+}
+
+_namespace_claimed() {
+    local owners
+    owners="$(gh api "repos/$GH_REPO_INDEX/contents/p/$E2E_NAMESPACE/$E2E_PACKAGE.json?ref=main" \
+        --header 'Accept: application/vnd.github.raw' \
+        --jq '[.owners[]?.github_id] | length' 2>/dev/null)" || return 1
+    [[ -n $owners ]] && ((owners > 0))
+}
+
+# (a) Tag and push the publisher. Echoes the tagged commit sha.
+push_publisher_tag() {
+    local tag="$1" checkout sha
+    checkout="$(publisher_checkout)"
+    ocx_step "(a) tagging $tag in $checkout and pushing to $GH_REPO_PUBLISHER" >&2
+    git -C "$checkout" fetch origin >&2
+    git -C "$checkout" tag "$tag" origin/main >&2 ||
+        ocx_fail "tag $tag already exists — pick a new one, or retract it per README 'Cleaning up a rehearsal'"
+    git -C "$checkout" push origin "refs/tags/$tag" >&2
+    sha="$(git -C "$checkout" rev-parse "refs/tags/$tag^{commit}")"
+    printf '%s\n' "$sha"
+}
+
+# (e) The lane outcome is read off live state, not assumed: a tag refresh
+# against an already-claimed namespace auto-merges via G-19 when the
+# announcer's github_id is already in the root's owners[], and routes to the
+# human lane otherwise. Both outcomes are legitimate here.
+print_governance_checklist() {
+    ocx_step "(e) governance lane — check both outcomes on PR #$1"
+    cat >&2 <<EOF
+  [ ] Open https://github.com/$GH_REPO_INDEX/pull/$1 and read the applied labels.
+  [ ] Machine lane (G-19): the PR auto-merges, no human click. Expected when the
+      announcer's numeric github_id is already in the root's owners[] AND the
+      diff stays inside the touched roots plus their own CAS objects.
+  [ ] Human lane: the PR waits for review. Expected for a first claim, an
+      owners[] change, or any diff that leaves the machine-lane path allowlist.
+  [ ] Neither matches what you expected? PLAYBOOKS.md playbook 3.
+EOF
+}
+
+# (g) Both index surfaces must serve, and the root must name THIS run's tag.
+# Grepping for `sha256:` instead would pass against a root a previous rehearsal
+# populated, so a no-op render would still report a served render.
+assert_served() {
+    local tag="$1"
+    local root="$INDEX_SITE/p/$E2E_NAMESPACE/$E2E_PACKAGE.json"
+    curl -fsS "$root" | grep -q "\"$tag\"" ||
+        ocx_fail "$root served, but does not name tag $tag — the render did not pick up this run"
+    curl -fsS "$INDEX_SITE/c/index.json" >/dev/null ||
+        ocx_fail "$INDEX_SITE/c/index.json did not serve"
+    ocx_done "(g) $INDEX_SITE serves the root carrying $tag, and the catalog"
+}
+
+# The tag names a served root commits, one per line. Never `print(*keys)`: an
+# empty tags object prints one empty line that way, and an empty line reads
+# downstream as a tag named "".
+_root_tag_names() {
+    printf '%s' "$1" |
+        python3 -c 'import json,sys; sys.stdout.writelines(t + "\n" for t in json.load(sys.stdin)["tags"])'
+}
+
+# The content digest a served root records for one tag. Args: <root-json> <tag>.
+_root_tag_content() {
+    printf '%s' "$1" |
+        python3 -c 'import json,sys; print(json.load(sys.stdin)["tags"][sys.argv[1]]["content"])' "$2"
+}
+
+# The physical repository a served root points at, as "<host> <path>". Read,
+# never assumed: the ADR's Validation bullet names the root's own `repository`
+# as the registry to check against, and `<ns>/<pkg>` is only a convention the
+# publisher is free not to follow.
+_root_repository() {
+    printf '%s' "$1" |
+        python3 -c 'import json,sys; u=json.load(sys.stdin)["repository"]; h,_,p = u.removeprefix("oci://").partition("/"); print(h, p) if u.startswith("oci://") and h and p else sys.exit("root.repository is not an oci://<host>/<path> URL: " + u)'
+}
+
+# An anonymous pull token from the registry's own token endpoint. Args:
+# <host> <repo-path>. ponytail: ghcr.io's convention, which registry:2 also
+# implements — a registry that delegates auth to a different host advertises it
+# in WWW-Authenticate, and parsing that challenge is the upgrade path if a pilot
+# package ever moves off ghcr.
+_pull_token() {
+    curl -fsS -- "https://$1/token?service=$1&scope=repository:$2:pull" |
+        python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])'
+}
+
+# The digest a registry says it served, out of a dumped header block. Args:
+# <header-file>. Header names are case-insensitive per RFC 9110 and the line
+# endings are CRLF, so neither is assumed. Empty when the header is absent,
+# which _assert_tag_identical reports rather than treating as a match.
+_content_digest_header() {
+    tr -d '\r' <"$1" | awk 'tolower($1) == "docker-content-digest:" { print $2 }'
+}
+
+# One tag's byte identity, with every outcome kept distinguishable — a
+# transport artefact must not read as a mapping defect. Args:
+# <tag> <content-digest>. Reads E2E_REG_HOST / E2E_REG_PATH / E2E_REG_TOKEN.
+_assert_tag_identical() {
+    local tag="$1" content="$2" hex="${2#sha256:}"
+    local cas="$WORK_DIR/cas" reg="$WORK_DIR/reg" hdr="$WORK_DIR/hdr" status served
+
+    curl -fsS -o "$cas" -- "$INDEX_SITE/p/$E2E_NAMESPACE/$E2E_PACKAGE/o/sha256/$hex.json" ||
+        ocx_fail "tag $tag records $content but nothing is committed at o/sha256/$hex.json — D2/D3 says every tags[].content has an object"
+
+    # Anchor 1: the committed object hashes to its own filename. A CAS that
+    # disagrees with itself makes every later comparison meaningless.
+    [[ "$(sha256sum <"$cas" | cut -d' ' -f1)" == "$hex" ]] ||
+        ocx_fail "committed o/sha256/$hex.json does not hash to its own filename"
+
+    # Anchor 2: the registry the root itself points at. Requested BY DIGEST, so
+    # Docker-Content-Digest separates a content-negotiating registry from a real
+    # mapping defect. Deliberately no -f: the HTTP status is the diagnosis.
+    status="$(curl -sS -o "$reg" -D "$hdr" -w '%{http_code}' \
+        -H "Authorization: Bearer $E2E_REG_TOKEN" \
+        -H "$MANIFEST_ACCEPT" \
+        -- "https://$E2E_REG_HOST/v2/$E2E_REG_PATH/manifests/$content")" ||
+        ocx_fail "the request for $content against $E2E_REG_HOST never completed — a transport failure, not a mapping defect"
+
+    case "$status" in
+        200) ;;
+        404)
+            ocx_fail "$E2E_REG_HOST does not serve $content for tag $tag (404) — THE BUG CLASS: the index committed a digest no registry can serve. PLAYBOOKS.md 'Registry Byte Identity', row 1"
+            ;;
+        *)
+            ocx_fail "$E2E_REG_HOST answered $status for $content — a transport or auth failure, not a mapping defect. PLAYBOOKS.md 'Registry Byte Identity', the paragraph below the taxonomy table"
+            ;;
+    esac
+
+    served="$(_content_digest_header "$hdr")"
+    [[ $served == "$content" ]] ||
+        ocx_fail "$E2E_REG_HOST served ${served:-<no Docker-Content-Digest header>} for a request for $content — the registry content-negotiated. A REGISTRY-BEHAVIOUR finding, not a format regression. PLAYBOOKS.md 'Registry Byte Identity', row 2"
+
+    # Reachable only when the registry lies about its own content: anchor 1
+    # established sha256(committed) == the requested digest, and the header
+    # check just established the registry claims that same digest. A
+    # re-serialization in the announce path cannot land here — it commits an
+    # object that hashes to its own filename and 404s on the registry, which is
+    # row 1.
+    cmp -s "$cas" "$reg" ||
+        ocx_fail "the object committed for tag $tag differs from the bytes $E2E_REG_HOST serves under $content — A REGISTRY INTEGRITY FAILURE: the registry advertised $content and served bytes that do not hash to it. PLAYBOOKS.md 'Registry Byte Identity', row 3"
+}
+
+# (g2) E1, the acceptance gate. ADR "Validation" bullet 2: sha256(bytes) ==
+# <hex> AND a GET by that digest against the root's own `repository` returns
+# byte-identical content — the platform mapping is a copy of the registry's
+# bytes, not an assertion about them. Pre-change, tags[].content was a digest
+# the announcer minted, so this GET 404s; that 404 is the reproduction.
+#
+# Every tag in the served root, not only this run's: --cascade aliases
+# 1.0.4 / 1.0 / 1 / latest onto one index, so a per-tag divergence is exactly
+# what a single-tag check would let through.
+assert_bytes_identical() {
+    local root_json="$1" repository names tag content
+    local -a tags=()
+    local -A content_of=()
+
+    # A command substitution, not `done < <(...)`: a process substitution's exit
+    # status is unobservable, so an unparseable root would run zero iterations
+    # and reach the vacuity refusal below wearing the wrong diagnosis.
+    names="$(_root_tag_names "$root_json")" ||
+        ocx_fail "could not read the served root's tags — (g2) refuses to judge a root it failed to parse"
+
+    # A root with no tags satisfies every assertion below by never running one.
+    # The gate says so rather than reporting a pass.
+    [[ -n $names ]] ||
+        ocx_fail "the served root commits no tags — (g2) would pass vacuously"
+    mapfile -t tags <<<"$names"
+
+    # Read and validate the whole root before touching the network, so a
+    # malformed root fails as a malformed root rather than as a registry error
+    # one round-trip later.
+    for tag in "${tags[@]}"; do
+        content="$(_root_tag_content "$root_json" "$tag")"
+        # The digest lands in a URL. Validated here at the boundary, not
+        # trusted because a schema somewhere else says it is well-formed.
+        if [[ ! $content =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            ocx_fail "the root records a malformed content digest for tag $tag: $content"
+        fi
+        content_of["$tag"]="$content"
+    done
+
+    repository="$(_root_repository "$root_json")" ||
+        ocx_fail "the served root does not name a usable physical repository"
+    # IFS is $'\n\t' script-wide, so the space is NOT a separator unless said
+    # here — same idiom as env.sh's `IFS='|' read`. Without it the host would
+    # swallow the path and every URL below would be malformed.
+    IFS=' ' read -r E2E_REG_HOST E2E_REG_PATH <<<"$repository"
+
+    # Both halves land in every registry URL below, and the root is
+    # publisher-controlled — same boundary the content digest is validated at.
+    # A `?` or `#` in the path would silently truncate the request into one that
+    # never asked for a manifest, and its 404 would read as the bug class; a
+    # host nobody constrained lets an attacker-named registry serve the
+    # committed bytes back and turn the gate green.
+    [[ $E2E_REG_HOST =~ ^[a-zA-Z0-9.-]+(:[0-9]+)?$ ]] ||
+        ocx_fail "the served root names $E2E_REG_HOST, which is not a host[:port] — refusing to build a registry URL from it"
+    [[ $E2E_REG_PATH =~ ^[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*(/[a-z0-9]+((\.|_|__|-+)[a-z0-9]+)*)*$ ]] ||
+        ocx_fail "the served root names $E2E_REG_PATH, which is not an OCI repository name — refusing to build a registry URL from it"
+
+    E2E_REG_TOKEN="$(_pull_token "$E2E_REG_HOST" "$E2E_REG_PATH")" ||
+        ocx_fail "could not obtain an anonymous pull token for $E2E_REG_PATH on $E2E_REG_HOST — a credential problem, not a mapping defect"
+
+    for tag in "${!content_of[@]}"; do
+        _assert_tag_identical "$tag" "${content_of[$tag]}"
+    done
+
+    E2E_BINDINGS_VERIFIED="${#content_of[@]}"
+    E2E_OBJECTS_VERIFIED="$(printf '%s\n' "${content_of[@]}" | sort -u | wc -l)"
+    ocx_done "(g2) all $E2E_BINDINGS_VERIFIED tag→object bindings, over $E2E_OBJECTS_VERIFIED distinct o/ objects, are byte-identical to what $E2E_REG_HOST serves under the same digest"
+}
+
+# (g2) E2a, D7: no reserved tag class reaches the index. Free — the pilot
+# repository genuinely carries both classes, since push_canonical_tag is
+# default-on and the publisher's `Describe package` step writes __ocx.desc.
+#
+# This does NOT prove the filter fired. The publisher announces via
+# --announce-file, which under D7 never carries a canonical tag, so a clean
+# root is consistent with no filter at all. E2a is a regression tripwire; E2b
+# and the local acceptance cases are the proof. README.md says the same.
+assert_no_reserved_tags() {
+    local root_json="$1" names tag
+    local -a tags=()
+
+    # A command substitution, not `done < <(...)`: a process substitution's exit
+    # status is unobservable, so an unparseable root would run zero iterations
+    # and attest D7 against a root this never read.
+    names="$(_root_tag_names "$root_json")" ||
+        ocx_fail "could not read the served root's tags — (g2) cannot attest D7 against a root it failed to parse"
+    [[ -n $names ]] ||
+        ocx_fail "the served root commits no tags — (g2) would attest D7 vacuously"
+    mapfile -t tags <<<"$names"
+
+    for tag in "${tags[@]}"; do
+        if [[ ${tag,,} == __ocx* ]]; then
+            ocx_fail "the served root carries reserved internal tag $tag — D7: announce drops __ocx*, case-insensitively"
+        fi
+        if [[ $tag =~ ^sha256\.[0-9a-f]{64}$ ]]; then
+            ocx_fail "the served root carries canonical digest-alias tag $tag — D7: announce drops sha256.<hex>"
+        fi
+    done
+    ocx_done "(g2) no reserved tag class reached the root over ${#tags[@]} tags (D7)"
+}
+
+main() {
+    local tag="${1:?usage: run_sequence.sh <tag>}"
+    local sha t0 publisher_run pr merge_line merge_sha merged_at deploy_run latency
+    local root_json
+    local secret_args=()
+
+    require_claimed_namespace
+
+    t0="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    sha="$(push_publisher_tag "$tag")"
+
+    ocx_step "(b) waiting for the publisher's build + push + announce at ${sha:0:7}"
+    publisher_run="$(poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha")" ||
+        ocx_fail "publisher CI did not conclude successfully — see PLAYBOOKS.md"
+
+    ocx_step "(c) waiting for the tag-refresh PR on $ANNOUNCE_BRANCH"
+    pr="$(poll_pr)" || ocx_fail "no pull request appeared on $ANNOUNCE_BRANCH"
+    ocx_done "(c) pull request #$pr"
+
+    ocx_step "(d) waiting for validate.yml on PR #$pr"
+    poll_check "$pr" ||
+        ocx_fail "validate.yml is not green on PR #$pr — see PLAYBOOKS.md playbook 2"
+
+    print_governance_checklist "$pr"
+
+    ocx_step "(f) waiting for PR #$pr to merge, then for render-deploy"
+    merge_line="$(poll_merge "$pr")" || ocx_fail "PR #$pr did not merge"
+    merge_sha="${merge_line%% *}"
+    merged_at="${merge_line##* }"
+    deploy_run="$(poll_run "$GH_REPO_INDEX" render-deploy main "$merge_sha")" ||
+        ocx_fail "render-deploy did not conclude successfully at ${merge_sha:0:7}"
+
+    ocx_step "(g) checking that $INDEX_SITE serves the root"
+    assert_served "$tag"
+
+    ocx_step "(g2) proving the committed objects are the registry's own bytes"
+    root_json="$(curl -fsS -- "$INDEX_SITE/p/$E2E_NAMESPACE/$E2E_PACKAGE.json")" ||
+        ocx_fail "could not read the served root for (g2)"
+    assert_no_reserved_tags "$root_json"
+    assert_bytes_identical "$root_json"
+
+    ocx_step "(h) clean-machine install"
+    "$E2E_SCRIPT_DIR/clean_install_check.sh" ||
+        ocx_fail "clean-machine install did not resolve $E2E_NAMESPACE/$E2E_PACKAGE"
+
+    latency="$(evidence latency --start "$t0" --end "$merged_at")"
+    mapfile -t secret_args < <(evidence_secret_args)
+    evidence record --scenario sequenced --status pass \
+        --pr-url "$(gh pr view "$pr" --repo "$GH_REPO_INDEX" --json url --jq '.url')" \
+        --run-urls "$publisher_run,$deploy_run,$INDEX_SITE/p/$E2E_NAMESPACE/$E2E_PACKAGE.json" \
+        --latency "$latency" \
+        --notes "tag $tag; PR #$pr merged at $merged_at; tag-push to merge ${latency}s; (g2) $E2E_BINDINGS_VERIFIED tag→object bindings over $E2E_OBJECTS_VERIFIED distinct o/ objects, byte-identical to $E2E_REG_HOST/$E2E_REG_PATH" \
+        "${secret_args[@]}" \
+        --out "$RESULTS_DIR/${RUN_ID}-sequenced.record.json"
+
+    ocx_done "sequenced scenario passed (PR #$pr, ${latency}s tag-push to merge)"
+}
+
+# Guarded so `selfcheck_g2.sh` can source this file and drive every (g2) verdict
+# against fixture roots, and so an operator can call assert_bytes_identical by
+# hand against an unmerged pull request's root (README, the E1-pre run).
+# Sourcing must never push a tag.
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    main "$@"
+fi

--- a/test/manual/announce-e2e/scripts/run_update_union.sh
+++ b/test/manual/announce-e2e/scripts/run_update_union.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Requirement (4): update-not-overwrite proof (C4) — two announces with the
+# first pull request left unmerged produce a single pull request whose
+# committed tag set is a superset of both runs' tags.
+#
+# Usage: run_update_union.sh <tag-a> <tag-b>
+#
+# Both tags must already exist on the registry — announce observes tags, it
+# does not create them. Uses `--tags-file` (union-add) for both runs:
+# `--tags` replaces the curated set, which would drop tag-a on the second run
+# and prove nothing.
+#
+# Needs OCX_ANNOUNCE_TOKEN; see README.md "Prerequisites".
+#
+# Consumes from env.sh: GH_REPO_INDEX, INDEX_FORK, E2E_NAMESPACE, E2E_PACKAGE.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# shellcheck source=./env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
+
+WORK_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$WORK_DIR"; }
+trap cleanup EXIT
+
+# One announce driven by a single-tag tags-file. Args: <label> <tag>.
+announce_tag() {
+    local label="$1" tag="$2"
+    local tags_file="$WORK_DIR/$label.tags"
+    printf '%s\n' "$tag" >"$tags_file"
+    announce_capture "$label" \
+        --package "$E2E_NAMESPACE/$E2E_PACKAGE" \
+        --tags-file "$tags_file" \
+        --fork "$INDEX_FORK" \
+        --index-repo "$GH_REPO_INDEX"
+}
+
+main() {
+    local tag_a="${1:?usage: run_update_union.sh <tag-a> <tag-b>}"
+    local tag_b="${2:?usage: run_update_union.sh <tag-a> <tag-b>}"
+    local pr_a pr_b committed union_result
+
+    ocx_step "announce #1 with $tag_a"
+    announce_tag union-1 "$tag_a" >/dev/null
+    pr_a="$(poll_pr)" || ocx_fail "announce #1 opened no pull request"
+    ocx_done "announce #1 opened PR #$pr_a"
+
+    # The union is only proved while #1 is still open — a merged PR would make
+    # run #2 a fresh branch off main and the second announce trivially a
+    # superset of itself.
+    [[ "$(gh pr view "$pr_a" --repo "$GH_REPO_INDEX" --json state --jq '.state')" == "OPEN" ]] ||
+        ocx_fail "PR #$pr_a is no longer open — someone merged it mid-run; restart the scenario"
+
+    ocx_step "announce #2 with $tag_b, PR #$pr_a deliberately left unmerged"
+    announce_tag union-2 "$tag_b" >/dev/null
+    pr_b="$(poll_pr)" || ocx_fail "no pull request after announce #2"
+
+    if [[ $pr_b != "$pr_a" ]]; then
+        evidence record --scenario update_union --status fail \
+            --notes "announce #2 opened PR #$pr_b instead of updating #$pr_a — C4 contract broke, escalate to Track A" \
+            "${EVIDENCE_SECRETS[@]}" \
+            --out "$RESULTS_DIR/${RUN_ID}-update_union.record.json"
+        ocx_fail "announce #2 opened PR #$pr_b instead of updating #$pr_a (C4 broken)"
+    fi
+
+    committed="$(committed_tags "$ANNOUNCE_BRANCH" | paste -sd, -)"
+    ocx_step "committed tags on $ANNOUNCE_BRANCH: $committed"
+
+    if ! union_result="$(evidence pr-union --committed "$committed" --expected "$tag_a,$tag_b")"; then
+        evidence record --scenario update_union --status fail \
+            --notes "committed tags [$committed] are not a superset of [$tag_a,$tag_b]: $union_result" \
+            "${EVIDENCE_SECRETS[@]}" \
+            --out "$RESULTS_DIR/${RUN_ID}-update_union.record.json"
+        ocx_fail "committed tags are not a superset of both runs: $union_result"
+    fi
+
+    evidence record --scenario update_union --status pass \
+        --pr-url "$(gh pr view "$pr_a" --repo "$GH_REPO_INDEX" --json url --jq '.url')" \
+        --notes "single PR #$pr_a; committed [$committed] superset of [$tag_a,$tag_b]" \
+        "${EVIDENCE_SECRETS[@]}" \
+        --out "$RESULTS_DIR/${RUN_ID}-update_union.record.json"
+
+    ocx_done "update-union proved: one PR (#$pr_a) carrying both tags"
+}
+
+main "$@"

--- a/test/manual/announce-e2e/scripts/selfcheck_g2.sh
+++ b/test/manual/announce-e2e/scripts/selfcheck_g2.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# Self-check for the (g2) gate's own decision logic in run_sequence.sh.
+#
+# (g2) cannot be exercised without a real publisher tag push and an owner-gated
+# merge, so without this its verdict branches would ship with nothing able to
+# fail on them — and a manual check performed once is not a test. This drives
+# every branch against fixture roots and a stubbed `curl`.
+#
+# Covered: the verdict taxonomy's dispatch, the Docker-Content-Digest parse, the
+# byte comparison, the two pre-network anchors, the boundary guards on the
+# root's `tags[].content` and `repository`, the vacuity and parse refusals, and
+# the binding-vs-object counting.
+#
+# NOT covered — and deliberately so: TLS, real registry auth, whether GHCR
+# behaves as assumed, and whether the announce path writes a registry digest at
+# all. `curl` is a stub on `PATH` for the duration; only the decision logic is
+# under test, never the transport. The live proof is the `1.0.4` run.
+#
+# Usage: selfcheck_g2.sh    (no network, no credentials, no live state)
+
+set -euo pipefail
+IFS=$'\n\t'
+
+TMP="$(mktemp -d)"
+
+# The live-run variables env.sh demands. Nothing here reaches a network: the
+# stub curl below is the only I/O, and sourcing run_sequence.sh never runs main.
+export GH_REPO_PUBLISHER="stub/publisher" GH_REPO_INDEX="stub/index" \
+    INDEX_FORK="stub/fork" E2E_NAMESPACE="ns" E2E_PACKAGE="pkg" \
+    BOT_ACTOR_IDS="1" RESULTS_DIR="$TMP/results" INDEX_SITE="https://stub.invalid"
+
+# Only the flags run_sequence.sh actually passes. The URL is whatever is left
+# over, so `--` and the bundled `-fsS` need no special case beyond being flags.
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+out="" dump="" url="" want_code=""
+while (($#)); do
+    case "$1" in
+        -o) out="$2" && shift 2 ;;
+        -D) dump="$2" && shift 2 ;;
+        -H | -w) want_code=1 && shift 2 ;;
+        --) shift ;;
+        -*) shift ;;
+        *) url="$1" && shift ;;
+    esac
+done
+hex="${url##*/}"
+hex="${hex%.json}"
+hex="${hex#sha256:}"
+case "$url" in
+    */token\?*)
+        printf '{"token": "stub"}\n'
+        ;;
+    */o/sha256/*)
+        [[ -f "$STUB_DIR/cas/$hex" ]] || exit 22
+        cp -- "$STUB_DIR/cas/$hex" "$out"
+        ;;
+    */manifests/*)
+        status=200
+        [[ -f "$STUB_DIR/status/$hex" ]] && status="$(<"$STUB_DIR/status/$hex")"
+        dcd="sha256:$hex"
+        [[ -f "$STUB_DIR/dcd/$hex" ]] && dcd="$(<"$STUB_DIR/dcd/$hex")"
+        : >"$out"
+        [[ -f "$STUB_DIR/reg/$hex" ]] && cp -- "$STUB_DIR/reg/$hex" "$out"
+        {
+            printf 'HTTP/1.1 %s stub\r\n' "$status"
+            printf 'Content-Type: application/vnd.oci.image.index.v1+json\r\n'
+            [[ -n $dcd ]] && printf 'Docker-Content-Digest: %s\r\n' "$dcd"
+            printf '\r\n'
+        } >"$dump"
+        [[ -n $want_code ]] && printf '%s\n' "$status"
+        ;;
+    *)
+        printf 'stub curl: unexpected url %s\n' "$url" >&2
+        exit 1
+        ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/curl"
+PATH="$TMP/bin:$PATH"
+export PATH
+
+# shellcheck source=./run_sequence.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/run_sequence.sh"
+
+# run_sequence.sh installs its own EXIT trap for WORK_DIR; replace it with one
+# that clears both, since sourcing means only one trap survives.
+trap 'rm -rf -- "$TMP" "$WORK_DIR"' EXIT
+
+CASES=0
+FAILURES=0
+STUB_DIR=""
+export STUB_DIR
+
+# A fresh stub state. Defaults are the passing case: status 200 and a
+# Docker-Content-Digest echoing the requested digest.
+new_case() {
+    CASES=$((CASES + 1))
+    STUB_DIR="$TMP/case-$CASES"
+    mkdir -p "$STUB_DIR/cas" "$STUB_DIR/reg" "$STUB_DIR/status" "$STUB_DIR/dcd"
+}
+
+# Register one object, served both as the committed CAS entry and as the
+# registry's manifest body. Args: <content-bytes>. Echoes sha256:<hex>.
+serve_object() {
+    local hex
+    hex="$(printf '%s' "$1" | sha256sum | cut -d' ' -f1)"
+    printf '%s' "$1" >"$STUB_DIR/cas/$hex"
+    printf '%s' "$1" >"$STUB_DIR/reg/$hex"
+    printf 'sha256:%s\n' "$hex"
+}
+
+# A served-root fixture. Args: <repository-url> <tag>=<content-digest>...
+root_json() {
+    local repo="$1" pair
+    local -a members=()
+    shift
+    for pair in "$@"; do
+        members+=("\"${pair%%=*}\": {\"content\": \"${pair#*=}\"}")
+    done
+    local IFS=,
+    printf '{"repository": "%s", "tags": {%s}}' "$repo" "${members[*]}"
+}
+
+report() {
+    if [[ $1 == pass ]]; then
+        printf 'ok   %s\n' "$2"
+    else
+        FAILURES=$((FAILURES + 1))
+        printf 'FAIL %s\n     %s\n' "$2" "${3//$'\n'/$'\n'     }"
+    fi
+}
+
+# Args: <description> <substring the success message must carry> <command...>
+expect_ok() {
+    local what="$1" pat="$2" out
+    shift 2
+    if ! out="$("$@" 2>&1)"; then
+        report fail "$what" "expected success, got: $out"
+    elif [[ $out == *"$pat"* ]]; then
+        report pass "$what"
+    else
+        report fail "$what" "expected '$pat' in: $out"
+    fi
+}
+
+# Args: <description> <substring the failure message must carry> <command...>
+expect_fail() {
+    local what="$1" pat="$2" out
+    shift 2
+    if out="$("$@" 2>&1)"; then
+        report fail "$what" "expected failure, got: $out"
+    elif [[ $out == *"$pat"* ]]; then
+        report pass "$what"
+    else
+        report fail "$what" "expected '$pat' in: $out"
+    fi
+}
+
+REPO="oci://registry.stub/ns/pkg"
+
+main_selfcheck() {
+    local d e root
+
+    # --- E1, the taxonomy. One row per verdict. ---
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    expect_ok "row 4 — proof" "1 tag→object bindings, over 1 distinct" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    rm -- "$STUB_DIR/reg/${d#sha256:}"
+    printf '404\n' >"$STUB_DIR/status/${d#sha256:}"
+    expect_fail "row 1 — 404 is the bug class" "THE BUG CLASS" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    printf '429\n' >"$STUB_DIR/status/${d#sha256:}"
+    expect_fail "transport — 429 is not a taxonomy row" "the paragraph below the taxonomy table" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    printf 'sha256:%064d\n' 0 >"$STUB_DIR/dcd/${d#sha256:}"
+    expect_fail "row 2 — content negotiation" "REGISTRY-BEHAVIOUR" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    : >"$STUB_DIR/dcd/${d#sha256:}"
+    expect_fail "row 2 — absent digest header" "no Docker-Content-Digest header" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    printf '{"index": 2}' >"$STUB_DIR/reg/${d#sha256:}"
+    expect_fail "row 3 — registry integrity" "REGISTRY INTEGRITY FAILURE" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    # --- The two anchors that fire before the registry is contacted. ---
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    rm -- "$STUB_DIR/cas/${d#sha256:}"
+    expect_fail "anchor — no committed object" "nothing is committed at" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    printf '{"index": 9}' >"$STUB_DIR/cas/${d#sha256:}"
+    expect_fail "anchor — CAS disagrees with its filename" "does not hash to its own filename" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d")"
+
+    # --- Boundary guards on the publisher-controlled root. ---
+
+    new_case
+    expect_fail "boundary — malformed content digest" "malformed content digest" \
+        assert_bytes_identical "$(root_json "$REPO" '1.0.4=sha256:nothex')"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    expect_fail "boundary — query string in the repository path" "not an OCI repository name" \
+        assert_bytes_identical "$(root_json 'oci://registry.stub/ns/pkg?x=1' "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    expect_fail "boundary — illegal character in the repository host" "is not a host" \
+        assert_bytes_identical "$(root_json 'oci://registry!stub/ns/pkg' "1.0.4=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    expect_fail "boundary — repository is not an oci:// URL" "does not name a usable physical repository" \
+        assert_bytes_identical "$(root_json 'https://registry.stub/ns/pkg' "1.0.4=$d")"
+
+    new_case
+    expect_fail "refusal — a root with no tags" "would pass vacuously" \
+        assert_bytes_identical "$(root_json "$REPO")"
+
+    new_case
+    expect_fail "refusal — a root that does not parse" "failed to parse" \
+        assert_bytes_identical '{"repository": "'"$REPO"'"}'
+
+    # --- Cascade: bindings and distinct objects are counted separately. ---
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    e="$(serve_object '{"index": 2}')"
+    expect_ok "cascade — 3 bindings over 2 objects" "3 tag→object bindings, over 2 distinct" \
+        assert_bytes_identical "$(root_json "$REPO" "1.0.4=$d" "1.0=$d" "latest=$e")"
+
+    # --- E2a, D7. ---
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    expect_ok "D7 — a clean root" "over 2 tags" \
+        assert_no_reserved_tags "$(root_json "$REPO" "1.0.4=$d" "latest=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    expect_fail "D7 — __ocx.desc, upper-cased" "reserved internal tag" \
+        assert_no_reserved_tags "$(root_json "$REPO" "1.0.4=$d" "__OCX.DESC=$d")"
+
+    new_case
+    d="$(serve_object '{"index": 1}')"
+    root="$(root_json "$REPO" "1.0.4=$d" "sha256.$(printf '%064d' 0)=$d")"
+    expect_fail "D7 — canonical digest alias" "canonical digest-alias tag" \
+        assert_no_reserved_tags "$root"
+
+    new_case
+    expect_fail "D7 — never attested against an unparseable root" "failed to parse" \
+        assert_no_reserved_tags '{"repository": "'"$REPO"'"}'
+
+    new_case
+    expect_fail "D7 — never attested vacuously" "attest D7 vacuously" \
+        assert_no_reserved_tags "$(root_json "$REPO")"
+
+    printf '\n%d cases, %d failures\n' "$CASES" "$FAILURES"
+    ((FAILURES == 0))
+}
+
+main_selfcheck

--- a/test/manual/scripts/_lib.sh
+++ b/test/manual/scripts/_lib.sh
@@ -64,6 +64,13 @@ ocx_done() {
     printf '%s%s%s\n' "$OCX_C_DONE" "$*" "$OCX_C_RESET"
 }
 
+# Fatal error to stderr, then exit 1. Scripts that assert against live
+# infrastructure fail closed rather than warning and continuing.
+ocx_fail() {
+    printf '%serror: %s%s\n' "$OCX_C_WARN" "$*" "$OCX_C_RESET" >&2
+    exit 1
+}
+
 # Write an executable `bin/<name>` script under <pkg_root>/<src>. Body read
 # from stdin. Parents created; mode 0755.
 scaffold_bin() {

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -5,7 +5,12 @@ requires-python = ">=3.10"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["."]
+# "." exposes the `src` package (`from src.helpers import ...`, the suite-wide
+# convention); "src" additionally exposes `announce_e2e` as a top-level import
+# so the Track D evidence module does not drag `src/__init__.py`'s registry /
+# oras imports into a pure-logic unit test. Scripts outside pytest set
+# PYTHONPATH=<repo>/test/src for the same reason.
+pythonpath = [".", "src"]
 markers = [
     "requires_tty: test requires a real TTY on stderr; skipped in capture-output environments (is_terminal() returns false in pipes)",
 ]

--- a/test/src/announce_e2e/evidence.py
+++ b/test/src/announce_e2e/evidence.py
@@ -1,0 +1,452 @@
+"""Pure classification / latency / redaction / render logic for the Track D
+announce E2E gate.
+
+Deliberately network-free: every function here takes already-fetched JSON
+(`gh api` output, an `ocx package announce --format json` report) so the whole
+module is unit-testable. Fetching is the bash layer's job — see
+`test/manual/announce-e2e/scripts/`.
+
+Import path: this package lives under `test/src/`, which pytest puts on
+`sys.path` via `pythonpath` in `test/pyproject.toml`. Outside pytest, set
+`PYTHONPATH=<repo>/test/src` (the scripts do).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Collection, Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+REDACTION = "***REDACTED***"
+
+#: Scenario names the results artifact carries a row for, in render order.
+SCENARIOS: tuple[str, ...] = (
+    "sequenced",
+    "idempotency",
+    "machine_lane",
+    "update_union",
+    "clean_install",
+)
+
+#: Rendered in place of any `None` field so an incomplete evidence set is
+#: visibly incomplete rather than silently short.
+MISSING = "MISSING"
+
+#: The two values `ocx package announce --format json` may report.
+_ANNOUNCE_STATUS: tuple[str, ...] = ("unchanged", "updated")
+
+_TABLE_HEADER = (
+    "| Scenario | Status | Pull Request | Runs | Latency (s) | Captured At | Notes |\n"
+    "|---|---|---|---|---|---|---|\n"
+)
+
+
+class Redacted(str):
+    """Text that has been through :func:`redact_secrets`.
+
+    A marker type, not a container: `EvidenceRecord` refuses free-text fields
+    that are not `Redacted`, so an unredacted capture cannot reach
+    :func:`render_evidence_markdown` by forgetting a call (Key Decision D-4).
+    Constructing `Redacted(raw)` by hand defeats that — it is deliberate,
+    greppable, and reviewed for in Step 5.1.
+    """
+
+    __slots__ = ()
+
+
+@dataclass(frozen=True, slots=True)
+class LaneClassification:
+    lane: Literal["human", "machine"]
+    human_click_detected: bool
+    actor_ids: list[int]  # numeric actor ids only — see Key Decision D-3
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    scenario: str  # one of SCENARIOS
+    status: Literal["pass", "fail"]
+    pr_url: Redacted | None
+    run_urls: list[Redacted]
+    latency_seconds: float | None
+    notes: Redacted
+    captured_at: str  # ISO-8601 UTC
+
+    def __post_init__(self) -> None:
+        """Refuse free text that has not been through :func:`redact_secrets`.
+
+        The results artifact is committed and read later by Tracks E and F, so
+        a live credential must not be able to reach it. Enforcing that here —
+        at the only door into the render path — beats a convention every
+        caller has to remember (Key Decision D-4).
+        """
+        if not isinstance(self.notes, Redacted):
+            raise TypeError(
+                "EvidenceRecord.notes must be redacted (see redact_secrets)"
+            )
+        if self.pr_url is not None and not isinstance(self.pr_url, Redacted):
+            raise TypeError(
+                "EvidenceRecord.pr_url must be redacted (see redact_secrets)"
+            )
+        for url in self.run_urls:
+            if not isinstance(url, Redacted):
+                raise TypeError(
+                    "every EvidenceRecord.run_urls entry must be redacted (see redact_secrets)"
+                )
+
+
+def classify_report(report: dict) -> Literal["unchanged", "updated"]:
+    """`ocx package announce --format json` report dict in; its `status`
+    field out. Raises ValueError if the field is absent or not one of
+    the two contract values (interface contract #4, C6)."""
+    if "status" not in report:
+        raise ValueError(f"announce report carries no `status` field: {sorted(report)}")
+    status = report["status"]
+    if status not in _ANNOUNCE_STATUS:
+        raise ValueError(
+            f"announce report `status` is {status!r}, not one of {_ANNOUNCE_STATUS}"
+        )
+    return status
+
+
+def compute_latency_seconds(start_iso: str, end_iso: str) -> float:
+    """ISO-8601 UTC in, elapsed seconds out. Raises ValueError on
+    unparseable input or end < start."""
+    start = _parse_iso_utc(start_iso, "start")
+    end = _parse_iso_utc(end_iso, "end")
+    if end < start:
+        raise ValueError(f"end {end_iso!r} precedes start {start_iso!r}")
+    return (end - start).total_seconds()
+
+
+def _parse_iso_utc(value: str, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{label} timestamp {value!r} is not ISO-8601") from error
+    # `gh api` emits `...Z`; a naive value can only have come from a UTC field.
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def classify_lane(
+    pr_events: list[dict], bot_actor_ids: Collection[int]
+) -> LaneClassification:
+    """Merged `gh api .../pulls/<n>/reviews` + `.../issues/<n>/events`
+    list in. `machine` lane requires every state-changing event's
+    `actor.id` (numeric, never `actor.login`) to be in the given
+    bot-id allowlist (`BOT_ACTOR_IDS` in `env.sh`).
+
+    Fail-closed on three counts: an event whose actor carries no numeric id
+    reads as human, an empty event list reads as human (silence is not proof
+    of a bot merge), and *every* event counts — a human comment on a PR the
+    bot merged still falsifies "no human touched this".
+
+    ponytail: no event-type taxonomy. If a future lane proof needs to
+    distinguish state-changing events from chatter, filter `pr_events` in the
+    caller — widening this function's trust is the wrong direction.
+    """
+    bot_ids = set(bot_actor_ids)
+    actor_ids: list[int] = []
+    human_click_detected = not pr_events
+
+    for event in pr_events:
+        actor_id = _actor_id(event)
+        if actor_id is None:
+            human_click_detected = True
+            continue
+        if actor_id not in actor_ids:
+            actor_ids.append(actor_id)
+        if actor_id not in bot_ids:
+            human_click_detected = True
+
+    return LaneClassification(
+        lane="human" if human_click_detected else "machine",
+        human_click_detected=human_click_detected,
+        actor_ids=actor_ids,
+    )
+
+
+def _actor_id(event: dict) -> int | None:
+    """The numeric id of whoever produced this event, or None.
+
+    Issue events name them `actor`, review submissions name them `user`.
+    `login` is never read — it is renameable and recyclable (D-3, register X7).
+    """
+    for key in ("actor", "user"):
+        who = event.get(key)
+        if isinstance(who, dict) and isinstance(who.get("id"), int):
+            return who["id"]
+    return None
+
+
+def assert_pr_union(
+    committed_tags: Sequence[str], expected_tags: Sequence[str]
+) -> tuple[bool, list[str]]:
+    """committed_tags = tags currently on the PR branch's root;
+    expected_tags = union of every announce run's tag set so far.
+    Returns (is_superset, missing_tags) — C4's contract."""
+    committed = set(committed_tags)
+    missing = [tag for tag in dict.fromkeys(expected_tags) if tag not in committed]
+    return not missing, missing
+
+
+def redact_secrets(text: str, secrets: Iterable[str]) -> Redacted:
+    """Replace every occurrence of every non-empty string in `secrets`
+    with `***REDACTED***`. Must be called on every captured log/output
+    before it reaches render_evidence_markdown (Key Decision D-4)."""
+    # Longest first: a secret containing a shorter one is masked whole rather
+    # than left as `***REDACTED***…tail`.
+    for secret in sorted((s for s in secrets if s), key=len, reverse=True):
+        text = text.replace(secret, REDACTION)
+    return Redacted(text)
+
+
+def render_evidence_markdown(records: Sequence[EvidenceRecord]) -> str:
+    """Render the frozen results-artifact template (see
+    `.claude/artifacts/e2e_results_announce.md`) from a list of
+    per-scenario records. A `None` field renders as the literal string
+    `MISSING` so an incomplete evidence set is visibly incomplete."""
+    rows = [_row(record) for record in records]
+    covered = {record.scenario for record in records}
+    rows.extend(_placeholder_row(name) for name in SCENARIOS if name not in covered)
+    return _TABLE_HEADER + "".join(rows)
+
+
+def _row(record: EvidenceRecord) -> str:
+    cells = (
+        record.scenario,
+        record.status,
+        _cell(record.pr_url),
+        ", ".join(record.run_urls) if record.run_urls else MISSING,
+        _cell(record.latency_seconds),
+        _cell(record.captured_at),
+        _cell(record.notes),
+    )
+    return "| " + " | ".join(cells) + " |\n"
+
+
+def _placeholder_row(scenario: str) -> str:
+    return "| " + " | ".join((scenario, *([MISSING] * 6))) + " |\n"
+
+
+def _cell(value: object) -> str:
+    """A field's markdown cell — `MISSING` for None, never an empty cell."""
+    if value is None or value == "":
+        return MISSING
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatcher — lets the bash drivers call this module without a second
+# language boundary: `uv run python -m announce_e2e.evidence <subcommand>`.
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: str | None) -> object:
+    raw = sys.stdin.read() if path in (None, "-") else Path(path).read_text()
+    return json.loads(raw)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="announce_e2e.evidence")
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+
+    report = subparsers.add_parser(
+        "classify-report", help="print an announce report's status"
+    )
+    report.add_argument("--file", help="report JSON path; omit or '-' for stdin")
+
+    latency = subparsers.add_parser("latency", help="print elapsed seconds")
+    latency.add_argument("--start", required=True)
+    latency.add_argument("--end", required=True)
+
+    lane = subparsers.add_parser("classify-lane", help="print a lane classification")
+    lane.add_argument(
+        "--file", help="merged reviews+events JSON; omit or '-' for stdin"
+    )
+    lane.add_argument(
+        "--bot-actor-ids",
+        required=True,
+        help="comma-separated numeric ids (env.sh BOT_ACTOR_IDS) — never logins",
+    )
+    lane.add_argument(
+        "--require-machine",
+        action="store_true",
+        help="exit 1 unless the lane is machine with no human click, so the "
+        "caller branches on an exit code instead of grepping this JSON",
+    )
+
+    union = subparsers.add_parser("pr-union", help="check a committed tag superset")
+    union.add_argument("--committed", required=True, help="comma-separated tags")
+    union.add_argument("--expected", required=True, help="comma-separated tags")
+
+    redact = subparsers.add_parser("redact", help="redact secrets from stdin")
+    _add_secret_args(redact)
+
+    record = subparsers.add_parser("record", help="write one EvidenceRecord JSON")
+    record.add_argument("--scenario", required=True, choices=SCENARIOS)
+    record.add_argument("--status", required=True, choices=("pass", "fail"))
+    record.add_argument("--pr-url", default="")
+    record.add_argument("--run-urls", default="", help="comma-separated")
+    record.add_argument("--latency", default="", help="seconds, or empty for none")
+    record.add_argument("--notes", default="")
+    record.add_argument("--out", required=True, help="destination path")
+    _add_secret_args(record)
+
+    render = subparsers.add_parser("render", help="render the results artifact")
+    render.add_argument(
+        "--file", help="EvidenceRecord list JSON; omit or '-' for stdin"
+    )
+    render.add_argument(
+        "--records-dir",
+        help="directory of `record`-written *.record.json files; replaces --file",
+    )
+    _add_secret_args(render)
+    return parser
+
+
+def _add_secret_args(sub: argparse.ArgumentParser) -> None:
+    """Secrets arrive by environment variable NAME, never by value.
+
+    `--secrets <token>` would put the live PAT on the argv of this process and
+    of the `uv` parent, where `/proc/<pid>/cmdline` and every process-monitoring
+    agent can read it — the same leak `subsystem-cli-commands.md` refuses for
+    `--password`. One of the two flags is required so an unredacted run is
+    always a stated choice, never an empty string nobody noticed.
+    """
+    group = sub.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--secrets-env",
+        default="",
+        help="comma-separated env var NAMES whose values are masked (e.g. OCX_ANNOUNCE_TOKEN)",
+    )
+    group.add_argument(
+        "--no-secrets",
+        action="store_true",
+        help="state that this invocation has nothing to redact",
+    )
+
+
+def _secrets_from_env(names: str) -> list[str]:
+    """Read each named variable's whole value. Never split a value on commas —
+    a secret is opaque. An unset or empty name is announced, not swallowed."""
+    secrets = []
+    for name in _split(names):
+        value = os.environ.get(name, "")
+        if value:
+            secrets.append(value)
+        else:
+            print(
+                f"warning: ${name} is unset or empty; nothing to redact",
+                file=sys.stderr,
+            )
+    return secrets
+
+
+def _split(value: str) -> list[str]:
+    return [item for item in (part.strip() for part in value.split(",")) if item]
+
+
+def _record_from_json(entry: dict, secrets: Sequence[str]) -> EvidenceRecord:
+    """Build a record, redacting on the way in so the CLI cannot skip D-4."""
+    pr_url = entry.get("pr_url")
+    return EvidenceRecord(
+        scenario=entry["scenario"],
+        status=entry["status"],
+        pr_url=None if pr_url is None else redact_secrets(pr_url, secrets),
+        run_urls=[redact_secrets(url, secrets) for url in entry.get("run_urls", [])],
+        latency_seconds=entry.get("latency_seconds"),
+        notes=redact_secrets(entry.get("notes", ""), secrets),
+        captured_at=entry["captured_at"],
+    )
+
+
+def _as_json(record: EvidenceRecord) -> dict:
+    return {
+        "scenario": record.scenario,
+        "status": record.status,
+        "pr_url": record.pr_url,
+        "run_urls": list(record.run_urls),
+        "latency_seconds": record.latency_seconds,
+        "notes": str(record.notes),
+        "captured_at": record.captured_at,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if args.subcommand == "classify-report":
+        print(classify_report(_read_json(args.file)))
+    elif args.subcommand == "latency":
+        print(compute_latency_seconds(args.start, args.end))
+    elif args.subcommand == "classify-lane":
+        lane = classify_lane(
+            _read_json(args.file), [int(i) for i in _split(args.bot_actor_ids)]
+        )
+        print(
+            json.dumps(
+                {
+                    "lane": lane.lane,
+                    "human_click_detected": lane.human_click_detected,
+                    "actor_ids": lane.actor_ids,
+                }
+            )
+        )
+        if args.require_machine:
+            return 0 if lane.lane == "machine" and not lane.human_click_detected else 1
+    elif args.subcommand == "pr-union":
+        is_superset, missing = assert_pr_union(
+            _split(args.committed), _split(args.expected)
+        )
+        print(json.dumps({"is_superset": is_superset, "missing_tags": missing}))
+        return 0 if is_superset else 1
+    elif args.subcommand == "redact":
+        print(
+            redact_secrets(sys.stdin.read(), _secrets_from_env(args.secrets_env)),
+            end="",
+        )
+    elif args.subcommand == "record":
+        entry = {
+            "scenario": args.scenario,
+            "status": args.status,
+            "pr_url": args.pr_url or None,
+            "run_urls": _split(args.run_urls),
+            "latency_seconds": float(args.latency) if args.latency else None,
+            "notes": args.notes,
+            "captured_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        }
+        # Round-trip through _record_from_json so the record that lands on disk
+        # is one the render path will accept — including its redaction (D-4).
+        Path(args.out).write_text(
+            json.dumps(
+                _as_json(_record_from_json(entry, _secrets_from_env(args.secrets_env))),
+                indent=2,
+            )
+        )
+        print(args.out)
+    elif args.subcommand == "render":
+        secrets = _secrets_from_env(args.secrets_env)
+        if args.records_dir:
+            entries = [
+                json.loads(path.read_text())
+                for path in sorted(Path(args.records_dir).glob("*.record.json"))
+            ]
+        else:
+            entries = _read_json(args.file)
+        print(
+            render_evidence_markdown(
+                [_record_from_json(entry, secrets) for entry in entries]
+            ),
+            end="",
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/tests/fixtures/announce_e2e/pr_events_human_lane.json
+++ b/test/tests/fixtures/announce_e2e/pr_events_human_lane.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 9000000010,
+    "event": "labeled",
+    "actor": { "login": "ocx-bot", "id": 198765432, "type": "User" },
+    "label": { "name": "human-review-required" },
+    "created_at": "2026-07-24T11:00:03Z"
+  },
+  {
+    "id": 9000000011,
+    "state": "APPROVED",
+    "user": { "login": "michael-herwig", "id": 1234567, "type": "User" },
+    "submitted_at": "2026-07-24T11:14:22Z"
+  },
+  {
+    "id": 9000000012,
+    "event": "merged",
+    "actor": { "login": "michael-herwig", "id": 1234567, "type": "User" },
+    "commit_id": "8de7f130a2b4c6d8e0f2a4b6c8d0e2f4a6b8c0d2",
+    "created_at": "2026-07-24T11:14:58Z"
+  }
+]

--- a/test/tests/fixtures/announce_e2e/pr_events_machine_lane.json
+++ b/test/tests/fixtures/announce_e2e/pr_events_machine_lane.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 9000000001,
+    "event": "labeled",
+    "actor": { "login": "ocx-bot", "id": 198765432, "type": "User" },
+    "label": { "name": "machine-lane" },
+    "created_at": "2026-07-24T10:00:12Z"
+  },
+  {
+    "id": 9000000002,
+    "event": "merged",
+    "actor": { "login": "ocx-bot", "id": 198765432, "type": "User" },
+    "commit_id": "3e6b202b1c9d4f0a7b5e8c2d6f1a0b3c4d5e6f70",
+    "created_at": "2026-07-24T10:01:47Z"
+  },
+  {
+    "id": 9000000003,
+    "event": "closed",
+    "actor": { "login": "ocx-bot", "id": 198765432, "type": "User" },
+    "created_at": "2026-07-24T10:01:47Z"
+  }
+]

--- a/test/tests/fixtures/announce_e2e/pr_events_recycled_login.json
+++ b/test/tests/fixtures/announce_e2e/pr_events_recycled_login.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 9000000020,
+    "event": "labeled",
+    "actor": { "login": "ocx-bot", "id": 198765432, "type": "User" },
+    "label": { "name": "machine-lane" },
+    "created_at": "2026-07-24T12:00:05Z"
+  },
+  {
+    "id": 9000000021,
+    "event": "merged",
+    "actor": { "login": "ocx-bot", "id": 77000111, "type": "User" },
+    "commit_id": "aa11bb22cc33dd44ee55ff6677889900aabbccdd",
+    "created_at": "2026-07-24T12:00:41Z"
+  }
+]

--- a/test/tests/fixtures/announce_e2e/report_missing_status.json
+++ b/test/tests/fixtures/announce_e2e/report_missing_status.json
@@ -1,0 +1,7 @@
+{
+  "package": "bazelbuild/bazelisk",
+  "pull_request_url": "https://github.com/ocx-sh/index/pull/57",
+  "pull_request_number": 57,
+  "fork": "michael-herwig/index",
+  "written_paths": []
+}

--- a/test/tests/fixtures/announce_e2e/report_unchanged.json
+++ b/test/tests/fixtures/announce_e2e/report_unchanged.json
@@ -1,0 +1,8 @@
+{
+  "package": "bazelbuild/bazelisk",
+  "status": "unchanged",
+  "pull_request_url": null,
+  "pull_request_number": null,
+  "fork": null,
+  "written_paths": []
+}

--- a/test/tests/fixtures/announce_e2e/report_updated.json
+++ b/test/tests/fixtures/announce_e2e/report_updated.json
@@ -1,0 +1,8 @@
+{
+  "package": "bazelbuild/bazelisk",
+  "status": "updated",
+  "pull_request_url": "https://github.com/ocx-sh/index/pull/57",
+  "pull_request_number": 57,
+  "fork": "michael-herwig/index",
+  "written_paths": []
+}

--- a/test/tests/test_announce_e2e_evidence.py
+++ b/test/tests/test_announce_e2e_evidence.py
@@ -1,0 +1,372 @@
+"""Unit tests for the Track D announce-E2E evidence module.
+
+Pure logic, no registry, no network, no `ocx` binary — the whole point of
+Key Decision D-2's split. Run narrowly with:
+
+    cd test && OCX_TESTS_NO_REGISTRY=1 uv run pytest tests/test_announce_e2e_evidence.py -v
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from announce_e2e.evidence import (
+    MISSING,
+    REDACTION,
+    EvidenceRecord,
+    LaneClassification,
+    Redacted,
+    assert_pr_union,
+    classify_lane,
+    classify_report,
+    compute_latency_seconds,
+    main,
+    redact_secrets,
+    render_evidence_markdown,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "announce_e2e"
+
+#: The index bot's numeric actor id, as `BOT_ACTOR_IDS` carries it at run time.
+#: Every fixture's bot events use this id.
+BOT_IDS = (198765432,)
+
+
+def fixture(name: str) -> dict | list:
+    return json.loads((FIXTURES / f"{name}.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# classify_report — interface contract #4 (C6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [("report_unchanged", "unchanged"), ("report_updated", "updated")],
+)
+def test_classify_report_passes_through_contract_values(
+    name: str, expected: str
+) -> None:
+    assert classify_report(fixture(name)) == expected
+
+
+def test_classify_report_rejects_missing_status() -> None:
+    with pytest.raises(ValueError):
+        classify_report(fixture("report_missing_status"))
+
+
+@pytest.mark.parametrize("garbage", ["created", "UNCHANGED", "", None, 0])
+def test_classify_report_rejects_off_contract_status(garbage: object) -> None:
+    with pytest.raises(ValueError):
+        classify_report({"package": "acme/widget", "status": garbage})
+
+
+# ---------------------------------------------------------------------------
+# compute_latency_seconds
+# ---------------------------------------------------------------------------
+
+
+def test_compute_latency_seconds_known_delta() -> None:
+    assert (
+        compute_latency_seconds("2026-07-24T10:00:00Z", "2026-07-24T10:01:47Z") == 107.0
+    )
+
+
+def test_compute_latency_seconds_accepts_offset_form() -> None:
+    assert (
+        compute_latency_seconds("2026-07-24T10:00:00+00:00", "2026-07-24T10:00:30Z")
+        == 30.0
+    )
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [
+        ("not-a-timestamp", "2026-07-24T10:00:00Z"),
+        ("2026-07-24T10:00:00Z", "yesterday"),
+        ("", "2026-07-24T10:00:00Z"),
+    ],
+)
+def test_compute_latency_seconds_rejects_malformed(start: str, end: str) -> None:
+    with pytest.raises(ValueError):
+        compute_latency_seconds(start, end)
+
+
+def test_compute_latency_seconds_rejects_end_before_start() -> None:
+    with pytest.raises(ValueError):
+        compute_latency_seconds("2026-07-24T10:01:00Z", "2026-07-24T10:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# classify_lane — Key Decision D-3 (numeric actor id, never the login string)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_lane_machine_when_every_actor_id_is_a_bot() -> None:
+    result = classify_lane(fixture("pr_events_machine_lane"), BOT_IDS)
+
+    assert isinstance(result, LaneClassification)
+    assert result.lane == "machine"
+    assert result.human_click_detected is False
+    assert result.actor_ids == [198765432]
+
+
+def test_classify_lane_human_when_any_actor_id_is_not_a_bot() -> None:
+    result = classify_lane(fixture("pr_events_human_lane"), BOT_IDS)
+
+    assert result.lane == "human"
+    assert result.human_click_detected is True
+    assert 1234567 in result.actor_ids
+
+
+def test_classify_lane_ignores_recycled_bot_login() -> None:
+    """A human actor id posting under the bot's *login* must still read human.
+
+    Register X7 names login recycling as a threat class; the client-side
+    assertion must not reintroduce it by trusting `actor.login`.
+    """
+    events = fixture("pr_events_recycled_login")
+    assert any(event.get("actor", {}).get("login") == "ocx-bot" for event in events)
+
+    result = classify_lane(events, BOT_IDS)
+
+    assert result.lane == "human"
+    assert result.human_click_detected is True
+    assert 77000111 in result.actor_ids
+
+
+def test_classify_lane_treats_an_actorless_event_as_human() -> None:
+    """Fail closed: an event with no numeric id proves nothing about the lane."""
+    result = classify_lane([{"event": "merged", "actor": None}], BOT_IDS)
+
+    assert result.lane == "human"
+    assert result.human_click_detected is True
+
+
+def test_classify_lane_empty_event_list_is_not_a_machine_merge() -> None:
+    """No events = no evidence of a bot merge. Never report `machine` on silence."""
+    result = classify_lane([], BOT_IDS)
+
+    assert result.lane == "human"
+    assert result.human_click_detected is True
+
+
+# ---------------------------------------------------------------------------
+# assert_pr_union — C4's contract
+# ---------------------------------------------------------------------------
+
+
+def test_assert_pr_union_superset() -> None:
+    assert assert_pr_union(["1.0.0", "1.1.0", "latest"], ["1.0.0", "1.1.0"]) == (
+        True,
+        [],
+    )
+
+
+def test_assert_pr_union_reports_missing_tags() -> None:
+    assert assert_pr_union(["1.0.0"], ["1.0.0", "1.1.0"]) == (False, ["1.1.0"])
+
+
+def test_assert_pr_union_empty_expected_is_trivially_true() -> None:
+    assert assert_pr_union([], []) == (True, [])
+
+
+# ---------------------------------------------------------------------------
+# redact_secrets — Key Decision D-4
+# ---------------------------------------------------------------------------
+
+
+def test_redact_secrets_replaces_every_occurrence() -> None:
+    token = "ghp_liveTokenValue"
+    text = f"Authorization: Bearer {token}\nretrying with {token}"
+
+    out = redact_secrets(text, [token])
+
+    assert token not in out
+    assert out.count("***REDACTED***") == 2
+
+
+def test_redact_secrets_reaches_into_a_url_query_string() -> None:
+    token = "ghp_liveTokenValue"
+    text = f"GET https://api.github.com/repos/ocx-sh/index/pulls?access_token={token}&per_page=1"
+
+    out = redact_secrets(text, [token])
+
+    assert token not in out
+    assert "***REDACTED***&per_page=1" in out
+
+
+def test_redact_secrets_ignores_an_empty_secret() -> None:
+    """An unset `OCX_ANNOUNCE_TOKEN` must not redact the entire log."""
+    text = "nothing secret here"
+
+    assert redact_secrets(text, ["", None]) == text  # type: ignore[list-item]
+
+
+def test_redact_secrets_returns_the_redacted_marker_type() -> None:
+    assert isinstance(redact_secrets("x", ["y"]), Redacted)
+
+
+# ---------------------------------------------------------------------------
+# EvidenceRecord — D-4 enforced by type, not by convention
+# ---------------------------------------------------------------------------
+
+
+def _record(**overrides: object) -> EvidenceRecord:
+    fields: dict = {
+        "scenario": "sequenced",
+        "status": "pass",
+        "pr_url": Redacted("https://github.com/ocx-sh/index/pull/57"),
+        "run_urls": [Redacted("https://github.com/ocx-sh/index/actions/runs/1")],
+        "latency_seconds": 107.0,
+        "notes": Redacted("validate.yml green"),
+        "captured_at": "2026-07-24T10:02:00Z",
+    }
+    fields.update(overrides)
+    return EvidenceRecord(**fields)
+
+
+def test_evidence_record_accepts_redacted_free_text() -> None:
+    assert _record().scenario == "sequenced"
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"notes": "raw capture with a ghp_ token in it"},
+        {"pr_url": "https://github.com/ocx-sh/index/pull/57"},
+        {"run_urls": ["https://github.com/ocx-sh/index/actions/runs/1"]},
+    ],
+)
+def test_evidence_record_rejects_unredacted_free_text(overrides: dict) -> None:
+    """The render path cannot be handed raw text — the record refuses to hold it."""
+    with pytest.raises(TypeError):
+        _record(**overrides)
+
+
+def test_evidence_record_accepts_a_null_pr_url() -> None:
+    assert _record(pr_url=None).pr_url is None
+
+
+# ---------------------------------------------------------------------------
+# render_evidence_markdown
+# ---------------------------------------------------------------------------
+
+
+def test_render_includes_scenario_and_status_of_every_record() -> None:
+    out = render_evidence_markdown(
+        [_record(), _record(scenario="idempotency", status="fail")]
+    )
+
+    assert "sequenced" in out
+    assert "idempotency" in out
+    assert "pass" in out
+    assert "fail" in out
+
+
+def test_render_writes_missing_for_a_none_field() -> None:
+    out = render_evidence_markdown([_record(pr_url=None, latency_seconds=None)])
+
+    assert MISSING in out
+    assert "None" not in out
+
+
+def test_render_of_an_empty_set_still_lists_every_scenario() -> None:
+    """The bare template: five placeholder rows, every cell MISSING."""
+    out = render_evidence_markdown([])
+
+    for scenario in (
+        "sequenced",
+        "idempotency",
+        "machine_lane",
+        "update_union",
+        "clean_install",
+    ):
+        assert scenario in out
+    assert out.count(MISSING) >= 5
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes — the machine-lane driver branches on these, not on JSON text
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_exit"),
+    [
+        ("pr_events_machine_lane", 0),
+        ("pr_events_human_lane", 1),
+        ("pr_events_recycled_login", 1),
+    ],
+)
+def test_classify_lane_require_machine_exit_code(
+    name: str, expected_exit: int, capsys: pytest.CaptureFixture[str]
+) -> None:
+    exit_code = main(
+        [
+            "classify-lane",
+            "--file",
+            str(FIXTURES / f"{name}.json"),
+            "--bot-actor-ids",
+            "198765432",
+            "--require-machine",
+        ]
+    )
+    capsys.readouterr()
+
+    assert exit_code == expected_exit
+
+
+def test_secrets_arrive_by_env_name_never_by_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A secret on argv is readable from /proc/<pid>/cmdline, so the CLI takes
+    the variable NAME and reads the value itself."""
+    monkeypatch.setenv("E2E_FAKE_TOKEN", "ghp_notreal")
+    out = tmp_path / "x.record.json"
+
+    main(
+        [
+            "record",
+            "--scenario",
+            "sequenced",
+            "--status",
+            "pass",
+            "--notes",
+            "leaked ghp_notreal into the log",
+            "--secrets-env",
+            "E2E_FAKE_TOKEN",
+            "--out",
+            str(out),
+        ]
+    )
+    capsys.readouterr()
+
+    written = out.read_text()
+    assert "ghp_notreal" not in written
+    assert REDACTION in written
+
+
+def test_an_unredacted_run_must_be_stated_not_defaulted() -> None:
+    """Neither flag is an error: an empty secret list can never happen by
+    omission, only by an explicit --no-secrets."""
+    with pytest.raises(SystemExit):
+        main(["redact"])
+
+
+def test_render_of_an_empty_set_matches_the_committed_results_template() -> None:
+    """The committed artifact's table is exactly what an empty render produces.
+
+    Track E and Track F read that file; if the renderer and the template drift,
+    a filled-in run stops being comparable to the skeleton it replaced.
+    """
+    artifact = (
+        Path(__file__).parents[2] / ".claude" / "artifacts" / "e2e_results_announce.md"
+    )
+    body = artifact.read_text().split("<!-- BEGIN evidence table")[1]
+    table = body.split("-->\n", 1)[1].split("<!-- END evidence table -->")[0]
+
+    assert table == render_evidence_markdown([])


### PR DESCRIPTION
Lands the Track D live announce drivers on `main`. Owner granted **G-4** on
2026-07-26; until now this work lived only on the `announce/d` branch.

## Why these exist

Each test belongs in the cheapest harness that can still fail for the real
reason. The ocx pytest suite doubles the forge; the index bot's suite doubles
the registry. **These drivers double nothing** — real GHCR, real
`ocx-sh/index`, the real bot, real `index.ocx.sh` — so they are the only thing
that can prove neither double is lying.

Today's machine-lane run is the case in point: it produced two Block-tier
defects that every doubled harness had passed —
[#228](https://github.com/ocx-sh/ocx/issues/228) and
[ocx-sh/index#67](https://github.com/ocx-sh/index/issues/67).

## Contents

| Path | What |
|---|---|
| `test/manual/announce-e2e/scripts/` | six drivers + the shared `env.sh` |
| `test/src/announce_e2e/evidence.py` | lane classification, latency, redacted records |
| `test/tests/test_announce_e2e_evidence.py` | 40 specification tests over six fixtures |
| `.claude/artifacts/e2e_results_announce.md` | the durable evidence table |

Two design points worth reading rather than skimming:

- **Secrets reach the evidence module by env var NAME, never by value.** A
  value on `argv` is readable from `/proc/<pid>/cmdline` for the life of the
  call.
- **Lane classification keys on numeric GitHub actor ids, never login
  strings** (Key Decision D-3) — a recycled login cannot forge a machine-lane
  verdict. There is a fixture for exactly that case.
  `classify-lane --require-machine` turns the verdict into an exit code, so no
  assertion depends on how JSON happens to be spaced.

## Committed state of the evidence table

`e2e_results_announce.md` lands **empty**, and
`test_announce_e2e_evidence.py` pins it byte-identical to what an empty render
produces. Filling it in is therefore a deliberate follow-up, never a side
effect of a run. Worth flagging: the file's own instructions say "replace the
table below with that output, then commit", which the test currently forbids —
a small tension to resolve when the first full evidence set is recorded.

## Two driver bugs recorded, not fixed

Both surfaced today on the retract-and-retry path and both silently certify
against the **wrong artifact**:

1. `poll_run` matches a **stale** workflow run when a tag is retracted and
   re-pushed — same workflow + ref + sha, so the previous run satisfies it
   before the new one starts.
2. `pr_number()` uses `--state all`, so it can lock onto a **closed** pull
   request.

They are left in place rather than fixed inside a landing PR. The `1.0.5`
machine-lane verdict was taken by running the post-merge assertions directly
against the pull request, not by trusting the driver's exit code.

## Verification

`task verify --force` → exit **0**; 1792 passed, 42 skipped, 3 xfailed,
2 xpassed.

Two fresh-worktree gate artifacts, environmental rather than diff-caused, in
case CI hits them: submodules must be initialised (otherwise
`arch-principles.md`'s `external/**/*.rs` glob reads as dead and clippy exits
101), and `task schema` must run before pytest (otherwise seven
`test_schema.py` cases fail on an absent generated
`website/src/public/schemas/metadata/v1.json`).

No production code changes — `crates/**` is untouched.
