### PR TITLE
fix(e2e): give the announce drivers a server-side freshness floor so they cannot certify off stale artifacts

### DIFF
--- a/test/manual/announce-e2e/README.md
+++ b/test/manual/announce-e2e/README.md
@@ -239,10 +239,11 @@ prove that.
 `_run_concluded` and `pr_number` against recorded `gh` JSON: how the floor is
 read, the floor on both matchers, newest-wins when several observations survive
 it, the polling gate that keeps an unconcluded run from reading as a verdict,
-and the head-repository and branch guards. Two cases give a stale artifact a
-creation time *after* the driver's own `date -u` — what a backward-skewed local
-clock produces — and require it to stay excluded, which is why the floor is a
-counter and not a timestamp. Both matchers used to be able to answer with an
+and the head-repository and branch guards. Two cases give a stale artifact the
+fresh-looking creation time a backward-skewed local clock would have accepted
+and require it to stay excluded — they pin that the matchers read the counter
+and nothing else; they do not replay the old timestamp comparison, which the
+counter signature no longer admits. Both matchers used to be able to answer with an
 earlier rehearsal's run or pull request, which is how a driver reports green off
 stale data — run this after any edit to either. It needs `jq` (test-only: it
 replays the drivers' own `--jq` programs offline, and `gh` embeds its own engine

--- a/test/manual/announce-e2e/README.md
+++ b/test/manual/announce-e2e/README.md
@@ -3,10 +3,11 @@
 Five drivers that prove the fork-PR announce lane works end to end against the
 **real** `ocx-sh/index` — not a sandbox. They are run by hand against live
 infrastructure and verified by checklist; nothing here is pytest-collected. The
-two surfaces that do run unattended are the pure logic in
-`test/src/announce_e2e/` (`cd test && uv run pytest
-tests/test_announce_e2e_evidence.py`) and the (g2) gate's own decision logic
-(`./scripts/selfcheck_g2.sh` — no network, no credentials).
+surfaces that do run unattended are the pure logic in `test/src/announce_e2e/`
+(`cd test && uv run pytest tests/test_announce_e2e_evidence.py`), the (g2)
+gate's own decision logic (`./scripts/selfcheck_g2.sh`) and the run /
+pull-request matchers (`./scripts/selfcheck_identity.sh`) — neither self-check
+touches a network or a credential.
 
 Each run leaves per-scenario evidence under `results/` (gitignored — real pull
 request URLs and live timestamps are scratch). The curated rollup lives in
@@ -115,9 +116,12 @@ request.
 **The branch trap — check this before `1.0.4` and before `1.0.5`.** The announce
 branch is **per-package, not per-tag** (`ANNOUNCE_BRANCH` in `scripts/env.sh`
 is `indexbot-announce-<ns>-<pkg>`). A fresh tag therefore reuses the same branch
-and lands on the **same open pull request** if one is still open — and the run
-then measures that older pull request's timeline, not this run's. Confirm no
-announce pull request is open for the package first:
+and lands on the **same open pull request** if one is still open. The drivers
+no longer *mis-measure* that: every poll carries a freshness floor taken before
+the push, so a pull request or workflow run from an earlier rehearsal is never
+mistaken for this run's. It shows up as a **timeout** instead — the driver waits
+for a pull request created after it acted, and an updated older one never
+qualifies. Confirm no announce pull request is open for the package first:
 
 ```sh
 gh pr list --repo ocx-sh/index --state open \
@@ -226,6 +230,16 @@ counting. No network, no credentials, no live state — run it after any edit to
 (g2). It does **not** test TLS, real registry auth, or whether the announce path
 writes a registry digest at all; the `1.0.4` run is the only thing that can
 prove that.
+
+**So does artifact identity.** `./scripts/selfcheck_identity.sh` sources
+`env.sh` with `gh` stubbed on `PATH` and drives `_run_concluded` and
+`pr_number` against recorded `gh` JSON: the freshness floor on both, newest-wins
+when several observations survive it, the polling gate that keeps an
+unconcluded run from reading as a verdict, and the head-repository and branch
+guards. Both matchers used to be able to answer with an earlier rehearsal's run
+or pull request, which is how a driver reports green off stale data — run this
+after any edit to either. It needs `jq` (test-only: it replays the drivers' own
+`--jq` programs offline, and `gh` embeds its own engine at run time).
 
 ## Idempotency Proof
 

--- a/test/manual/announce-e2e/README.md
+++ b/test/manual/announce-e2e/README.md
@@ -117,11 +117,14 @@ request.
 branch is **per-package, not per-tag** (`ANNOUNCE_BRANCH` in `scripts/env.sh`
 is `indexbot-announce-<ns>-<pkg>`). A fresh tag therefore reuses the same branch
 and lands on the **same open pull request** if one is still open. The drivers
-no longer *mis-measure* that: every poll carries a freshness floor taken before
-the push, so a pull request or workflow run from an earlier rehearsal is never
+no longer *mis-measure* that: every poll carries a freshness floor — the highest
+pull-request number and workflow-run id GitHub had already issued, read before
+the push — so a pull request or workflow run from an earlier rehearsal is never
 mistaken for this run's. It shows up as a **timeout** instead — the driver waits
-for a pull request created after it acted, and an updated older one never
-qualifies. Confirm no announce pull request is open for the package first:
+for a number above the floor, and an updated older pull request never qualifies.
+The floor is a server-side counter and never a timestamp, so a local clock
+running behind GitHub's cannot make stale data look fresh. Confirm no announce
+pull request is open for the package first:
 
 ```sh
 gh pr list --repo ocx-sh/index --state open \
@@ -232,14 +235,18 @@ writes a registry digest at all; the `1.0.4` run is the only thing that can
 prove that.
 
 **So does artifact identity.** `./scripts/selfcheck_identity.sh` sources
-`env.sh` with `gh` stubbed on `PATH` and drives `_run_concluded` and
-`pr_number` against recorded `gh` JSON: the freshness floor on both, newest-wins
-when several observations survive it, the polling gate that keeps an
-unconcluded run from reading as a verdict, and the head-repository and branch
-guards. Both matchers used to be able to answer with an earlier rehearsal's run
-or pull request, which is how a driver reports green off stale data — run this
-after any edit to either. It needs `jq` (test-only: it replays the drivers' own
-`--jq` programs offline, and `gh` embeds its own engine at run time).
+`env.sh` with `gh` stubbed on `PATH` and drives `run_floor`, `pr_floor`,
+`_run_concluded` and `pr_number` against recorded `gh` JSON: how the floor is
+read, the floor on both matchers, newest-wins when several observations survive
+it, the polling gate that keeps an unconcluded run from reading as a verdict,
+and the head-repository and branch guards. Two cases give a stale artifact a
+creation time *after* the driver's own `date -u` — what a backward-skewed local
+clock produces — and require it to stay excluded, which is why the floor is a
+counter and not a timestamp. Both matchers used to be able to answer with an
+earlier rehearsal's run or pull request, which is how a driver reports green off
+stale data — run this after any edit to either. It needs `jq` (test-only: it
+replays the drivers' own `--jq` programs offline, and `gh` embeds its own engine
+at run time).
 
 ## Idempotency Proof
 

--- a/test/manual/announce-e2e/scripts/env.sh
+++ b/test/manual/announce-e2e/scripts/env.sh
@@ -146,10 +146,30 @@ publisher_checkout() {
 
 # The pull requests that are candidates at all: head repository owner and
 # branch. A same-named branch on another fork is a different pull request.
-# Shared by pr_floor and pr_number so the two cannot drift — a floor computed
-# over a wider set than it filters would sit too high and hang the driver.
+# Shared by every caller — pr_floor, pr_number, run_idempotency's pr_count — so
+# the predicate cannot drift: a floor computed over a wider set than it filters
+# would sit too high and hang the driver, and a count on a looser predicate
+# would report a foreign fork's pull request as movement.
 E2E_PR_SELECT=".headRefName == \"$ANNOUNCE_BRANCH\"
            and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\""
+
+# Run <jq-program> over the announce branch's pull requests. Args: <jq-program>.
+#
+# One shared invocation because the window and the predicate have to agree.
+# `--head` makes GitHub apply the branch filter *before* --limit, so the 20 are
+# 20 pull requests on this branch — without it they are the newest 20 in the
+# whole index repository, and a repository busy enough to issue 20 newer pull
+# requests hides ours entirely: pr_floor reads 0, the announce updates an older
+# pull request that is still open instead of opening a new one, and pr_number
+# then polls a window that will never contain it.
+#
+# `--head` takes a bare branch name — `owner:branch` is documented unsupported
+# — so it cannot distinguish two forks carrying the same branch name. The
+# fork-owner half of the identity therefore stays in E2E_PR_SELECT.
+pr_list() {
+    gh pr list --repo "$GH_REPO_INDEX" --head "$ANNOUNCE_BRANCH" --state all \
+        --limit 20 --json number,headRefName,headRepositoryOwner --jq "$1"
+}
 
 # The highest pull-request number the announce branch already carries, or 0.
 # Call it BEFORE triggering the announce: it is the freshness floor pr_number
@@ -162,9 +182,7 @@ E2E_PR_SELECT=".headRefName == \"$ANNOUNCE_BRANCH\"
 # the driver certifies against it. Numbers issued by the same server that
 # issues the ones being filtered involve no clock on either side.
 pr_floor() {
-    gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
-        --json number,headRefName,headRepositoryOwner \
-        --jq "[.[] | select($E2E_PR_SELECT)] | max_by(.number).number // 0"
+    pr_list "[.[] | select($E2E_PR_SELECT)] | max_by(.number).number // 0"
 }
 
 # Echo the number of the pull request *this run's* announce put on the fork's
@@ -188,9 +206,7 @@ pr_floor() {
 # the right direction to fail: a red run, never a green one off stale data.
 pr_number() {
     local floor="$1" number
-    number="$(gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
-        --json number,headRefName,headRepositoryOwner \
-        --jq "[.[] | select($E2E_PR_SELECT and .number > $floor)] |
+    number="$(pr_list "[.[] | select($E2E_PR_SELECT and .number > $floor)] |
               max_by(.number) | .number // empty")"
     [[ -n $number ]] || return 1
     printf '%s\n' "$number"

--- a/test/manual/announce-e2e/scripts/env.sh
+++ b/test/manual/announce-e2e/scripts/env.sh
@@ -144,16 +144,39 @@ publisher_checkout() {
     ocx_fail "no publisher checkout found — set PUBLISHER_WORKTREE to a clone of $GH_REPO_PUBLISHER"
 }
 
-# Echo the number of the pull request *this run's* announce put on the fork's
-# announce branch, or return 1. Args: <since> — an RFC3339 UTC timestamp taken
-# before the announce was triggered.
+# The pull requests that are candidates at all: head repository owner and
+# branch. A same-named branch on another fork is a different pull request.
+# Shared by pr_floor and pr_number so the two cannot drift — a floor computed
+# over a wider set than it filters would sit too high and hang the driver.
+E2E_PR_SELECT=".headRefName == \"$ANNOUNCE_BRANCH\"
+           and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\""
+
+# The highest pull-request number the announce branch already carries, or 0.
+# Call it BEFORE triggering the announce: it is the freshness floor pr_number
+# filters on.
 #
-# Identity is head repository owner (a same-named branch on another fork is a
-# different pull request), branch, and creation time. The branch is per-package
-# and not per-tag, so every rehearsal of every tag reuses it: without the
-# <since> floor an earlier rehearsal's pull request — closed *or* merged, both
-# of which the branch match returns — wins, and the driver then measures that
-# run's timeline instead of its own.
+# GitHub's own monotonic counter, not a timestamp. A timestamp comparison would
+# be a local clock read against a server-assigned `createdAt`, which is only
+# sound while the local clock runs ahead — a backward-skewed clock (routine on
+# WSL after a resume) makes an earlier rehearsal's pull request look fresh, and
+# the driver certifies against it. Numbers issued by the same server that
+# issues the ones being filtered involve no clock on either side.
+pr_floor() {
+    gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
+        --json number,headRefName,headRepositoryOwner \
+        --jq "[.[] | select($E2E_PR_SELECT)] | max_by(.number).number // 0"
+}
+
+# Echo the number of the pull request *this run's* announce put on the fork's
+# announce branch, or return 1. Args: <floor> — a pr_floor reading taken before
+# the announce was triggered.
+#
+# The branch is per-package and not per-tag, so every rehearsal of every tag
+# reuses it: without the floor an earlier rehearsal's pull request — closed
+# *or* merged, both of which the branch match returns — wins, and the driver
+# then measures that run's timeline instead of its own. A *baseline* is what
+# makes this sound; a bare `max_by(.number)` is not, because in the window
+# before the new pull request exists the stale one is still the maximum.
 #
 # `--state all` stays. Restricting to open would hang the very lane it is meant
 # to prove: run_machine_lane's pull request can auto-merge before the first
@@ -161,24 +184,19 @@ publisher_checkout() {
 # caller that genuinely needs the pull request still open (run_update_union)
 # asserts that itself, at the point where it matters.
 #
-# Newest by number rather than by list position: `gh` documents no ordering,
-# and pull request numbers are monotonic per repository.
-#
-# A local clock running ahead of GitHub's makes this time out. That is the
-# right direction to fail: a red run, never a green one off stale data.
+# A floor read that raced a foreign pull request makes this time out. That is
+# the right direction to fail: a red run, never a green one off stale data.
 pr_number() {
-    local since="$1" number
+    local floor="$1" number
     number="$(gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
-        --json number,createdAt,headRefName,headRepositoryOwner \
-        --jq "[.[] | select(.headRefName == \"$ANNOUNCE_BRANCH\"
-                        and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\"
-                        and .createdAt > \"$since\")] |
+        --json number,headRefName,headRepositoryOwner \
+        --jq "[.[] | select($E2E_PR_SELECT and .number > $floor)] |
               max_by(.number) | .number // empty")"
     [[ -n $number ]] || return 1
     printf '%s\n' "$number"
 }
 
-# Wait for the announce branch's pull request to exist. Args: <since>, as
+# Wait for the announce branch's pull request to exist. Args: <floor>, as
 # pr_number. Echoes its number.
 poll_pr() {
     poll_until "$POLL_DEADLINE_SECONDS" "a pull request on $ANNOUNCE_BRANCH" \
@@ -205,28 +223,42 @@ _checks_settled() {
         grep -qx 'PENDING'
 }
 
+# The highest workflow-run id this repo+workflow+ref already carries, or 0.
+# Args: <repo> <workflow> <ref>. Call it BEFORE the push: it is the freshness
+# floor poll_run filters on, and for the same reason pr_floor exists — a server
+# counter, so no clock on either side can skew the comparison.
+#
+# The same --limit as _run_concluded: a floor read over a narrower window than
+# the one being filtered could sit below a stale run and let it through.
+run_floor() {
+    gh run list --repo "$1" --workflow "$2" --branch "$3" --limit 50 \
+        --json databaseId --jq 'max_by(.databaseId).databaseId // 0'
+}
+
 # Wait for one workflow run to conclude. Args: <repo> <workflow> <ref> <sha>
-# <since>. Echoes the run URL, and only on success; returns 1 otherwise.
+# <floor>. Echoes the run URL, and only on success; returns 1 otherwise.
 #
 # <workflow> and <ref> are part of a run's identity because a commit sha alone
 # is not: a tag push and a branch push at one sha are two runs, and a merge on
 # the index's main is one run per workflow. <ref> is the run's headBranch,
 # which for a tag push is the tag name.
 #
-# <since> — an RFC3339 UTC timestamp taken before the push — completes the
-# identity, because workflow + ref + sha still does not name one run: a
+# <floor> — a run_floor reading taken before the push — completes the identity,
+# because workflow + ref + sha still does not name one run: a
 # retracted-and-repushed tag puts two runs at all three, and the older one is
 # already concluded. Without the floor the driver reads that stale verdict in
-# the seconds before its own run is created, and certifies against it. A local
-# clock ahead of GitHub's makes this time out — red, never a false green.
+# the seconds before its own run is created, and certifies against it. A bare
+# `max_by(.databaseId)` would not do: during that same window the stale run is
+# still the maximum. A floor that raced a foreign run makes this time out —
+# red, never a false green.
 #
 # Every field comes from one observation, because two `gh` calls can select
 # different runs.
 poll_run() {
-    local repo="$1" workflow="$2" ref="$3" sha="$4" since="$5" conclusion url
+    local repo="$1" workflow="$2" ref="$3" sha="$4" floor="$5" conclusion url
     E2E_RUN_RECORD=""
     poll_until "$POLL_DEADLINE_SECONDS" "$workflow to conclude at ${sha:0:7} ($ref) in $repo" \
-        _run_concluded "$repo" "$workflow" "$ref" "$sha" "$since" || return 1
+        _run_concluded "$repo" "$workflow" "$ref" "$sha" "$floor" || return 1
     IFS='|' read -r conclusion url <<<"$E2E_RUN_RECORD"
     if [[ $conclusion != "success" ]]; then
         ocx_warn "$workflow at ${sha:0:7} ($ref) in $repo concluded $conclusion — $url"
@@ -245,12 +277,12 @@ poll_run() {
 # rather than a jq error; it, the in-progress case, and a failed `gh` all leave
 # the conclusion empty and are all polled on.
 #
-# Newest by databaseId among the runs created after <since>, because `gh`
-# documents no ordering and run ids are monotonic per repository.
+# Newest by databaseId among the runs above the floor, because `gh` documents
+# no ordering and run ids are monotonic per repository.
 _run_concluded() {
     E2E_RUN_RECORD="$(gh run list --repo "$1" --workflow "$2" --branch "$3" --limit 50 \
-        --json databaseId,headSha,createdAt,conclusion,url \
-        --jq "[.[] | select(.headSha == \"$4\" and .createdAt > \"$5\")] |
+        --json databaseId,headSha,conclusion,url \
+        --jq "[.[] | select(.headSha == \"$4\" and .databaseId > $5)] |
               max_by(.databaseId) // {} |
               [.conclusion // \"\", .url // \"\"] | join(\"|\")")"
     [[ $E2E_RUN_RECORD == ?*"|"* ]]

--- a/test/manual/announce-e2e/scripts/env.sh
+++ b/test/manual/announce-e2e/scripts/env.sh
@@ -144,23 +144,46 @@ publisher_checkout() {
     ocx_fail "no publisher checkout found — set PUBLISHER_WORKTREE to a clone of $GH_REPO_PUBLISHER"
 }
 
-# Echo the number of the pull request whose head is the announce branch on the
-# fork, or return 1. Matches head repository owner as well as branch name — a
-# same-named branch on another fork is a different pull request.
+# Echo the number of the pull request *this run's* announce put on the fork's
+# announce branch, or return 1. Args: <since> — an RFC3339 UTC timestamp taken
+# before the announce was triggered.
+#
+# Identity is head repository owner (a same-named branch on another fork is a
+# different pull request), branch, and creation time. The branch is per-package
+# and not per-tag, so every rehearsal of every tag reuses it: without the
+# <since> floor an earlier rehearsal's pull request — closed *or* merged, both
+# of which the branch match returns — wins, and the driver then measures that
+# run's timeline instead of its own.
+#
+# `--state all` stays. Restricting to open would hang the very lane it is meant
+# to prove: run_machine_lane's pull request can auto-merge before the first
+# poll sees it, so "open" is not the shared requirement — freshness is. The one
+# caller that genuinely needs the pull request still open (run_update_union)
+# asserts that itself, at the point where it matters.
+#
+# Newest by number rather than by list position: `gh` documents no ordering,
+# and pull request numbers are monotonic per repository.
+#
+# A local clock running ahead of GitHub's makes this time out. That is the
+# right direction to fail: a red run, never a green one off stale data.
 pr_number() {
-    local number
+    local since="$1" number
     number="$(gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
-        --json number,headRefName,headRepositoryOwner \
-        --jq "[.[] | select(.headRefName == \"$ANNOUNCE_BRANCH\" and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\")] | first | .number // empty")"
+        --json number,createdAt,headRefName,headRepositoryOwner \
+        --jq "[.[] | select(.headRefName == \"$ANNOUNCE_BRANCH\"
+                        and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\"
+                        and .createdAt > \"$since\")] |
+              max_by(.number) | .number // empty")"
     [[ -n $number ]] || return 1
     printf '%s\n' "$number"
 }
 
-# Wait for the announce branch's pull request to exist. Echoes its number.
+# Wait for the announce branch's pull request to exist. Args: <since>, as
+# pr_number. Echoes its number.
 poll_pr() {
     poll_until "$POLL_DEADLINE_SECONDS" "a pull request on $ANNOUNCE_BRANCH" \
-        pr_number >/dev/null
-    pr_number
+        pr_number "$1" >/dev/null
+    pr_number "$1"
 }
 
 # Wait for every check on a pull request to settle, then require them all
@@ -182,19 +205,28 @@ _checks_settled() {
         grep -qx 'PENDING'
 }
 
-# Wait for one workflow run to conclude. Args: <repo> <workflow> <ref> <sha>.
-# Echoes the run URL, and only on success; returns 1 otherwise.
+# Wait for one workflow run to conclude. Args: <repo> <workflow> <ref> <sha>
+# <since>. Echoes the run URL, and only on success; returns 1 otherwise.
 #
 # <workflow> and <ref> are part of a run's identity because a commit sha alone
 # is not: a tag push and a branch push at one sha are two runs, and a merge on
 # the index's main is one run per workflow. <ref> is the run's headBranch,
-# which for a tag push is the tag name. Every field comes from one observation,
-# because two `gh` calls can select different runs.
+# which for a tag push is the tag name.
+#
+# <since> — an RFC3339 UTC timestamp taken before the push — completes the
+# identity, because workflow + ref + sha still does not name one run: a
+# retracted-and-repushed tag puts two runs at all three, and the older one is
+# already concluded. Without the floor the driver reads that stale verdict in
+# the seconds before its own run is created, and certifies against it. A local
+# clock ahead of GitHub's makes this time out — red, never a false green.
+#
+# Every field comes from one observation, because two `gh` calls can select
+# different runs.
 poll_run() {
-    local repo="$1" workflow="$2" ref="$3" sha="$4" conclusion url
+    local repo="$1" workflow="$2" ref="$3" sha="$4" since="$5" conclusion url
     E2E_RUN_RECORD=""
     poll_until "$POLL_DEADLINE_SECONDS" "$workflow to conclude at ${sha:0:7} ($ref) in $repo" \
-        _run_concluded "$repo" "$workflow" "$ref" "$sha" || return 1
+        _run_concluded "$repo" "$workflow" "$ref" "$sha" "$since" || return 1
     IFS='|' read -r conclusion url <<<"$E2E_RUN_RECORD"
     if [[ $conclusion != "success" ]]; then
         ocx_warn "$workflow at ${sha:0:7} ($ref) in $repo concluded $conclusion — $url"
@@ -208,14 +240,18 @@ poll_run() {
 #
 # The gate is a non-empty conclusion — the field poll_run judges on — not a
 # `completed` status: a run is briefly `completed` with a null conclusion, and
-# polling through that window is what keeps the read unambiguous. `first // {}`
-# keeps the not-started case (no run matches) a valid empty record rather than
-# a jq error; it, the in-progress case, and a failed `gh` all leave the
-# conclusion empty and are all polled on.
+# polling through that window is what keeps the read unambiguous. `max_by // {}`
+# keeps the not-started case (no run passes the filter) a valid empty record
+# rather than a jq error; it, the in-progress case, and a failed `gh` all leave
+# the conclusion empty and are all polled on.
+#
+# Newest by databaseId among the runs created after <since>, because `gh`
+# documents no ordering and run ids are monotonic per repository.
 _run_concluded() {
     E2E_RUN_RECORD="$(gh run list --repo "$1" --workflow "$2" --branch "$3" --limit 50 \
-        --json headSha,conclusion,url \
-        --jq "[.[] | select(.headSha == \"$4\")] | first // {} |
+        --json databaseId,headSha,createdAt,conclusion,url \
+        --jq "[.[] | select(.headSha == \"$4\" and .createdAt > \"$5\")] |
+              max_by(.databaseId) // {} |
               [.conclusion // \"\", .url // \"\"] | join(\"|\")")"
     [[ $E2E_RUN_RECORD == ?*"|"* ]]
 }

--- a/test/manual/announce-e2e/scripts/run_idempotency.sh
+++ b/test/manual/announce-e2e/scripts/run_idempotency.sh
@@ -18,11 +18,12 @@ IFS=$'\n\t'
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
 
 # Pull request count on the announce branch: 0 or 1 by construction, but a
-# second PR is precisely the C4/C6 failure this counts.
+# second PR is precisely the C4/C6 failure this counts. Counts exactly what
+# pr_floor and pr_number select — E2E_PR_SELECT over pr_list's window — so a
+# foreign fork's pull request can never read as movement here while being
+# invisible to the matchers.
 pr_count() {
-    gh pr list --repo "$GH_REPO_INDEX" --state all --limit 20 \
-        --json headRefName,headRepositoryOwner \
-        --jq "[.[] | select(.headRefName == \"$ANNOUNCE_BRANCH\" and .headRepositoryOwner.login == \"${INDEX_FORK%%/*}\")] | length"
+    pr_list "[.[] | select($E2E_PR_SELECT)] | length"
 }
 
 # Head commit of the announce branch on the fork, or "absent".

--- a/test/manual/announce-e2e/scripts/run_machine_lane.sh
+++ b/test/manual/announce-e2e/scripts/run_machine_lane.sh
@@ -49,10 +49,13 @@ main() {
     sha="$(git -C "$checkout" rev-parse "refs/tags/$tag^{commit}")"
 
     ocx_step "waiting for the publisher's announce at ${sha:0:7}"
-    poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" >/dev/null ||
+    poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" "$t0" >/dev/null ||
         fail_proof "publisher CI did not conclude successfully for tag $tag"
 
-    pr="$(poll_pr)" || fail_proof "no pull request appeared on $ANNOUNCE_BRANCH for tag $tag"
+    # $t0 predates the push, so nothing an earlier rehearsal left on this
+    # per-package branch can answer — including its merged pull request, which
+    # this driver would otherwise take the merge latency and lane verdict off.
+    pr="$(poll_pr "$t0")" || fail_proof "no pull request appeared on $ANNOUNCE_BRANCH for tag $tag"
     ocx_step "waiting for PR #$pr to auto-merge — take no action, that is the proof"
     merge_line="$(poll_merge "$pr")" ||
         fail_proof "PR #$pr did not auto-merge within ${POLL_DEADLINE_SECONDS}s — see PLAYBOOKS.md playbook 3"

--- a/test/manual/announce-e2e/scripts/run_machine_lane.sh
+++ b/test/manual/announce-e2e/scripts/run_machine_lane.sh
@@ -36,12 +36,17 @@ _serves_tag() {
 main() {
     local tag="${1:?usage: run_machine_lane.sh <tag>}"
     local checkout sha t0 pr merge_line merged_at lane latency_merge latency_serve t_serve
+    local publish_floor pr_base
     local secret_args=()
 
     checkout="$(publisher_checkout)"
 
     ocx_step "pushing new tag $tag to $GH_REPO_PUBLISHER"
+    # Read before the push: GitHub's own counters, so nothing this per-package
+    # branch already carries can answer for this run. t0 is latency only.
     t0="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    publish_floor="$(run_floor "$GH_REPO_PUBLISHER" e2e-publish "$tag")"
+    pr_base="$(pr_floor)"
     git -C "$checkout" fetch origin
     git -C "$checkout" tag "$tag" origin/main ||
         ocx_fail "tag $tag already exists — pick a new one, or retract it per README 'Cleaning up a rehearsal'"
@@ -49,13 +54,13 @@ main() {
     sha="$(git -C "$checkout" rev-parse "refs/tags/$tag^{commit}")"
 
     ocx_step "waiting for the publisher's announce at ${sha:0:7}"
-    poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" "$t0" >/dev/null ||
+    poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" "$publish_floor" >/dev/null ||
         fail_proof "publisher CI did not conclude successfully for tag $tag"
 
-    # $t0 predates the push, so nothing an earlier rehearsal left on this
+    # $pr_base predates the push, so nothing an earlier rehearsal left on this
     # per-package branch can answer — including its merged pull request, which
     # this driver would otherwise take the merge latency and lane verdict off.
-    pr="$(poll_pr "$t0")" || fail_proof "no pull request appeared on $ANNOUNCE_BRANCH for tag $tag"
+    pr="$(poll_pr "$pr_base")" || fail_proof "no pull request appeared on $ANNOUNCE_BRANCH for tag $tag"
     ocx_step "waiting for PR #$pr to auto-merge — take no action, that is the proof"
     merge_line="$(poll_merge "$pr")" ||
         fail_proof "PR #$pr did not auto-merge within ${POLL_DEADLINE_SECONDS}s — see PLAYBOOKS.md playbook 3"

--- a/test/manual/announce-e2e/scripts/run_sequence.sh
+++ b/test/manual/announce-e2e/scripts/run_sequence.sh
@@ -308,20 +308,27 @@ assert_no_reserved_tags() {
 main() {
     local tag="${1:?usage: run_sequence.sh <tag>}"
     local sha t0 publisher_run pr merge_line merge_sha merged_at deploy_run latency
+    local publish_floor pr_base deploy_floor
     local root_json
     local secret_args=()
 
     require_claimed_namespace
 
+    # Freshness floors, all read before the push: what GitHub had already
+    # numbered, so nothing an earlier rehearsal left behind can answer for this
+    # run. t0 stays a timestamp — it is only ever reported as latency.
     t0="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    publish_floor="$(run_floor "$GH_REPO_PUBLISHER" e2e-publish "$tag")"
+    deploy_floor="$(run_floor "$GH_REPO_INDEX" render-deploy main)"
+    pr_base="$(pr_floor)"
     sha="$(push_publisher_tag "$tag")"
 
     ocx_step "(b) waiting for the publisher's build + push + announce at ${sha:0:7}"
-    publisher_run="$(poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" "$t0")" ||
+    publisher_run="$(poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" "$publish_floor")" ||
         ocx_fail "publisher CI did not conclude successfully — see PLAYBOOKS.md"
 
     ocx_step "(c) waiting for the tag-refresh PR on $ANNOUNCE_BRANCH"
-    pr="$(poll_pr "$t0")" || ocx_fail "no pull request appeared on $ANNOUNCE_BRANCH"
+    pr="$(poll_pr "$pr_base")" || ocx_fail "no pull request appeared on $ANNOUNCE_BRANCH"
     ocx_done "(c) pull request #$pr"
 
     ocx_step "(d) waiting for validate.yml on PR #$pr"
@@ -334,7 +341,7 @@ main() {
     merge_line="$(poll_merge "$pr")" || ocx_fail "PR #$pr did not merge"
     merge_sha="${merge_line%% *}"
     merged_at="${merge_line##* }"
-    deploy_run="$(poll_run "$GH_REPO_INDEX" render-deploy main "$merge_sha" "$t0")" ||
+    deploy_run="$(poll_run "$GH_REPO_INDEX" render-deploy main "$merge_sha" "$deploy_floor")" ||
         ocx_fail "render-deploy did not conclude successfully at ${merge_sha:0:7}"
 
     ocx_step "(g) checking that $INDEX_SITE serves the root"

--- a/test/manual/announce-e2e/scripts/run_sequence.sh
+++ b/test/manual/announce-e2e/scripts/run_sequence.sh
@@ -317,11 +317,11 @@ main() {
     sha="$(push_publisher_tag "$tag")"
 
     ocx_step "(b) waiting for the publisher's build + push + announce at ${sha:0:7}"
-    publisher_run="$(poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha")" ||
+    publisher_run="$(poll_run "$GH_REPO_PUBLISHER" e2e-publish "$tag" "$sha" "$t0")" ||
         ocx_fail "publisher CI did not conclude successfully — see PLAYBOOKS.md"
 
     ocx_step "(c) waiting for the tag-refresh PR on $ANNOUNCE_BRANCH"
-    pr="$(poll_pr)" || ocx_fail "no pull request appeared on $ANNOUNCE_BRANCH"
+    pr="$(poll_pr "$t0")" || ocx_fail "no pull request appeared on $ANNOUNCE_BRANCH"
     ocx_done "(c) pull request #$pr"
 
     ocx_step "(d) waiting for validate.yml on PR #$pr"
@@ -334,7 +334,7 @@ main() {
     merge_line="$(poll_merge "$pr")" || ocx_fail "PR #$pr did not merge"
     merge_sha="${merge_line%% *}"
     merged_at="${merge_line##* }"
-    deploy_run="$(poll_run "$GH_REPO_INDEX" render-deploy main "$merge_sha")" ||
+    deploy_run="$(poll_run "$GH_REPO_INDEX" render-deploy main "$merge_sha" "$t0")" ||
         ocx_fail "render-deploy did not conclude successfully at ${merge_sha:0:7}"
 
     ocx_step "(g) checking that $INDEX_SITE serves the root"

--- a/test/manual/announce-e2e/scripts/run_update_union.sh
+++ b/test/manual/announce-e2e/scripts/run_update_union.sh
@@ -39,17 +39,18 @@ announce_tag() {
 main() {
     local tag_a="${1:?usage: run_update_union.sh <tag-a> <tag-b>}"
     local tag_b="${2:?usage: run_update_union.sh <tag-a> <tag-b>}"
-    local pr_a pr_b committed union_result t0
+    local pr_a pr_b committed union_result pr_base
 
-    # Taken before the first announce: both polls below want the pull request
+    # Read before the first announce: both polls below want the pull request
     # *this* run produced, and announce #2 updates the one announce #1 opened,
     # so one floor covers both. An earlier rehearsal's pull request on the same
-    # per-package branch predates it and can no longer be mistaken for either.
-    t0="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    # per-package branch is numbered at or below it and can no longer be
+    # mistaken for either.
+    pr_base="$(pr_floor)"
 
     ocx_step "announce #1 with $tag_a"
     announce_tag union-1 "$tag_a" >/dev/null
-    pr_a="$(poll_pr "$t0")" || ocx_fail "announce #1 opened no pull request"
+    pr_a="$(poll_pr "$pr_base")" || ocx_fail "announce #1 opened no pull request"
     ocx_done "announce #1 opened PR #$pr_a"
 
     # The union is only proved while #1 is still open — a merged PR would make
@@ -60,7 +61,7 @@ main() {
 
     ocx_step "announce #2 with $tag_b, PR #$pr_a deliberately left unmerged"
     announce_tag union-2 "$tag_b" >/dev/null
-    pr_b="$(poll_pr "$t0")" || ocx_fail "no pull request after announce #2"
+    pr_b="$(poll_pr "$pr_base")" || ocx_fail "no pull request after announce #2"
 
     if [[ $pr_b != "$pr_a" ]]; then
         evidence record --scenario update_union --status fail \

--- a/test/manual/announce-e2e/scripts/run_update_union.sh
+++ b/test/manual/announce-e2e/scripts/run_update_union.sh
@@ -39,11 +39,17 @@ announce_tag() {
 main() {
     local tag_a="${1:?usage: run_update_union.sh <tag-a> <tag-b>}"
     local tag_b="${2:?usage: run_update_union.sh <tag-a> <tag-b>}"
-    local pr_a pr_b committed union_result
+    local pr_a pr_b committed union_result t0
+
+    # Taken before the first announce: both polls below want the pull request
+    # *this* run produced, and announce #2 updates the one announce #1 opened,
+    # so one floor covers both. An earlier rehearsal's pull request on the same
+    # per-package branch predates it and can no longer be mistaken for either.
+    t0="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
     ocx_step "announce #1 with $tag_a"
     announce_tag union-1 "$tag_a" >/dev/null
-    pr_a="$(poll_pr)" || ocx_fail "announce #1 opened no pull request"
+    pr_a="$(poll_pr "$t0")" || ocx_fail "announce #1 opened no pull request"
     ocx_done "announce #1 opened PR #$pr_a"
 
     # The union is only proved while #1 is still open — a merged PR would make
@@ -54,7 +60,7 @@ main() {
 
     ocx_step "announce #2 with $tag_b, PR #$pr_a deliberately left unmerged"
     announce_tag union-2 "$tag_b" >/dev/null
-    pr_b="$(poll_pr)" || ocx_fail "no pull request after announce #2"
+    pr_b="$(poll_pr "$t0")" || ocx_fail "no pull request after announce #2"
 
     if [[ $pr_b != "$pr_a" ]]; then
         evidence record --scenario update_union --status fail \

--- a/test/manual/announce-e2e/scripts/selfcheck_identity.sh
+++ b/test/manual/announce-e2e/scripts/selfcheck_identity.sh
@@ -15,10 +15,19 @@
 # the pull-request side.
 #
 # The floor is a GitHub-issued counter, never a timestamp, so every fixture
-# below carries a `createdAt` the matchers must ignore: the cases marked
-# "backward-skewed clock" hand a stale artifact a *fresh-looking* creation time
-# — what a WSL clock running behind GitHub's produces after a resume — and
-# require it to stay excluded anyway.
+# below carries a `createdAt` the matchers must ignore. The two cases named
+# "createdAt is never consulted" hand a stale artifact the fresh-looking
+# creation time a backward-skewed local clock would have made look valid, and
+# require it to stay excluded.
+#
+# Be precise about what those two discriminate: that the current matchers key on
+# `.databaseId` / `.number` and read no other field. They do NOT reproduce clock
+# skew, and cannot — the matchers take a counter, so there is no timestamp left
+# to skew, and replaying these fixtures against the old timestamp comparison
+# hands it a number where it expects an RFC3339 string, which is a type
+# mismatch and not a faithful repro. The skew defect was proven separately,
+# against the old code with a real timestamp floor; this file only pins that the
+# replacement is clock-free.
 #
 # NOT covered — deliberately: whether `gh` really returns these fields, and
 # whether announce opens a pull request at all. Only the selection logic is
@@ -187,7 +196,7 @@ main_selfcheck() {
         run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
     fixture "$(run_obj 100 "$SHA" "$AFTER" success https://run/STALE)"
-    expect "run — backward-skewed clock: a stale run dated after t0 is still stale" "" \
+    expect "run — createdAt is never consulted: a fresh-dated stale run stays stale" "" \
         run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
     fixture "$(run_obj 100 "$SHA" "$BEFORE" success https://run/old)" \
@@ -229,7 +238,7 @@ main_selfcheck() {
         pr_number "$PR_FLOOR"
 
     fixture "$(pr_obj 141 "$AFTER" MERGED "$ANNOUNCE_BRANCH" stub)"
-    expect "pr — backward-skewed clock: a stale pull request dated after t0 is still stale" "" \
+    expect "pr — createdAt is never consulted: a fresh-dated stale pull request stays stale" "" \
         pr_number "$PR_FLOOR"
 
     fixture "$(pr_obj 141 "$BEFORE" MERGED "$ANNOUNCE_BRANCH" stub)" \

--- a/test/manual/announce-e2e/scripts/selfcheck_identity.sh
+++ b/test/manual/announce-e2e/scripts/selfcheck_identity.sh
@@ -9,13 +9,20 @@
 # driven here against recorded `gh` JSON, with `gh` stubbed on `PATH` — the
 # pattern selfcheck_g2.sh established for `curl`.
 #
-# Covered: the freshness floor on both matchers, newest-wins when several
-# observations survive it, the polling gate (an unconcluded run is not a
-# verdict), and the head-repository/branch guards on the pull-request side.
+# Covered: the freshness floor on both matchers, how the floor itself is read,
+# newest-wins when several observations survive it, the polling gate (an
+# unconcluded run is not a verdict), and the head-repository/branch guards on
+# the pull-request side.
 #
-# NOT covered — deliberately: whether `gh` really returns these fields, GitHub's
-# clock, and whether announce opens a pull request at all. Only the selection
-# logic is under test, never the transport.
+# The floor is a GitHub-issued counter, never a timestamp, so every fixture
+# below carries a `createdAt` the matchers must ignore: the cases marked
+# "backward-skewed clock" hand a stale artifact a *fresh-looking* creation time
+# — what a WSL clock running behind GitHub's produces after a resume — and
+# require it to stay excluded anyway.
+#
+# NOT covered — deliberately: whether `gh` really returns these fields, and
+# whether announce opens a pull request at all. Only the selection logic is
+# under test, never the transport.
 #
 # Needs `jq` to evaluate the drivers' own `--jq` programs offline (`gh` embeds
 # its own). Test-only: no driver gains a jq dependency.
@@ -73,9 +80,13 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
 CASES=0
 FAILURES=0
 
-# The three timestamps every case is written against: the driver's own t0, one
-# observation from before it acted, one from after.
-T0="2026-01-01T00:00:00Z"
+# The floors the driver would have read before acting: the highest run id and
+# pull-request number GitHub had already issued. Everything at or below them
+# belongs to an earlier rehearsal.
+RUN_FLOOR="100"
+PR_FLOOR="141"
+
+# Creation times, present only so the cases can prove they are not consulted.
 BEFORE="2025-12-31T23:59:00Z"
 AFTER="2026-01-01T00:00:30Z"
 SHA="0123456789abcdef0123456789abcdef01234567"
@@ -144,75 +155,108 @@ run_record() {
 }
 
 main_selfcheck() {
-    # --- Bug (a): a run older than the push can never be this run's. ---
+    # --- The floors themselves: what the driver reads before it acts. ---
+
+    fixture
+    expect "floor — a repository with no run yet floors at 0" "0" \
+        run_floor stub/repo e2e-publish 1.0.5
+
+    fixture "$(run_obj 200 "$SHA" "$AFTER" success https://run/older)" \
+        "$(run_obj 300 "$SHA" "$AFTER" success https://run/newest)"
+    expect "floor — the run floor is the highest id, not the first listed" "300" \
+        run_floor stub/repo e2e-publish 1.0.5
+
+    fixture
+    expect "floor — a branch with no pull request yet floors at 0" "0" \
+        pr_floor
+
+    fixture "$(pr_obj 142 "$AFTER" MERGED "$ANNOUNCE_BRANCH" stub)" \
+        "$(pr_obj 143 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)"
+    expect "floor — the pull-request floor is the highest number, not the first listed" "143" \
+        pr_floor
+
+    fixture "$(pr_obj 142 "$AFTER" OPEN "$ANNOUNCE_BRANCH" someone-else)" \
+        "$(pr_obj 143 "$AFTER" OPEN indexbot-announce-ns-other stub)"
+    expect "floor — foreign forks and other packages do not raise the floor" "0" \
+        pr_floor
+
+    # --- Bug (a): a run at or below the floor can never be this run's. ---
 
     fixture "$(run_obj 100 "$SHA" "$BEFORE" success https://run/old)"
-    expect "run — a concluded run from before the push is not a verdict" "" \
-        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+    expect "run — a run the floor already counted is not a verdict" "" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
+
+    fixture "$(run_obj 100 "$SHA" "$AFTER" success https://run/STALE)"
+    expect "run — backward-skewed clock: a stale run dated after t0 is still stale" "" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
     fixture "$(run_obj 100 "$SHA" "$BEFORE" success https://run/old)" \
         "$(run_obj 200 "$SHA" "$AFTER" '' https://run/new)"
     expect "run — retracted-and-repushed tag: poll the new run, not the old verdict" "" \
-        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
     fixture "$(run_obj 100 "$SHA" "$BEFORE" success https://run/old)" \
         "$(run_obj 200 "$SHA" "$AFTER" failure https://run/new)"
     expect "run — the new run's own conclusion is the verdict" "failure|https://run/new" \
-        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
     fixture "$(run_obj 200 "$SHA" "$AFTER" success https://run/new)"
     expect "run — a fresh concluded run is read whole" "success|https://run/new" \
-        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
-    fixture "$(run_obj 300 "$SHA" "$AFTER" success https://run/newest)" \
-        "$(run_obj 200 "$SHA" "$AFTER" failure https://run/older)"
+    fixture "$(run_obj 200 "$SHA" "$AFTER" failure https://run/older)" \
+        "$(run_obj 300 "$SHA" "$AFTER" success https://run/newest)"
     expect "run — several fresh runs: newest databaseId wins, not list order" \
         "success|https://run/newest" \
-        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
     fixture "$(run_obj 200 "$OTHER_SHA" "$AFTER" success https://run/other)"
     expect "run — another commit's run never matches" "" \
-        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
     fixture
     expect "run — no run yet is a poll, not a failure" "" \
-        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$RUN_FLOOR"
 
-    # --- Bug (b): a pull request older than the announce is a rehearsal's. ---
+    # --- Bug (b): a pull request at or below the floor is a rehearsal's. ---
 
-    fixture "$(pr_obj 41 "$BEFORE" CLOSED "$ANNOUNCE_BRANCH" stub)"
+    fixture "$(pr_obj 141 "$BEFORE" CLOSED "$ANNOUNCE_BRANCH" stub)"
     expect "pr — an earlier rehearsal's closed pull request never wins" "" \
-        pr_number "$T0"
+        pr_number "$PR_FLOOR"
 
-    fixture "$(pr_obj 41 "$BEFORE" MERGED "$ANNOUNCE_BRANCH" stub)"
+    fixture "$(pr_obj 141 "$BEFORE" MERGED "$ANNOUNCE_BRANCH" stub)"
     expect "pr — an earlier rehearsal's merged pull request never wins" "" \
-        pr_number "$T0"
+        pr_number "$PR_FLOOR"
 
-    fixture "$(pr_obj 41 "$BEFORE" MERGED "$ANNOUNCE_BRANCH" stub)" \
-        "$(pr_obj 42 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)"
-    expect "pr — this run's pull request wins over the rehearsal it follows" "42" \
-        pr_number "$T0"
+    fixture "$(pr_obj 141 "$AFTER" MERGED "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — backward-skewed clock: a stale pull request dated after t0 is still stale" "" \
+        pr_number "$PR_FLOOR"
 
-    fixture "$(pr_obj 42 "$AFTER" MERGED "$ANNOUNCE_BRANCH" stub)"
-    expect "pr — the machine lane's own pull request is found after it auto-merged" "42" \
-        pr_number "$T0"
+    fixture "$(pr_obj 141 "$BEFORE" MERGED "$ANNOUNCE_BRANCH" stub)" \
+        "$(pr_obj 142 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — this run's pull request wins over the rehearsal it follows" "142" \
+        pr_number "$PR_FLOOR"
 
-    fixture "$(pr_obj 42 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)" \
-        "$(pr_obj 43 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)"
-    expect "pr — a second fresh pull request is seen (C4 breakage is detectable)" "43" \
-        pr_number "$T0"
+    fixture "$(pr_obj 142 "$AFTER" MERGED "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — the machine lane's own pull request is found after it auto-merged" "142" \
+        pr_number "$PR_FLOOR"
 
-    fixture "$(pr_obj 42 "$AFTER" OPEN "$ANNOUNCE_BRANCH" someone-else)"
+    fixture "$(pr_obj 142 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)" \
+        "$(pr_obj 143 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — a second fresh pull request is seen (C4 breakage is detectable)" "143" \
+        pr_number "$PR_FLOOR"
+
+    fixture "$(pr_obj 142 "$AFTER" OPEN "$ANNOUNCE_BRANCH" someone-else)"
     expect "pr — a same-named branch on another fork is another pull request" "" \
-        pr_number "$T0"
+        pr_number "$PR_FLOOR"
 
-    fixture "$(pr_obj 42 "$AFTER" OPEN indexbot-announce-ns-other stub)"
+    fixture "$(pr_obj 142 "$AFTER" OPEN indexbot-announce-ns-other stub)"
     expect "pr — another package's announce branch never matches" "" \
-        pr_number "$T0"
+        pr_number "$PR_FLOOR"
 
     fixture
     expect "pr — no pull request yet is a poll, not a failure" "" \
-        pr_number "$T0"
+        pr_number "$PR_FLOOR"
 
     printf '\n%d cases, %d failures\n' "$CASES" "$FAILURES"
     ((FAILURES == 0))

--- a/test/manual/announce-e2e/scripts/selfcheck_identity.sh
+++ b/test/manual/announce-e2e/scripts/selfcheck_identity.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Self-check for run and pull-request *identity* in env.sh — which observation
+# on GitHub is the one this driver's own push produced.
+#
+# Both matchers used to be able to lock onto an artifact from an earlier
+# rehearsal and certify the current run against it: the worst failure a harness
+# has, because it reports green off stale data. Neither can be exercised live
+# without burning a tag and an owner merge click, so the matching logic is
+# driven here against recorded `gh` JSON, with `gh` stubbed on `PATH` — the
+# pattern selfcheck_g2.sh established for `curl`.
+#
+# Covered: the freshness floor on both matchers, newest-wins when several
+# observations survive it, the polling gate (an unconcluded run is not a
+# verdict), and the head-repository/branch guards on the pull-request side.
+#
+# NOT covered — deliberately: whether `gh` really returns these fields, GitHub's
+# clock, and whether announce opens a pull request at all. Only the selection
+# logic is under test, never the transport.
+#
+# Needs `jq` to evaluate the drivers' own `--jq` programs offline (`gh` embeds
+# its own). Test-only: no driver gains a jq dependency.
+#
+# Usage: selfcheck_identity.sh    (no network, no credentials, no live state)
+
+set -euo pipefail
+IFS=$'\n\t'
+
+command -v jq >/dev/null ||
+    {
+        printf 'selfcheck_identity.sh needs jq to replay the drivers --jq programs offline\n' >&2
+        exit 1
+    }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf -- "$TMP"' EXIT
+
+# The live-run variables env.sh demands. Nothing here reaches a network: the
+# stub `gh` below is the only I/O, and env.sh is a pure sourcing surface.
+export GH_REPO_PUBLISHER="stub/publisher" GH_REPO_INDEX="stub/index" \
+    INDEX_FORK="stub/fork" E2E_NAMESPACE="ns" E2E_PACKAGE="pkg" \
+    BOT_ACTOR_IDS="1" RESULTS_DIR="$TMP/results"
+
+# Serves $STUB_GH_FIXTURE through whatever `--jq` program the caller passed, so
+# the expression under test is the one the driver ships. `gh --jq` emits raw
+# strings, hence `jq -r`. Every other flag is irrelevant to selection.
+mkdir -p "$TMP/bin"
+cat >"$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+filter=""
+while (($#)); do
+    case "$1" in
+        --jq) filter="$2" && shift 2 ;;
+        *) shift ;;
+    esac
+done
+if [[ -z $filter ]]; then
+    printf 'stub gh: called without --jq\n' >&2
+    exit 1
+fi
+jq -r "$filter" <"$STUB_GH_FIXTURE"
+STUB
+chmod +x "$TMP/bin/gh"
+PATH="$TMP/bin:$PATH"
+export PATH
+
+STUB_GH_FIXTURE="$TMP/fixture.json"
+export STUB_GH_FIXTURE
+
+# shellcheck source=./env.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/env.sh"
+
+CASES=0
+FAILURES=0
+
+# The three timestamps every case is written against: the driver's own t0, one
+# observation from before it acted, one from after.
+T0="2026-01-01T00:00:00Z"
+BEFORE="2025-12-31T23:59:00Z"
+AFTER="2026-01-01T00:00:30Z"
+SHA="0123456789abcdef0123456789abcdef01234567"
+OTHER_SHA="fedcba9876543210fedcba9876543210fedcba98"
+
+report() {
+    if [[ $1 == pass ]]; then
+        printf 'ok   %s\n' "$2"
+    else
+        FAILURES=$((FAILURES + 1))
+        printf 'FAIL %s\n     %s\n' "$2" "$3"
+    fi
+}
+
+# Args: <description> <expected stdout> <command...>. An empty expectation
+# means the command must fail and print nothing — the "keep polling" verdict.
+expect() {
+    local what="$1" want="$2" got status=0
+    shift 2
+    got="$("$@" 2>&1)" || status=$?
+    if [[ -z $want ]]; then
+        if ((status == 0)); then
+            report fail "$what" "expected failure, got: $got"
+        elif [[ -n $got ]]; then
+            report fail "$what" "expected no output, got: $got"
+        else
+            report pass "$what"
+        fi
+    elif ((status != 0)); then
+        report fail "$what" "expected '$want', command failed: $got"
+    elif [[ $got == "$want" ]]; then
+        report pass "$what"
+    else
+        report fail "$what" "expected '$want', got: $got"
+    fi
+    CASES=$((CASES + 1))
+}
+
+# Write the array `gh` would have returned. Args: <element>...
+fixture() {
+    local IFS=,
+    printf '[%s]' "$*" >"$STUB_GH_FIXTURE"
+}
+
+# One `gh run list` element. Args: <databaseId> <headSha> <createdAt>
+# <conclusion, empty for a run still in flight> <url>.
+run_obj() {
+    local conclusion="null"
+    [[ -z $4 ]] || conclusion="\"$4\""
+    printf '{"databaseId": %s, "headSha": "%s", "createdAt": "%s", "conclusion": %s, "url": "%s"}' \
+        "$1" "$2" "$3" "$conclusion" "$5"
+}
+
+# One `gh pr list` element. Args: <number> <createdAt> <state> <headRefName>
+# <headRepositoryOwner>.
+pr_obj() {
+    printf '{"number": %s, "createdAt": "%s", "state": "%s", "headRefName": "%s", "headRepositoryOwner": {"login": "%s"}}' \
+        "$1" "$2" "$3" "$4" "$5"
+}
+
+# _run_concluded assigns E2E_RUN_RECORD in its caller's shell rather than
+# printing it; echo it so one expectation helper covers both matchers.
+run_record() {
+    _run_concluded "$@" || return 1
+    printf '%s\n' "$E2E_RUN_RECORD"
+}
+
+main_selfcheck() {
+    # --- Bug (a): a run older than the push can never be this run's. ---
+
+    fixture "$(run_obj 100 "$SHA" "$BEFORE" success https://run/old)"
+    expect "run — a concluded run from before the push is not a verdict" "" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+
+    fixture "$(run_obj 100 "$SHA" "$BEFORE" success https://run/old)" \
+        "$(run_obj 200 "$SHA" "$AFTER" '' https://run/new)"
+    expect "run — retracted-and-repushed tag: poll the new run, not the old verdict" "" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+
+    fixture "$(run_obj 100 "$SHA" "$BEFORE" success https://run/old)" \
+        "$(run_obj 200 "$SHA" "$AFTER" failure https://run/new)"
+    expect "run — the new run's own conclusion is the verdict" "failure|https://run/new" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+
+    fixture "$(run_obj 200 "$SHA" "$AFTER" success https://run/new)"
+    expect "run — a fresh concluded run is read whole" "success|https://run/new" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+
+    fixture "$(run_obj 300 "$SHA" "$AFTER" success https://run/newest)" \
+        "$(run_obj 200 "$SHA" "$AFTER" failure https://run/older)"
+    expect "run — several fresh runs: newest databaseId wins, not list order" \
+        "success|https://run/newest" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+
+    fixture "$(run_obj 200 "$OTHER_SHA" "$AFTER" success https://run/other)"
+    expect "run — another commit's run never matches" "" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+
+    fixture
+    expect "run — no run yet is a poll, not a failure" "" \
+        run_record stub/repo e2e-publish 1.0.5 "$SHA" "$T0"
+
+    # --- Bug (b): a pull request older than the announce is a rehearsal's. ---
+
+    fixture "$(pr_obj 41 "$BEFORE" CLOSED "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — an earlier rehearsal's closed pull request never wins" "" \
+        pr_number "$T0"
+
+    fixture "$(pr_obj 41 "$BEFORE" MERGED "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — an earlier rehearsal's merged pull request never wins" "" \
+        pr_number "$T0"
+
+    fixture "$(pr_obj 41 "$BEFORE" MERGED "$ANNOUNCE_BRANCH" stub)" \
+        "$(pr_obj 42 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — this run's pull request wins over the rehearsal it follows" "42" \
+        pr_number "$T0"
+
+    fixture "$(pr_obj 42 "$AFTER" MERGED "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — the machine lane's own pull request is found after it auto-merged" "42" \
+        pr_number "$T0"
+
+    fixture "$(pr_obj 42 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)" \
+        "$(pr_obj 43 "$AFTER" OPEN "$ANNOUNCE_BRANCH" stub)"
+    expect "pr — a second fresh pull request is seen (C4 breakage is detectable)" "43" \
+        pr_number "$T0"
+
+    fixture "$(pr_obj 42 "$AFTER" OPEN "$ANNOUNCE_BRANCH" someone-else)"
+    expect "pr — a same-named branch on another fork is another pull request" "" \
+        pr_number "$T0"
+
+    fixture "$(pr_obj 42 "$AFTER" OPEN indexbot-announce-ns-other stub)"
+    expect "pr — another package's announce branch never matches" "" \
+        pr_number "$T0"
+
+    fixture
+    expect "pr — no pull request yet is a poll, not a failure" "" \
+        pr_number "$T0"
+
+    printf '\n%d cases, %d failures\n' "$CASES" "$FAILURES"
+    ((FAILURES == 0))
+}
+
+main_selfcheck


### PR DESCRIPTION
Two bugs in the Track D drivers, same class: **neither matcher had a freshness baseline**, so an artifact that existed before the driver acted could answer for it. Both silently certify a run against the wrong artifact — the worst failure mode a harness has, because it reports green off stale data. This bit for real: the 1.0.5 verdict had to be taken by running post-merge assertions directly against the PR rather than trusting driver exit codes.

- **`poll_run`** identified a run by workflow + branch + `headSha` and took `first`. A retracted-and-repushed tag puts two runs at all three keys, and in the seconds before the new run is created the *only* match is the old, concluded one.
- **`pr_number`** identified a PR by fork owner + branch alone, and `ANNOUNCE_BRANCH` is per-package, not per-tag — so an earlier rehearsal's PR (closed **or** merged) won `first`.

**The floor is a GitHub-issued counter, not a clock.** The first fix used a local `date -u` stamp compared against GitHub's `createdAt`; review executed the counter-case and showed a *backward*-skewed clock reproduces the original false-green exactly — and post-resume drift on WSL, where these run, is routine. Now `run_floor`/`pr_floor` read `max(databaseId)` / `max(number)` before the triggering action, and the matchers filter `> floor`. `createdAt` is out of both `--json` field lists; no clock feeds identity anywhere.

Details that are load-bearing: `run_floor` reads the **same `--limit 50` window** as its matcher, so the floor can never sit below a stale run it will later see; `pr_list` now filters `--head` server-side so the limit applies to announce-branch PRs rather than the repo's newest 20; and all three PR call sites route through one helper so window and predicate cannot drift. The baseline is *kept* rather than replaced by a bare max-rule — a max with no floor still answers with the stale artifact in the window before the new one exists.

All four `poll_pr` call sites keep the state semantics they need (`run_machine_lane` must still see a MERGED PR). Every poll stays under `poll_until`; the failure direction is a timeout, never a green.

**Discrimination** (`selfcheck_identity.sh`, 22 cases, stubs `gh` on `PATH` per the `selfcheck_g2.sh` precedent):

| `env.sh` under test | Result |
|---|---|
| this branch | 22 cases, **0 failures** |
| timestamp-floor version | **10 failures** |
| original, no floor | **15 failures** |

Honesty note carried in the harness itself: the two "fresh-dated stale artifact" cases pin that the matchers read only `.databaseId`/`.number` — they do **not** reproduce clock skew, since the counter signature leaves no timestamp to skew. The skew defect was proven separately. The header and README say so, so nobody reads those cases as stronger than they are.

shellcheck/shfmt clean; no production code touched.