### PR TITLE
fix(announce): rebuild from the base when the announce branch is spent

### DIFF
--- a/crates/ocx_lib/src/announce.rs
+++ b/crates/ocx_lib/src/announce.rs
@@ -37,7 +37,7 @@ use std::collections::BTreeMap;
 
 use serde_json::Value;
 
-use crate::forge::{ForkIdentity, GitHubForge, RepoCoordinate};
+use crate::forge::{BranchComparison, ForkIdentity, GitHubForge, RefUpdate, RepoCoordinate};
 use crate::oci::index::serialize_root;
 use crate::publisher::Publisher;
 
@@ -78,12 +78,20 @@ pub async fn announce(
     };
     let fork_coordinate = existing_fork.as_ref().map(ForkIdentity::coordinate);
 
-    // 1. Read the committed root (C10), from the fork branch head when it exists
-    //    (C4) so sequential announces accumulate, else from the index main.
+    // 0b. Is the announce branch still carrying work, or is it residue?
+    //     The branch is per package (C4) and outlives every pull request opened
+    //     from it, so its mere existence says nothing. Accumulating onto a spent
+    //     branch re-proposes already-merged commits and the pull request
+    //     conflicts on the root file every announce edits (#228).
+    let branch_state = resolve_branch_state(forge, &request.index_repo, fork_coordinate.as_ref(), &branch).await?;
+
+    // 1. Read the committed root (C10), from the fork branch head while the
+    //    branch is live (C4) so sequential announces accumulate, else from the
+    //    index main.
     let root_read = read_committed_root(
         forge,
         &request.index_repo,
-        fork_coordinate.as_ref(),
+        fork_coordinate.as_ref().filter(|_| branch_state.is_live()),
         &root_path,
         &branch,
     )
@@ -145,16 +153,14 @@ pub async fn announce(
                 // on the branch that the index base does not have. Such a run
                 // may have committed content whose pull request then failed to
                 // open, stranding the update; ensure an open PR exists so it is
-                // never lost (design register C6 amendment). The predicate is
-                // genuine ancestry, not mere branch existence: a branch sitting
-                // at (or already merged into) the base carries nothing
-                // unmerged, and ensuring a PR for it would open a spurious
-                // empty one on every unchanged run.
+                // never lost (design register C6 amendment). `branch_sha` is
+                // `Some` only for a LIVE branch, which is the whole predicate:
+                // a branch sitting at, already merged into, or squash-merged
+                // away from the base carries nothing unmerged, and opening a
+                // pull request for it produces the unmergeable one #228 is
+                // about.
                 if let Some(fork) = &existing_fork
                     && root_read.branch_sha.is_some()
-                    && forge
-                        .branch_is_ahead(&request.index_repo, INDEX_BASE_REF, &fork.owner, &branch)
-                        .await?
                 {
                     let pull_request = forge
                         .open_or_update_pull_request(
@@ -186,8 +192,10 @@ pub async fn announce(
             }
             // C8: reuse the already-resolved fork, else create one under the
             // requested owner (S12 shared fork), then commit onto the
-            // accumulating branch head (C4) or the upstream base SHA (C8, first
-            // announce) — one atomic multi-file commit (C15).
+            // accumulating branch head (C4, live branch) or the upstream base
+            // SHA (C8 — first announce, and equally a spent branch, whose head
+            // `read_committed_root` was told to ignore) — one atomic multi-file
+            // commit (C15).
             let fork = match existing_fork {
                 Some(fork) => fork,
                 None => forge.ensure_fork(&request.index_repo, Some(&target.owner)).await?,
@@ -207,7 +215,14 @@ pub async fn announce(
             // and retry exactly once so the concurrent change is preserved,
             // never overwritten.
             match forge
-                .commit_files(&fork.coordinate(), &branch, &base_sha, &message, &files)
+                .commit_files(
+                    &fork.coordinate(),
+                    &branch,
+                    &base_sha,
+                    &message,
+                    &files,
+                    branch_state.ref_update(),
+                )
                 .await
             {
                 Ok(_) => {}
@@ -250,7 +265,18 @@ pub async fn announce(
                         status = AnnounceStatus::Unchanged;
                     } else {
                         forge
-                            .commit_files(&fork.coordinate(), &branch, &head_sha, &message, &merged.files)
+                            // The winning head IS our base now, so this is a
+                            // fast-forward by construction — and it must stay
+                            // CAS-checked, since a third announce could have
+                            // advanced the branch again while we regenerated.
+                            .commit_files(
+                                &fork.coordinate(),
+                                &branch,
+                                &head_sha,
+                                &message,
+                                &merged.files,
+                                RefUpdate::FastForward,
+                            )
                             .await?;
                     }
                 }
@@ -358,6 +384,89 @@ struct RootRead {
 /// Reading the branch through the verified coordinate rather than the raw
 /// `--fork` value is what makes C4 accumulation work for a fork renamed away
 /// from the upstream's repository name.
+/// What the per-package announce branch on the fork is currently worth.
+///
+/// The branch name is derived from the package alone, so it outlives every pull
+/// request opened from it. "The ref exists" therefore answers nothing on its own,
+/// and reading it that way is what made a second announce for a package
+/// unmergeable once the first one's pull request had been squash-merged
+/// (ocx-sh/ocx#228).
+enum BranchState {
+    /// No announce branch on the fork — the first announce for this package.
+    Absent,
+    /// The branch is still carrying work: an open pull request holds it, or its
+    /// commits fast-forward onto the index base. Accumulate onto it (C4), so two
+    /// announces before a merge land in one pull request with both tag sets.
+    Live,
+    /// The branch exists and carries nothing the base needs — its pull request
+    /// merged (leaving it `Diverged` under a squash merge, `Behind` under a merge
+    /// commit) or was closed unmerged. Residue: rebuild from the base and repoint
+    /// the ref at the result.
+    Spent,
+}
+
+impl BranchState {
+    /// Whether the branch may serve as the base for this announce.
+    fn is_live(&self) -> bool {
+        matches!(self, Self::Live)
+    }
+
+    /// How the ref update must behave. Repointing a spent branch at a commit
+    /// built on the upstream base is deliberately not a fast-forward — refusing
+    /// the rewrite would preserve the already-merged commits that make the branch
+    /// unusable in the first place.
+    fn ref_update(&self) -> RefUpdate {
+        match self {
+            Self::Spent => RefUpdate::Reset,
+            Self::Absent | Self::Live => RefUpdate::FastForward,
+        }
+    }
+}
+
+/// Classify the announce branch (see [`BranchState`]).
+///
+/// Ancestry is asked first and unconditionally, so an indeterminate or
+/// unmodelled compare fails closed on **every** run rather than only on the runs
+/// that happen to reach it. Three of the four answers are decisive on their own;
+/// only [`BranchComparison::Diverged`] needs a second question, because git
+/// cannot tell "my commits were squash-merged and the base now carries them"
+/// from "my commits are unmerged and the base moved on underneath me". An open
+/// pull request means the latter.
+async fn resolve_branch_state(
+    forge: &GitHubForge,
+    index_repo: &RepoCoordinate,
+    fork: Option<&RepoCoordinate>,
+    branch: &str,
+) -> Result<BranchState, AnnounceError> {
+    let Some(fork) = fork else {
+        return Ok(BranchState::Absent);
+    };
+    if forge.get_ref_sha(fork, &format!("heads/{branch}")).await?.is_none() {
+        return Ok(BranchState::Absent);
+    }
+    match forge
+        .compare_branch(index_repo, INDEX_BASE_REF, &fork.owner, branch)
+        .await?
+    {
+        // Strictly ahead: the commits are unmerged and they fast-forward, so
+        // keep them whether or not a pull request is open — when none is, the
+        // C6 amendment opens the one they never got.
+        BranchComparison::Ahead => Ok(BranchState::Live),
+        BranchComparison::Identical | BranchComparison::Behind => Ok(BranchState::Spent),
+        BranchComparison::Diverged => {
+            if forge
+                .find_open_pull_request(index_repo, &fork.owner, branch)
+                .await?
+                .is_some()
+            {
+                Ok(BranchState::Live)
+            } else {
+                Ok(BranchState::Spent)
+            }
+        }
+    }
+}
+
 async fn read_committed_root(
     forge: &GitHubForge,
     index_repo: &RepoCoordinate,

--- a/crates/ocx_lib/src/forge.rs
+++ b/crates/ocx_lib/src/forge.rs
@@ -28,7 +28,7 @@ mod identity;
 mod poll;
 
 pub use error::ForgeError;
-pub use github::GitHubForge;
+pub use github::{BranchComparison, GitHubForge, RefUpdate};
 
 /// Announce credential, sourced from `OCX_ANNOUNCE_TOKEN`.
 ///

--- a/crates/ocx_lib/src/forge/github.rs
+++ b/crates/ocx_lib/src/forge/github.rs
@@ -41,6 +41,58 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// Fixed delay before the single fresh-fork write retry (design register X5).
 const FRESH_FORK_RETRY_DELAY: Duration = Duration::from_secs(3);
 
+/// How a branch stands relative to a base ref, as GitHub's compare API reports it.
+///
+/// The distinction that matters to announce is [`Ahead`](Self::Ahead) versus
+/// [`Diverged`](Self::Diverged), and it is not cosmetic. An `Ahead` branch
+/// fast-forwards onto the base, so appending to it always produces a mergeable
+/// pull request. A `Diverged` branch does not — and the ordinary way an announce
+/// branch becomes `Diverged` is that its pull request was **squash-merged**, which
+/// puts its content on the base under a new commit while leaving none of its own
+/// commits in the base's history. Appending there re-proposes work that is already
+/// merged, and the pull request conflicts on the very file every announce edits
+/// (ocx-sh/ocx#228).
+///
+/// Git alone cannot tell that case apart from "my commits are genuinely unmerged
+/// and the base moved on underneath me", so `Diverged` is never a verdict by
+/// itself: the caller pairs it with whether an open pull request still exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BranchComparison {
+    /// The branch is the base commit.
+    Identical,
+    /// The branch holds commits the base does not, and the base holds none the
+    /// branch does not — a fast-forward.
+    Ahead,
+    /// The base has moved on; the branch holds nothing of its own.
+    Behind,
+    /// Both sides hold commits the other does not.
+    Diverged,
+}
+
+/// Whether a ref update may rewrite history.
+///
+/// [`FastForward`](Self::FastForward) is the default and the one every ordinary
+/// announce uses: it is the compare-and-swap that makes a concurrent announce
+/// surface as [`ForgeError::NonFastForward`] instead of being silently
+/// overwritten (design register C4). [`Reset`](Self::Reset) is reserved for the
+/// one case where a non-fast-forward is the *intent* — repointing a spent
+/// announce branch at the upstream base, where refusing to rewrite would preserve
+/// exactly the already-merged commits that make the branch unusable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefUpdate {
+    /// Reject an update that is not a fast-forward.
+    FastForward,
+    /// Repoint the ref even when the new commit is not a descendant.
+    Reset,
+}
+
+impl RefUpdate {
+    /// The value GitHub's ref-update endpoint expects in its `force` field.
+    fn force(self) -> bool {
+        matches!(self, Self::Reset)
+    }
+}
+
 /// GitHub REST forge client.
 ///
 /// One no-redirect [`reqwest::Client`] per instance (design register X5); the
@@ -265,18 +317,28 @@ impl GitHubForge {
     }
 
     /// Point `refs/heads/<branch>` at `commit_sha`, creating the ref when it
-    /// does not yet exist. The update is **fast-forward-only** (compare-and-swap,
-    /// design register C4): a non-fast-forward — a concurrent announce advanced
-    /// the branch — surfaces as [`ForgeError::NonFastForward`] for the caller to
-    /// re-read and retry, never a silent force-overwrite.
+    /// does not yet exist.
+    ///
+    /// Under [`RefUpdate::FastForward`] — every ordinary announce — the update is
+    /// a compare-and-swap (design register C4): a non-fast-forward, meaning a
+    /// concurrent announce advanced the branch, surfaces as
+    /// [`ForgeError::NonFastForward`] for the caller to re-read and retry, never
+    /// a silent force-overwrite. Under [`RefUpdate::Reset`] the rewrite is the
+    /// point, so no such rejection can occur.
     ///
     /// A rejected update costs one extra request: GitHub reports "absent ref"
     /// and "not a fast-forward" with the same 422, so the ref is read to tell
     /// them apart. That read is off the happy path entirely — a successful
     /// update returns without it.
-    async fn upsert_branch(&self, repo: &RepoCoordinate, branch: &str, commit_sha: &str) -> Result<(), ForgeError> {
+    async fn upsert_branch(
+        &self,
+        repo: &RepoCoordinate,
+        branch: &str,
+        commit_sha: &str,
+        update: RefUpdate,
+    ) -> Result<(), ForgeError> {
         let update_url = self.url(&format!("/repos/{}/{}/git/refs/heads/{branch}", repo.owner, repo.repo));
-        let update_body = json!({ "sha": commit_sha, "force": false });
+        let update_body = json!({ "sha": commit_sha, "force": update.force() });
         let (status, _) = self
             .send(
                 self.json_request(Method::PATCH, &update_url, &update_body)?,
@@ -382,13 +444,13 @@ impl GitHubForge {
         Ok(Some(sha.to_string()))
     }
 
-    /// Whether `head_owner:head_branch` carries commits `base` does not.
+    /// How `head_owner:head_branch` stands relative to `base`.
     ///
     /// One compare call answers ancestry exactly, which a bare ref-SHA equality
-    /// check cannot: GitHub reports `identical` when the branch *is* the base
-    /// and `behind` when it is an ancestor of the base (both "not ahead" —
-    /// nothing unmerged to recover), against `ahead` / `diverged` when the
-    /// branch holds commits of its own.
+    /// check cannot. The four states are kept distinct rather than collapsed to
+    /// a boolean because [`BranchComparison::Diverged`] and
+    /// [`BranchComparison::Ahead`] demand *opposite* handling — see that type's
+    /// documentation.
     ///
     /// Fails closed on anything else. A 404 here is an **indeterminate** compare,
     /// not a verdict: the only caller asks this after already observing that the
@@ -407,13 +469,13 @@ impl GitHubForge {
     /// Returns a [`ForgeError`] on transport failure, any non-success status
     /// (404 included), a missing `status` field, or a `status` value the client
     /// does not model.
-    pub async fn branch_is_ahead(
+    pub async fn compare_branch(
         &self,
         repo: &RepoCoordinate,
         base: &str,
         head_owner: &str,
         head_branch: &str,
-    ) -> Result<bool, ForgeError> {
+    ) -> Result<BranchComparison, ForgeError> {
         let url = self.url(&format!(
             "/repos/{}/{}/compare/{base}...{head_owner}:{head_branch}",
             repo.owner, repo.repo
@@ -431,7 +493,43 @@ impl GitHubForge {
                 url: url.clone(),
                 field: "status".to_string(),
             })?;
-        compare_status_is_ahead(&url, status)
+        parse_compare_status(&url, status)
+    }
+
+    /// The open pull request whose head is `head_owner:branch`, or `None`.
+    ///
+    /// Read-only, and deliberately scoped to **open** pull requests: the
+    /// announce branch is per package and outlives every pull request opened
+    /// from it, so "a pull request exists" is not the same question as "this
+    /// branch is still carrying one".
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ForgeError`] on transport failure, a non-success status, or
+    /// a malformed pull-request response body.
+    pub async fn find_open_pull_request(
+        &self,
+        index: &RepoCoordinate,
+        head_owner: &str,
+        branch: &str,
+    ) -> Result<Option<PullRequest>, ForgeError> {
+        let pulls_url = self.url(&format!("/repos/{}/{}/pulls", index.owner, index.repo));
+        let head = pr_head(head_owner, branch);
+        let request = self
+            .request(Method::GET, &pulls_url)
+            .query(&[("head", head.as_str()), ("state", "open")]);
+        let (status, body) = self.send(request, &pulls_url).await?;
+        if !status.is_success() {
+            return Err(ForgeError::Status {
+                url: pulls_url,
+                status: status.as_u16(),
+            });
+        }
+        let list = Self::parse_json(&pulls_url, &body)?;
+        let Some(existing) = list.as_array().and_then(|pulls| pulls.first()) else {
+            return Ok(None);
+        };
+        pull_request_from_body(&pulls_url, existing, true).map(Some)
     }
 
     /// Look up an existing fork of `upstream` at `fork`, **without creating
@@ -549,11 +647,16 @@ impl GitHubForge {
         base_sha: &str,
         message: &str,
         files: &BTreeMap<String, Vec<u8>>,
+        update: RefUpdate,
     ) -> Result<String, ForgeError> {
-        match self.commit_files_once(repo, branch, base_sha, message, files).await {
+        match self
+            .commit_files_once(repo, branch, base_sha, message, files, update)
+            .await
+        {
             Err(error) if is_fresh_fork_race(&error) => {
                 tokio::time::sleep(FRESH_FORK_RETRY_DELAY).await;
-                self.commit_files_once(repo, branch, base_sha, message, files).await
+                self.commit_files_once(repo, branch, base_sha, message, files, update)
+                    .await
             }
             result => result,
         }
@@ -568,6 +671,7 @@ impl GitHubForge {
         base_sha: &str,
         message: &str,
         files: &BTreeMap<String, Vec<u8>>,
+        update: RefUpdate,
     ) -> Result<String, ForgeError> {
         let base_tree_sha = self.base_tree_sha(repo, base_sha).await?;
         let mut tree_entries = Vec::with_capacity(files.len());
@@ -577,7 +681,7 @@ impl GitHubForge {
         }
         let tree_sha = self.create_tree(repo, &base_tree_sha, tree_entries).await?;
         let commit_sha = self.create_commit(repo, message, &tree_sha, base_sha).await?;
-        self.upsert_branch(repo, branch, &commit_sha).await?;
+        self.upsert_branch(repo, branch, &commit_sha, update).await?;
         Ok(commit_sha)
     }
 
@@ -620,25 +724,12 @@ impl GitHubForge {
                 status: status.as_u16(),
             });
         }
-        let request = self
-            .request(Method::GET, &pulls_url)
-            .query(&[("head", head.as_str()), ("state", "open")]);
-        let (list_status, list_body) = self.send(request, &pulls_url).await?;
-        if !list_status.is_success() {
-            return Err(ForgeError::Status {
-                url: pulls_url,
-                status: list_status.as_u16(),
-            });
-        }
-        let list = Self::parse_json(&pulls_url, &list_body)?;
-        let existing = list
-            .as_array()
-            .and_then(|pulls| pulls.first())
+        self.find_open_pull_request(index, head_owner, branch)
+            .await?
             .ok_or_else(|| ForgeError::MissingField {
-                url: pulls_url.clone(),
+                url: pulls_url,
                 field: "pull_request".to_string(),
-            })?;
-        pull_request_from_body(&pulls_url, existing, true)
+            })
     }
 }
 
@@ -679,10 +770,12 @@ fn pr_head(head_owner: &str, branch: &str) -> String {
 /// Exhaustive over GitHub's documented four values; an unmodelled value is an
 /// error, never a guess — a wrong "not ahead" strands a committed announce with
 /// no pull request (design register C6 amendment).
-fn compare_status_is_ahead(url: &str, status: &str) -> Result<bool, ForgeError> {
+fn parse_compare_status(url: &str, status: &str) -> Result<BranchComparison, ForgeError> {
     match status {
-        "ahead" | "diverged" => Ok(true),
-        "identical" | "behind" => Ok(false),
+        "identical" => Ok(BranchComparison::Identical),
+        "ahead" => Ok(BranchComparison::Ahead),
+        "behind" => Ok(BranchComparison::Behind),
+        "diverged" => Ok(BranchComparison::Diverged),
         unknown => Err(ForgeError::UnknownCompareStatus {
             url: url.to_string(),
             status: unknown.to_string(),
@@ -904,7 +997,7 @@ mod tests {
         .expect("fake forge starts");
 
         fake.forge()
-            .upsert_branch(&test_repo(), BRANCH, "commitsha")
+            .upsert_branch(&test_repo(), BRANCH, "commitsha", RefUpdate::FastForward)
             .await
             .expect("an absent ref is created, not reported as a conflict");
 
@@ -932,7 +1025,7 @@ mod tests {
 
         let error = fake
             .forge()
-            .upsert_branch(&test_repo(), BRANCH, "commitsha")
+            .upsert_branch(&test_repo(), BRANCH, "commitsha", RefUpdate::FastForward)
             .await
             .expect_err("a present ref that rejected the update is a conflict");
 
@@ -954,7 +1047,7 @@ mod tests {
         .expect("fake forge starts");
 
         fake.forge()
-            .upsert_branch(&test_repo(), BRANCH, "commitsha")
+            .upsert_branch(&test_repo(), BRANCH, "commitsha", RefUpdate::FastForward)
             .await
             .expect("a successful update needs nothing else");
 
@@ -981,7 +1074,7 @@ mod tests {
 
         let error = fake
             .forge()
-            .upsert_branch(&test_repo(), BRANCH, "commitsha")
+            .upsert_branch(&test_repo(), BRANCH, "commitsha", RefUpdate::FastForward)
             .await
             .expect_err("a lost create race is a conflict");
 
@@ -1002,7 +1095,7 @@ mod tests {
 
         let error = fake
             .forge()
-            .upsert_branch(&test_repo(), BRANCH, "commitsha")
+            .upsert_branch(&test_repo(), BRANCH, "commitsha", RefUpdate::FastForward)
             .await
             .expect_err("an unmodelled status must surface");
 
@@ -1032,26 +1125,40 @@ mod tests {
     }
 
     #[test]
-    fn compare_status_ahead_and_diverged_carry_unmerged_commits() {
-        assert!(compare_status_is_ahead("https://api", "ahead").expect("modelled"));
-        assert!(compare_status_is_ahead("https://api", "diverged").expect("modelled"));
-    }
-
-    #[test]
-    fn compare_status_identical_and_behind_carry_nothing_unmerged() {
-        assert!(!compare_status_is_ahead("https://api", "identical").expect("modelled"));
-        assert!(!compare_status_is_ahead("https://api", "behind").expect("modelled"));
+    fn compare_status_maps_each_github_value_to_its_own_state() {
+        // `ahead` and `diverged` must NOT collapse together: appending to an
+        // `ahead` branch fast-forwards, appending to a `diverged` one re-proposes
+        // squash-merged commits and conflicts (#228).
+        for (status, expected) in [
+            ("identical", BranchComparison::Identical),
+            ("ahead", BranchComparison::Ahead),
+            ("behind", BranchComparison::Behind),
+            ("diverged", BranchComparison::Diverged),
+        ] {
+            assert_eq!(
+                parse_compare_status("https://api", status).expect("modelled"),
+                expected,
+                "status {status}"
+            );
+        }
     }
 
     #[test]
     fn compare_status_unmodelled_value_errors_instead_of_guessing() {
-        // A wrong "not ahead" strands a committed announce with no pull
-        // request, so an unrecognized value must surface, never default.
-        let error = compare_status_is_ahead("https://api", "sideways").expect_err("unmodelled status must error");
+        // Every wrong verdict here is silent: guessing "spent" discards an
+        // unmerged announce, guessing "live" rebuilds the #228 conflict. An
+        // unrecognized value must surface, never default.
+        let error = parse_compare_status("https://api", "sideways").expect_err("unmodelled status must error");
         assert!(matches!(
             error,
             ForgeError::UnknownCompareStatus { ref status, .. } if status == "sideways"
         ));
+    }
+
+    #[test]
+    fn only_a_reset_forces_the_ref_update() {
+        assert!(!RefUpdate::FastForward.force());
+        assert!(RefUpdate::Reset.force());
     }
 
     #[test]

--- a/test/tests/fake_forge.py
+++ b/test/tests/fake_forge.py
@@ -323,6 +323,26 @@ class FakeForge(http.server.ThreadingHTTPServer):
             self.refs.setdefault(full, {})[branch] = self.refs[source_full][source_branch]
             self.repos.setdefault(full, {"full_name": full, "owner": owner, "parent": source_full})
 
+    def close_pull_request(self, owner: str, repo: str, head: str) -> None:
+        """Drop the open pull request whose head is `head` (`"<owner>:<branch>"`),
+        leaving its branch in place. Models both halves of the trap #228 is about:
+        a merged pull request and a closed-unmerged one look identical from the
+        branch's side, because the branch is per package and outlives either."""
+        with self.lock:
+            self.open_prs.get((owner, repo), {}).pop(head, None)
+
+    def commit_parent(self, owner: str, repo: str, branch: str) -> str | None:
+        """The parent sha of `branch`'s head commit — what a committed announce
+        was actually built ON, as opposed to what it contains."""
+        with self.lock:
+            head = self.refs.get(f"{owner}/{repo}", {}).get(branch)
+            return None if head is None else self.commits[head]["parent"]
+
+    def branch_head(self, owner: str, repo: str, branch: str) -> str | None:
+        """The head sha of `branch`, or `None` when the ref does not exist."""
+        with self.lock:
+            return self.refs.get(f"{owner}/{repo}", {}).get(branch)
+
     def _seed_files_locked(self, owner: str, repo: str, files: dict[str, bytes], branch: str) -> None:
         """Commit `files` onto `branch`, advancing its head (caller holds `self.lock`)."""
         full = f"{owner}/{repo}"
@@ -530,16 +550,31 @@ class FakeForge(http.server.ThreadingHTTPServer):
 
     def handle_patch_ref(self, handler: _Handler, owner: str, repo: str, branch: str, body: dict[str, Any]) -> None:
         force = body.get("force")
-        if force is not False:
-            # The branch update is fast-forward-only CAS (design register C4
-            # amendment F2): the client must state `force: false` explicitly.
-            # A regression to `force: true` (or a dropped field) answers with a
-            # status the client models nowhere, so it surfaces as a hard failure
-            # instead of silently passing through the 422 retry branch.
-            handler._reply_json(400, {"message": f"expected force:false, got {force!r}"})
+        if force not in (True, False):
+            # The client must STATE the field, never leave it to GitHub's
+            # default: a dropped field would silently pick a rewrite policy
+            # nobody chose. A missing value answers with a status the client
+            # models nowhere, so it surfaces as a hard failure instead of
+            # passing through the 422 retry branch.
+            handler._reply_json(400, {"message": f"expected an explicit force flag, got {force!r}"})
             return
         full = f"{owner}/{repo}"
         key = f"{full}/{branch}"
+        if force:
+            # `force: true` repoints the ref unconditionally — no CAS, no
+            # ancestry check, and no "reference does not exist" split, because
+            # GitHub creates nothing here either way. This is the announce
+            # branch-reset path (#228); a concurrent-advance injection is
+            # deliberately NOT consulted, since a reset is not racing anyone for
+            # a fast-forward.
+            with self.lock:
+                if branch not in self.refs.get(full, {}):
+                    handler._reply_json(422, {"message": "Reference does not exist"})
+                    return
+                sha = body.get("sha")
+                self.refs[full][branch] = sha
+            handler._reply_json(200, {"object": {"sha": sha}})
+            return
         with self.lock:
             advance = self.concurrent_ref_advance.pop(key, None)
             if advance is not None:

--- a/test/tests/test_announce.py
+++ b/test/tests/test_announce.py
@@ -25,6 +25,8 @@ from pathlib import Path
 from announce_helpers import (
     FIXED_CLOCK,
     INDEX_FULL,
+    INDEX_OWNER,
+    INDEX_REPO,
     TOKEN,
     announce,
     announce_json,
@@ -665,6 +667,89 @@ def test_announce_tags_file_union_adds_without_dropping(
     tags_file.write_text("2.0.0")
     announce_json(ocx, fake_forge, *args, "--tags-file", str(tags_file))
 
+    assert set(committed_root(fake_forge, package)["tags"]) == {"1.0.0", "2.0.0"}
+
+
+def _squash_merge_the_announce(fake_forge: FakeForge, package: str) -> None:
+    """Land the fork branch's root on the index base the way `ocx-sh/index`
+    actually merges — a **squash**: the content arrives under a brand-new commit
+    and none of the branch's own commits become ancestors of `main`. Then close
+    the pull request, leaving the per-package branch behind, because that is what
+    GitHub does."""
+    root_path = f"p/{package}.json"
+    merged = committed_root(fake_forge, package)
+    fake_forge.seed_root(INDEX_OWNER, INDEX_REPO, root_path, merged)
+    fake_forge.close_pull_request(INDEX_OWNER, INDEX_REPO, f"forkuser:{branch_name(package)}")
+
+
+def test_announce_after_its_pull_request_squash_merges_rebuilds_from_the_base(
+    ocx: OcxRunner, fake_forge: FakeForge, unique_repo: str, tmp_path: Path
+) -> None:
+    """The second announce for a package must not stack on the spent branch.
+
+    Regression for ocx-sh/ocx#228. The announce branch is named from the package
+    alone, so it outlives every pull request opened from it. `ocx-sh/index`
+    squash-merges, which puts the branch's content on `main` under a new commit
+    while leaving none of the branch's own commits in `main`'s history. Basing
+    the next announce on that branch re-proposed the already-merged commits and
+    the pull request conflicted on the one file every announce edits — measured
+    live as 6 commits / 2 changed files / `mergeable_state: dirty`, against
+    1 commit / 1 file / clean once the branch was rebuilt from the base.
+
+    The parent assertion is what discriminates: the tag set alone passes either
+    way, because the merged root is read back in both worlds."""
+    make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=False)
+    make_package(ocx, unique_repo, "2.0.0", tmp_path, new=False, cascade=False)
+    package = f"acme/{unique_repo}"
+    physical = f"oci://{ocx.registry}/{unique_repo}"
+    seed_empty_root(fake_forge, package, physical)
+    configure_trusted_hosts(ocx, ocx.registry, [registry_host(ocx.registry)])
+    args = ["--package", package, "--fork", "forkuser/index", "--index-repo", INDEX_FULL]
+
+    announce_json(ocx, fake_forge, *args, "--tags", "1.0.0")
+    _squash_merge_the_announce(fake_forge, package)
+
+    announce_json(ocx, fake_forge, *args, "--tags", "1.0.0,2.0.0")
+
+    branch = branch_name(package)
+    assert fake_forge.commit_parent("forkuser", "index", branch) == fake_forge.branch_head(
+        INDEX_OWNER, INDEX_REPO, "main"
+    ), "the announce must sit directly on the index base, not on the spent branch"
+    assert set(committed_root(fake_forge, package)["tags"]) == {"1.0.0", "2.0.0"}
+
+
+def test_announce_keeps_accumulating_while_its_pull_request_is_open(
+    ocx: OcxRunner, fake_forge: FakeForge, unique_repo: str, tmp_path: Path
+) -> None:
+    """C4 survives the #228 fix: an OPEN pull request still accumulates.
+
+    The guard against over-correcting. Resetting the branch whenever it does not
+    fast-forward would silently drop announce #1's still-unmerged tag the moment
+    anything else landed on the index base — the exact failure C4's
+    "update, don't overwrite" rule exists to prevent. Here nothing merged, the
+    pull request is still open, and the second announce must build ON the first."""
+    make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=False)
+    make_package(ocx, unique_repo, "2.0.0", tmp_path, new=False, cascade=False)
+    package = f"acme/{unique_repo}"
+    physical = f"oci://{ocx.registry}/{unique_repo}"
+    seed_empty_root(fake_forge, package, physical)
+    configure_trusted_hosts(ocx, ocx.registry, [registry_host(ocx.registry)])
+    args = ["--package", package, "--fork", "forkuser/index", "--index-repo", INDEX_FULL]
+
+    announce_json(ocx, fake_forge, *args, "--tags", "1.0.0")
+    first_head = fake_forge.branch_head("forkuser", "index", branch_name(package))
+
+    # An unrelated commit lands on the index base, so the branch is now
+    # `diverged` from it — with its pull request still open.
+    fake_forge.seed_root(INDEX_OWNER, INDEX_REPO, "p/other/package.json", {"tags": {}})
+
+    tags_file = tmp_path / "tags.txt"
+    tags_file.write_text("2.0.0")
+    announce_json(ocx, fake_forge, *args, "--tags-file", str(tags_file))
+
+    assert (
+        fake_forge.commit_parent("forkuser", "index", branch_name(package)) == first_head
+    ), "an open pull request must keep accumulating onto its own branch"
     assert set(committed_root(fake_forge, package)["tags"]) == {"1.0.0", "2.0.0"}
 
 


### PR DESCRIPTION
Closes #228.

The second announce for a package could never merge once the first one's pull
request had been squash-merged.

## Measured live, on tag `1.0.5`

| | commits | changed files | `mergeable_state` |
|---|---|---|---|
| [ocx-sh/index#65](https://github.com/ocx-sh/index/pull/65) | 6 | 2 | `dirty` — auto-merge could never fire |
| [ocx-sh/index#66](https://github.com/ocx-sh/index/pull/66), after deleting the branch by hand | 1 | 1 | clean, auto-merged |

Same tag, same package. The only difference is which commit the announce was
built on.

## Root cause

The announce branch is named from the package alone, so it outlives every pull
request opened from it. `announce.rs:195-203` chose the new commit's parent on a
single question — *does the branch ref exist* — and `ocx-sh/index` squash-merges,
which puts the branch's content on `main` under a new commit while leaving none
of the branch's own commits in `main`'s history. The next announce stacked on
that branch, re-proposed every already-merged commit, and conflicted on
`p/<ns>/<pkg>.json` — the one file every announce edits.

Underneath it sat a latent classifier defect: `compare_status_is_ahead` folded
`diverged` into `ahead`. Those two demand **opposite** handling. An `ahead`
branch fast-forwards, so appending always yields a mergeable pull request; a
`diverged` one does not — and squash-merge is precisely how an announce branch
becomes `diverged`.

## The fix

`BranchComparison` keeps all four GitHub compare values distinct, and
`BranchState` classifies the branch before anything reads it:

| compare(`main`…`fork:branch`) | open PR? | verdict |
|---|---|---|
| `ahead` | — | **live** — accumulate (C4) |
| `identical` / `behind` | — | **spent** — rebuild from the base |
| `diverged` | yes | **live** — unmerged work, base moved underneath |
| `diverged` | no | **spent** — squash-merged, or closed unmerged |

Git alone cannot separate the last two, which is why the open pull request is
consulted — **but only there**. Ancestry is asked first and unconditionally, so
an indeterminate or unmodelled compare still fails closed on every run. An
earlier ordering that asked about the pull request first silently dropped that
guarantee whenever one was open; two existing tests caught it, which is the
argument for having written them.

Repointing a spent branch is deliberately *not* a fast-forward, so `commit_files`
now takes a `RefUpdate`. `FastForward` stays the default and keeps the C4
compare-and-swap that makes a concurrent announce surface as `NonFastForward`
rather than being overwritten. `Reset` is used for the one case where rewriting
is the intent — refusing it there would preserve exactly the merged commits that
make the branch unusable.

## Test double

The fake forge modelled `force: true` as a hard 400. It now models GitHub: an
explicit flag is still required (a dropped field would let GitHub pick a rewrite
policy nobody chose), `false` keeps the CAS semantics including the
concurrent-advance injection, `true` repoints unconditionally.

## Two tests, dividing the work deliberately

- **`…squash_merges_rebuilds_from_the_base`** asserts the new commit's **parent**
  is the index base. The tag set alone passes either way, because the merged root
  is read back in both worlds — the parent is the only assertion that
  discriminates.
- **`…keeps_accumulating_while_its_pull_request_is_open`** is the guard against
  over-correcting. Resetting whenever the branch failed to fast-forward would
  drop announce #1's still-unmerged tag the moment anything else landed on the
  base — the exact failure C4's "update, don't overwrite" rule exists to prevent.

**Discrimination proven**: with the fix reverted (and the resulting dead-code
lints silenced, so the acceptance binary actually rebuilt rather than a stale one
faking a pass), the squash-merge test fails on its parent assertion while the
accumulate test still passes.

## Verification

`task verify --force` → exit **0**; 1794 passed, 42 skipped, 3 xfailed, 2 xpassed.

## API note

`GitHubForge::commit_files` gains a parameter and `branch_is_ahead` is replaced by
`compare_branch`. `ocx-mirror` links `ocx_lib` but references neither — checked on
disk, no call sites.
