### PR TITLE
test(announce-e2e): fill the Track D evidence table from live runs (gate G-D)

### DIFF
--- a/.claude/artifacts/e2e_results_announce.md
+++ b/.claude/artifacts/e2e_results_announce.md
@@ -4,9 +4,12 @@ Durable evidence that the fork-PR announce lane works end to end against the
 real `ocx-sh/index`. Consumed by Track E's rollout handover and Track F's
 doc-accuracy check.
 
-**Status:** template — no run recorded yet. Every cell reads `MISSING` until an
-operator executes the drivers in `test/manual/announce-e2e/` and pastes the
-rollup in. An incomplete evidence set is meant to look incomplete.
+**Status:** all five scenarios captured live on 2026-07-27 against
+`ocx-sh/index`, `michael-herwig/ocx-e2e-publisher` and
+`ghcr.io/michael-herwig/ocx-e2e-hello`. Every pull request, run and timestamp
+below is clickable. Re-running any driver overwrites its own row only — a
+scenario nobody captured stays a full `MISSING` row, because an incomplete
+evidence set is meant to look incomplete.
 
 ## How to fill this in
 
@@ -22,16 +25,65 @@ is committed and durable, so it must never carry a live credential.
 
 ## Results
 
-<!-- BEGIN evidence table — byte-identical to `render_evidence_markdown([])`
-     while empty; pinned by test_announce_e2e_evidence.py -->
+<!-- BEGIN evidence table — verbatim `evidence render` output; its shape is
+     pinned by test_announce_e2e_evidence.py -->
 | Scenario | Status | Pull Request | Runs | Latency (s) | Captured At | Notes |
 |---|---|---|---|---|---|---|
-| sequenced | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
-| idempotency | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
-| machine_lane | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
-| update_union | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
-| clean_install | MISSING | MISSING | MISSING | MISSING | MISSING | MISSING |
+| idempotency | pass | MISSING | MISSING | MISSING | 2026-07-27T07:29:10+00:00 | status=unchanged; 3 PR(s) unchanged; branch head 392b039 unchanged |
+| machine_lane | pass | https://github.com/ocx-sh/index/pull/87 | MISSING | 146.0 | 2026-07-27T07:28:40+00:00 | tag 1.0.8; {"lane": "machine", "human_click_detected": false, "actor_ids": [41898282]}; tag-push to merge 146.0s, tag-push to served 222.0s |
+| clean_install | pass | MISSING | MISSING | MISSING | 2026-07-27T07:24:17+00:00 | resolved michael-herwig/ocx-e2e-hello from https://index.ocx.sh in a clean debian container |
+| sequenced | pass | https://github.com/ocx-sh/index/pull/86 | https://github.com/michael-herwig/ocx-e2e-publisher/actions/runs/30245751807, https://github.com/ocx-sh/index/actions/runs/30245921245, https://index.ocx.sh/p/michael-herwig/ocx-e2e-hello.json | 160.0 | 2026-07-27T07:24:17+00:00 | tag 1.0.7; PR #86 merged at 2026-07-27T07:22:23Z; tag-push to merge 160.0s; (g2) 9 tag→object bindings over 2 distinct o/ objects, byte-identical to ghcr.io/michael-herwig/ocx-e2e-hello |
+| update_union | pass | https://github.com/ocx-sh/index/pull/88 | MISSING | MISSING | 2026-07-27T07:32:10+00:00 | single PR #88; committed [1,1.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5,1.0.6,1.0.7,1.0.8,1.0.9,latest] superset of [1.0.6,1.0.9] |
 <!-- END evidence table -->
+
+### Reading the MISSING cells
+
+A `MISSING` cell in a `pass` row is a field that driver never had a value for,
+not a gap in the evidence: `run_idempotency.sh` and `clean_install_check.sh`
+open no pull request, and `run_machine_lane.sh` records its two latency legs in
+Notes rather than as run URLs. Only a row whose **Status** reads `MISSING` is an
+uncaptured scenario, and such a row is `MISSING` in every column.
+
+## How this run was captured
+
+Tags `1.0.6`–`1.0.9` on `michael-herwig/ocx-e2e-publisher` were spent here
+(`1.0.1`–`1.0.5` were already consumed):
+
+| Tag | What it did | Disposition |
+|---|---|---|
+| `1.0.6` | first sequenced attempt; its pull request (#83) opened `CONFLICTING` off a spent branch | **closed unmerged**, tag left in place |
+| `1.0.7` | sequenced — pushed three times, retracted twice (see the two driver defects below) | merged as #86 |
+| `1.0.8` | machine lane | auto-merged as #87 — that *is* the proof |
+| `1.0.9` | pushed with the fork's announce branch deleted, so its announce could not commit | no pull request; tag left on the registry |
+
+`1.0.6` and `1.0.9` therefore sat on `ghcr.io` uncommitted, which is exactly the
+pair `run_update_union.sh` needs — two announceable tags without a sixth CI
+cycle.
+
+Three things had to be true before any driver ran, and the first of them is why
+the `1.0.6` attempt failed:
+
+- **The fork's announce branch must point at the index's `main` before each
+  run.** The index squash-merges, so the branch is spent after every merge and
+  the next announce opens `CONFLICTING` (that is what closed #83). Reset it,
+  never delete it — the dev-channel `ocx` the publisher CI resolves predates
+  `60c8b391` and cannot create the branch from scratch, which is how the `1.0.9`
+  announce was made to fail on purpose. See README.md "The spent branch".
+- **`OCX_ANNOUNCE_TOKEN` for the two local-announce drivers** —
+  `run_idempotency.sh` and `run_update_union.sh` announce from this machine.
+- **A release-shaped `ocx`** for the clean-machine image, staged from
+  `target/release/ocx`, never `test/bin/ocx` (D-7).
+
+`update_union`'s pull request (#88) auto-merged at `2026-07-27T07:32:58Z`,
+**after** the driver had already asserted the union at `07:32:10Z` against the
+still-open pull request — the C4 assertion was made on an unmerged branch, which
+is what the scenario requires.
+
+Two driver defects were found and fixed by this run, both in
+`scripts/env.sh`: `_checks_settled` treated a `QUEUED` GitHub Actions check as
+settled and failed a pull request whose checks had not started, and `poll_run`
+matched a retracted tag's stale workflow run and reported the previous attempt's
+verdict as this one's.
 
 ## What each row proves
 

--- a/test/manual/announce-e2e/README.md
+++ b/test/manual/announce-e2e/README.md
@@ -133,6 +133,22 @@ gh pr list --repo ocx-sh/index --state open \
 
 Empty output, or nothing naming your package, means the run measures itself.
 
+**The spent branch — reset it before every run.** The index squash-merges, so the
+announce branch's own commits never become ancestors of `main`. The next
+announce builds on that spent branch and its pull request opens `CONFLICTING`,
+which auto-merge cannot act on. `ocx` fixes this on its side (rebuild from the
+base when the branch is spent), but the publisher's CI resolves a dev-channel
+`ocx` and only picks the fix up once it is deployed. Until then, point the
+branch back at the index's `main` before each run — **reset it, never delete
+it**: a dev-channel `ocx` that predates the fix cannot create the branch from
+scratch and exits with `forge returned HTTP status 404 for .../git/refs`.
+
+```sh
+gh api -X PATCH "repos/$INDEX_FORK/git/refs/heads/$ANNOUNCE_BRANCH" \
+    -f sha="$(gh api "repos/$GH_REPO_INDEX/git/ref/heads/main" --jq .object.sha)" \
+    -F force=true --jq .object.sha
+```
+
 ## Sequenced Scenario
 
 `./scripts/run_sequence.sh <tag>` — design-spec §7's exit gate, in order.

--- a/test/manual/announce-e2e/scripts/env.sh
+++ b/test/manual/announce-e2e/scripts/env.sh
@@ -234,9 +234,15 @@ poll_check() {
 }
 
 _checks_settled() {
-    # grep exits 1 when no check is still PENDING — that is the success case.
+    # grep exits 1 when no check is still running — that is the success case.
+    #
+    # PENDING alone is not the whole unsettled set: gh reports a commit status
+    # as PENDING, but a check RUN carries its own status until it completes —
+    # QUEUED, IN_PROGRESS, WAITING, REQUESTED. Gating on PENDING only reads a
+    # queued Actions job as settled, and poll_check's all-green assertion then
+    # fails a pull request whose checks had simply not started yet.
     ! gh pr checks "$1" --repo "$GH_REPO_INDEX" --json state --jq '.[].state' |
-        grep -qx 'PENDING'
+        grep -qxE 'PENDING|QUEUED|IN_PROGRESS|WAITING|REQUESTED'
 }
 
 # The highest workflow-run id this repo+workflow+ref already carries, or 0.

--- a/test/tests/test_announce_e2e_evidence.py
+++ b/test/tests/test_announce_e2e_evidence.py
@@ -12,12 +12,16 @@ import json
 from pathlib import Path
 
 import pytest
+
 from announce_e2e.evidence import (
+    _TABLE_HEADER,
     MISSING,
     REDACTION,
+    SCENARIOS,
     EvidenceRecord,
     LaneClassification,
     Redacted,
+    _placeholder_row,
     assert_pr_union,
     classify_lane,
     classify_report,
@@ -357,11 +361,21 @@ def test_an_unredacted_run_must_be_stated_not_defaulted() -> None:
         main(["redact"])
 
 
-def test_render_of_an_empty_set_matches_the_committed_results_template() -> None:
-    """The committed artifact's table is exactly what an empty render produces.
+def test_the_committed_results_table_is_one_the_renderer_could_have_produced() -> None:
+    """The committed artifact's table stays renderer-shaped once it is filled.
 
-    Track E and Track F read that file; if the renderer and the template drift,
-    a filled-in run stops being comparable to the skeleton it replaced.
+    Track E and Track F read that file; if the renderer and the artifact drift,
+    a filled-in run stops being comparable to the skeleton it replaced. Real
+    records make byte-equality with `render_evidence_markdown([])` impossible,
+    so what is pinned is what the renderer decides regardless of run data: the
+    header, every scenario present exactly once, seven cells per row, and the
+    rule that an uncaptured scenario is a whole MISSING row rather than a
+    half-filled one.
+
+    Row *order* is deliberately not pinned. The renderer emits captured records
+    in the order they were read and only appends placeholders in `SCENARIOS`
+    order, so a filled table is ordered by record filename — pinning that would
+    fail the moment a scenario is recaptured under a new run id.
     """
     artifact = (
         Path(__file__).parents[2] / ".claude" / "artifacts" / "e2e_results_announce.md"
@@ -369,4 +383,22 @@ def test_render_of_an_empty_set_matches_the_committed_results_template() -> None
     body = artifact.read_text().split("<!-- BEGIN evidence table")[1]
     table = body.split("-->\n", 1)[1].split("<!-- END evidence table -->")[0]
 
-    assert table == render_evidence_markdown([])
+    assert table.startswith(_TABLE_HEADER)
+    rows = table[len(_TABLE_HEADER) :].splitlines(keepends=True)
+    scenarios = [_cells(row)[0] for row in rows]
+    assert sorted(scenarios) == sorted(SCENARIOS), (
+        "every scenario appears exactly once, and nothing else does"
+    )
+
+    for scenario, row in zip(scenarios, rows, strict=True):
+        cells = _cells(row)
+        assert len(cells) == 7, f"{scenario} row has {len(cells)} cells, not 7"
+        # A captured row may still carry MISSING in a field the run had no
+        # value for (idempotency records no pull request), so only the status
+        # cell distinguishes a placeholder — and a placeholder is all-MISSING.
+        if cells[1] == MISSING:
+            assert row == _placeholder_row(scenario)
+
+
+def _cells(row: str) -> list[str]:
+    return row.rstrip("\n").removeprefix("| ").removesuffix(" |").split(" | ")


### PR DESCRIPTION
Closes gate **G-D**. All five scenarios in `.claude/artifacts/e2e_results_announce.md` are now captured from live runs against the real `ocx-sh/index`, `michael-herwig/ocx-e2e-publisher` and `ghcr.io/michael-herwig/ocx-e2e-hello` — no hand-written cells.

| Scenario | Evidence |
|---|---|
| `sequenced` | [PR #86](https://github.com/ocx-sh/index/pull/86), tag `1.0.7`, 160s tag-push→merge; (g2) proved 9 tag→object bindings over 2 distinct `o/` objects byte-identical to ghcr.io |
| `machine_lane` | [PR #87](https://github.com/ocx-sh/index/pull/87), tag `1.0.8`, auto-merged, `human_click_detected: false`, 146s→merge / 222s→served |
| `idempotency` | `--refresh` reported `status=unchanged`, zero new PRs, zero new commits |
| `update_union` | [PR #88](https://github.com/ocx-sh/index/pull/88) carried both `1.0.6` and `1.0.9`; asserted at 07:32:10Z while still open (it auto-merged 48s later) |
| `clean_install` | `ocx package install` resolved from `index.ocx.sh` inside a clean debian container |

## The artifact and its pinning test move together

`test_render_of_an_empty_set_matches_the_committed_results_template` byte-compared the committed table against `render_evidence_markdown([])`. Real records make that impossible, so it is replaced by a test that pins what the renderer decides *regardless of run data*: the header, every scenario exactly once, seven cells per row, and a `MISSING` status meaning a whole `MISSING` row. Row order is deliberately not pinned — the renderer emits captured records in record-file order and only appends placeholders in `SCENARIOS` order.

Discrimination checked both ways: dropping the `update_union` row fails it, and turning a `pass` row into a half-filled placeholder (status `MISSING`, other cells populated) fails it. Restored → 40 passed.

## Two driver defects found by running the drivers

Both in `test/manual/announce-e2e/scripts/env.sh`, both fixed at the shared function:

- **`_checks_settled` gated on `PENDING` only.** `gh` reports a commit *status* as `PENDING`, but a check *run* carries its own status until it completes — `QUEUED`, `IN_PROGRESS`. A queued Actions job read as settled and `poll_check`'s all-green assertion then failed a pull request whose checks had simply not started. This aborted the first sequenced attempt on a PR that was green 30 seconds later.
- **`poll_run` identified a run by workflow, ref and commit alone.** After a tag is retracted and re-pushed — which README documents under "Cleaning up a rehearsal" — the retracted tag's run still matches, has already concluded, and `poll_run` reports the *previous* attempt's verdict as this one's. Verified: 2 stale runs on ref `1.0.7`, 0 after a floor. **This branch no longer carries a fix for it.** `announce/integration` already fixes it with `run_floor`'s server-side `databaseId` floor, and on rebase the wall-clock `--created` filter this branch carried was dropped rather than stacked on top: the id floor is read from the same server that issues the ids it filters, so no clock is involved on either side, and it is taken immediately before the push rather than at `env.sh` source time — strictly the tighter of the two. `scripts/selfcheck_identity.sh` (22 cases, 0 failures on this head) pins it.

## Operational blocker recorded in the README

The index squash-merges, so the fork's announce branch is never an ancestor of `main` after a merge. The next announce builds on that spent branch and its PR opens `CONFLICTING`, which auto-merge cannot act on — that is what closed [PR #83](https://github.com/ocx-sh/index/pull/83). `ocx` fixes this in `60c8b391`, but the publisher CI resolves a **dev-channel** `ocx` that predates it, so until `announce/integration` is deployed to the dev channel the operator must reset the branch to `main` before each run. **Reset, never delete** — the older `ocx` cannot create the branch from scratch and exits with `forge returned HTTP status 404 for .../git/refs`.

That 404 is also what made `update_union` cheap: pushing `1.0.9` with the branch deleted let its registry push land while its announce could not commit, which produced the second uncommitted registry tag the scenario needs without a sixth CI cycle.

## Gate

`task verify --force` → exit 0 (1794 passed, 42 skipped, 3 xfailed, 2 xpassed; AI-config suite 68 passed, 3 skipped). Acceptance suite run once, serialized, after all live drivers had finished.

## Not done

- The `sequenced` row's proof still depends on an operator resetting the announce branch by hand. That disappears once this branch reaches the dev channel — it is not a driver change.
- Tags `1.0.6`–`1.0.9` on the publisher are spent; `1.0.10`+ for the next rehearsal.
