### PR TITLE
docs(index): state the shipped default-index behaviour on the publish path

### DIFF
--- a/website/src/docs/reference/configuration.md
+++ b/website/src/docs/reference/configuration.md
@@ -129,7 +129,7 @@ Pinning the namespace at a [`[mirrors]`](#keys-mirrors) **registry** endpoint is
 
 Two limits keep the switch from firing where it was not meant to:
 
-- **Only a config file you control** — the compiled defaults, the discovered chain, and [`--config`][arg-config]/[`OCX_CONFIG`][env-config]. A `[mirrors]` entry arriving through the [`[managed]`](#keys-managed) tier redirects traffic like any other, but cannot suppress the index: a remotely-published payload must not be able to drop a namespace off the verified resolution path and its yank gate.
+- **Only a config file you control** — the compiled defaults, the discovered chain, and [`--config`][arg-config]/[`OCX_CONFIG`][env-config]. A `[mirrors]` entry arriving through the [`[managed]`](#keys-managed) tier or through [`OCX_MIRRORS`][env-mirrors] redirects traffic like any other, but cannot suppress the index: neither a remotely-published payload nor an inherited environment variable may drop a namespace off the verified resolution path and its yank gate.
 - **Only the `registry` role.** The `index` role is applied keyed on the *index endpoint's* own host, so `"ocx.sh" = { index = … }` cannot redirect anything for the `ocx.sh` namespace and does not suppress. Redirecting the index endpoint itself keeps the index path, pointed at your host:
 
 ```toml

--- a/website/src/docs/reference/environment.md
+++ b/website/src/docs/reference/environment.md
@@ -287,6 +287,14 @@ This variable is **resolution-affecting**: it is forwarded to every subprocess `
 
 `OCX_MIRRORS` overrides the [`[mirrors]`][config-mirrors] config key on a per-host, per-role basis. A role present in a host's `OCX_MIRRORS` entry replaces the config entry for that role only; roles and hosts absent from `OCX_MIRRORS` still come from `[mirrors]` in the config file.
 
+One thing it cannot do is revoke a verified index path. A `registry`-role entry
+in a config file the operator controls suppresses the compiled-in index for that
+namespace; the same entry arriving through `OCX_MIRRORS` redirects traffic but
+leaves the index in place. `OCX_MIRRORS='{"ocx.sh":"…"}'` therefore still
+resolves `ocx.sh/…` through [`index.ocx.sh`][in-depth-indices-public] — a forwarded
+environment variable must not be able to drop a namespace off the index's digest
+verification and yank gate.
+
 ::: warning Malformed values abort at startup
 A malformed `OCX_MIRRORS` value is a **hard startup error**. OCX aborts with an error message naming the problem:
 

--- a/website/src/docs/user-guide.md
+++ b/website/src/docs/user-guide.md
@@ -594,22 +594,21 @@ Two one-time steps happen on the [index site][index-ocx-sh] itself, before the f
 
 Most publishers already have a release workflow that builds and uploads binaries; slotting announce into it is additive, not a rewrite. The [copy-paste GitHub Actions snippet][index-announce-ci-snippet] on the index site shows where `push --announce-file` and `announce` go relative to your existing build steps, plus the `OCX_ANNOUNCE_TOKEN` secret wiring for both a classic-PAT and a machine-account setup. The snippet lives there, not here, so it stays in sync with the index bot's own contract instead of drifting out of two copies.
 
-### What your consumers need today {#publish-consumer-prerequisite}
+### What your consumers need {#publish-consumer-prerequisite}
 
-One honest caveat about the install side. Resolving `<ns>/<pkg>` through the
-public index requires the consumer's ocx to treat that namespace as
-index-kind, and today that means an explicit [`[registries."<prefix>"]`
-entry][config-registries-index] carrying an `index` URL — keyed on the
-**registry prefix** (`ocx.sh`), not on your package's namespace. Two things
-follow. That config field is not in a released ocx yet: 0.4.3 rejects it with
-`unknown field 'index', expected 'url'`. And `ocx.sh` is not index-kind by
-default, so even on a build that accepts the field, a consumer has to opt in
-by hand until that default ships.
+Nothing. The [compiled-in defaults][config-registries-index] name
+`https://index.ocx.sh` as the index for the `ocx.sh` namespace, so
+[`ocx package install`][cmd-install] `<ns>/<pkg>` resolves through the [public
+index][in-depth-indices-public] on a machine with no OCX config at all. A
+consumer opts *out*, not in — `index = ""`, or a [`[mirrors]`][config-mirrors]
+entry pinning `ocx.sh` at a registry endpoint.
 
-Until then, announce is worth doing early — the index entry is durable and
-your package is discoverable the moment consumers can resolve it — but a
-colleague on a released ocx cannot yet `ocx package install <ns>/<pkg>`
-without the registry coordinates you were trying to stop handing out.
+That authority is exclusive, and it cuts both ways. The index is the sole
+resolver for `ocx.sh/…` — which is what lets a yank reach everyone who
+installs the package — so an `index.ocx.sh` outage fails those installs
+outright rather than falling through to whatever registry happens to serve a
+repository under the same name. An announced package inherits the index's
+availability along with its guarantees.
 
 ### What happens after {#publish-what-happens-after}
 
@@ -764,6 +763,17 @@ A plain string, as above, redirects every kind of traffic OCX sends that host. A
 ### Relation to the default registry {#mirrors-default-registry}
 
 [`[registry] default`][config-registry-default] and `[mirrors]` are independent and compose. Default injection expands a bare identifier (e.g. `cmake:3.28` → `ocx.sh/cmake:3.28`) at parse time, before any mirror rewrite. If you also configure a `[mirrors]` entry for `ocx.sh`, that default-injected identifier is then mirrored. A fully air-gapped setup can mirror every registry the project uses, including the default one.
+
+Pinning `ocx.sh` at a mirror's **registry** endpoint carries one deliberate side effect: it suppresses the [compiled-in index][config-registries-index] for that namespace, which then resolves as a plain OCI registry through the mirror. That is the point — a site that routes `ocx.sh` to its own artifact manager should not start dialling `index.ocx.sh`, a host it never allow-listed. OCX logs a warning naming the namespace it dropped, because the index's digest verification and yank gate go with it. To keep the verified index path *and* pin the physical registry, name the index explicitly; a written `index` outranks the compiled-in one and is never suppressed.
+
+```toml
+[registries."ocx.sh"]
+index = "https://index.ocx.sh"                     # explicit: survives the mirror entry
+
+[mirrors]
+"ocx.sh" = "https://artifactory.corp/ocx-remote"
+"index.ocx.sh" = { index = "https://artifactory.corp/ocx-index" }
+```
 
 ### Lockfile portability {#mirrors-lockfile}
 


### PR DESCRIPTION
Gate **G-F** verification pass. Track F's doc work merged before three behaviour changes landed; this corrects what the docs now promise but no longer deliver.

## What was wrong

| Surface | Claim | Reality |
|---|---|---|
| `user-guide.md` §What your consumers need | consumers need an explicit `[registries."ocx.sh"] index` entry, and `ocx.sh` "is not index-kind by default" | the compiled-in default tier ships it; with `OCX_NO_CONFIG=1` and a scratch `OCX_HOME`, `ocx package inspect bazelbuild/bazelisk` resolves through `index.ocx.sh` |
| `user-guide.md` §Relation to the default registry | "a fully air-gapped setup can mirror every registry the project uses, including the default one" — full stop | a `[mirrors]` registry entry for `ocx.sh` also **suppresses** the compiled-in index; the namespace loses digest verification and the yank gate, with only a `warn` line to say so |
| `reference/environment.md` §`OCX_MIRRORS` | "overrides `[mirrors]` on a per-host, per-role basis" | it cannot revoke a verified index path — only a config file the operator controls can |
| `reference/configuration.md` "Two limits" | named the `[managed]` tier as the excluded source | `OCX_MIRRORS` is excluded too, and was unnamed |

The unreachable-index consequence is now stated where publishers meet it: `ocx.sh/…` fails outright rather than falling through to a registry serving the same name. That is the yank gate working, and it couples default installs to index availability — worth saying out loud on the page that asks people to announce.

## Evidence

Both against a release build of `announce/integration`, scratch `OCX_HOME`, `DOCKER_CONFIG` on an empty `{"auths":{}}`:

- no config at all → `ocx.sh/bazelbuild/bazelisk` resolves via the index (5 platform candidates).
- `OCX_MIRRORS='{"ocx.sh":"https://artifactory.invalid/ocx-remote"}'` → **still resolves through the index**.
- the same entry in a config file → `WARN [mirrors."ocx.sh"] pins this namespace at a mirror, so the compiled-in index default for it is suppressed`, then a plain-OCI fetch against the mirror.
- released `0.4.3`, same name, no config → `manifest not found` (no default tier), and it rejects the `index` key with `unknown field 'index', expected 'url'`.

Live `https://index.ocx.sh/config.json` serves `{"format_version":1,"name_segments":2}`; `ocx.sh/cmake` (single segment) still falls through to plain OCI, `ocx.sh/bazelbuild/bazelisk` does not.

`reference/configuration.md` §`index` and `in-depth/indices.md` §index.ocx.sh were checked line by line and are already accurate — the three code commits carried their own doc updates. Only `user-guide.md` and `environment.md` were left behind.

## Gate

`task website:build` exits 0. Docs-only diff (3 markdown files), so the website build is the gate per `subsystem-website.md`, not `task verify`.

## Deliberate deviation

The brief suggested distinguishing the released CLI from this branch rather than deleting the "add an `index` entry" instruction. I removed it instead: docs on a branch describe that branch, `CLAUDE.md` puts version boundaries in `CHANGELOG.md` and bans migration prose in user docs, and the sentence would become actively wrong on merge. The `index` key itself stays fully documented in `reference/configuration.md`, including the compiled-in tier and both off-switches. Say the word and I will add a version floor instead.