### PR TITLE
ci(verify): run the basic and licence gates on announce/** branches

### DIFF
--- a/.github/workflows/verify-basic.yml
+++ b/.github/workflows/verify-basic.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'announce/**']
 
 permissions:
   contents: read

--- a/.github/workflows/verify-licenses.yml
+++ b/.github/workflows/verify-licenses.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, 'announce/**']
 
 permissions:
   contents: read


### PR DESCRIPTION
PRs targeting the long-living `announce/integration` branch got no CI at all — both `verify-basic.yml` and `verify-licenses.yml` filtered `pull_request` to `main` only.

Widens the branch filter to `[main, 'announce/**']` so the same gates run before anything lands on the integration branch.

Verified locally: `task verify --force` exit 0, 1684 passed, 41 skipped, 2 xfailed, 2 xpassed.