### PR TITLE
fix(create): require --platform with --metadata instead of guessing the host

### DIFF
--- a/.claude/artifacts/adr_platform_model_unification.md
+++ b/.claude/artifacts/adr_platform_model_unification.md
@@ -448,8 +448,9 @@ happened to carry moves to the single caller that fans out.
 - **`TargetPlatforms` is deleted** (`metadata/authoring/target_platforms.rs`). Published
   metadata never carried it (stripped at publish); authoring no longer needs a set.
 - **One platform per `ocx package create` / `ocx package push`.** `--platform` takes a single
-  value (default `current()`); `ocx package create --platform P` resolves each tag-only
-  dependency to the single leaf compatible with `P` and embeds nothing broader.
+  value, **required whenever `--metadata` is given and with no default** (see "No host default at
+  create" below); `ocx package create --platform P` resolves each tag-only dependency to the
+  single leaf compatible with `P` and embeds nothing broader.
 - **The `--platform any` coverage-intersection machinery is deleted** (`dependency_pinning.rs:
   155-297`): `resolve_for_any`, `derive_target_platforms`, `covered_platforms`,
   `candidate_universe`, `advertised_platform_keys`.
@@ -480,10 +481,41 @@ equals the pin (a flat `Manifest::Image`: its own digest must equal the pin). Er
 fetch cause) when the manifest cannot be fetched — an unverifiable claim is treated as untrusted,
 never silently accepted. Cost: one extra manifest GET per dependency, on `any`-target pushes only.
 
+### No host default at create
+
+`--platform` has **no default**. It is required whenever `--metadata` is given; an absent flag is a
+usage error (`UsageError`, exit 64) naming both flags. Without `--metadata` the flag stays optional —
+nothing is recorded, and it only shapes the inferred output filename.
+
+**Rationale.** `Platform::current()` answers a different question than the sidecar field asks. The
+host platform describes what the **build machine supplies** — including the libc family
+`HostCapabilities::detect` found on it. The recorded platform describes what the **packaged artifact
+demands**. Supply and demand are independent quantities: a static musl binary cross-built on a glibc
+runner demands neither the host's libc nor its architecture. `create` is the step that *records* the
+platform, so a guess there is not a local convenience — it is the origin of the value `push` and
+`test` bind to (below), the platform dependency pins are resolved for, and the executable convention
+`bin_scan` scans under. Verified on a glibc host: `create -m metadata.json` with no `--platform` wrote
+`"platform": "linux/amd64+libc.glibc"` into the sidecar without the publisher naming a platform
+anywhere.
+
+This closes the same class of defect the recorded-platform binding closed for `push`/`test`, at the
+one step that had kept a host default alive. Two consequences follow for free:
+
+- The D5 any-target rules (`any`-only dependencies, no direct digest pins) now run on **every**
+  `create --metadata` invocation. The no-`--platform` path previously skipped `pin_dependencies`
+  entirely for an already-pinned sidecar, so an `any`-targeted bundle carrying a hand-written digest
+  pin slipped past the check this ADR requires it to fail.
+- The "`--platform` omitted ⇒ metadata must already be fully pinned" usage error disappears with the
+  branch it guarded; the flag is required before pinning state is ever inspected.
+
+**Cost, accepted.** A fully-pinned sidecar bundled without `--platform` used to succeed and now exits
+64. Pre-1.0 clean break (D5 above) — no shim, no fallback, no deprecation window. Callers add the
+platform they were already targeting.
+
 ### Recorded platform binds `create` to `push`/`test`
 
-`ocx package create` resolves every dependency against its `--platform` value (default
-`Platform::current()`). That platform is **recorded in the authoring sidecar** — a new optional
+`ocx package create` resolves every dependency against its required `--platform` value. That
+platform is **recorded in the authoring sidecar** — a new optional
 `AuthoringBundle.platform` field, serialized as a **canonical-grammar string** on the wire
 (`#[serde(with = "platform_field")]`, `skip_serializing_if none`; optional in the JSON schema),
 read back via `AuthoringMetadata::platform()` / `resolve_platform()`.
@@ -691,6 +723,10 @@ resolved by user review (see D4 and R6). The remaining two are resolved by the a
 - [ ] `ocx package push`/`test` default to the sidecar's recorded platform; an explicit
       `--platform` mismatching it → `PlatformMismatch` (65); a sidecar missing the field →
       `MissingRecordedPlatform` (65).
+- [x] `ocx package create --metadata` without `--platform` exits 64 naming both flags and writes no
+      sidecar — including for an already-pinned sidecar, the case that previously succeeded and
+      recorded the host's own platform. Mutation-checked: restoring the host default turns the
+      guard red. *(implemented)*
 - [ ] Dual-libc host resolves both a `libc.glibc` and a `libc.musl` lock entry (gap-closed
       regression).
 - [ ] V1 and V2 `ocx.lock` fixtures both fail load with `UnsupportedLockVersion` + regenerate
@@ -735,3 +771,4 @@ resolved by user review (see D4 and R6). The remaining two are resolved by the a
 | 2026-07-17 | architect (opus) | Post-review amendments (both verified against merged `feat/platform-model-unification`): (1) D1 scoring extended to the **3-tuple `(is_specific, matched_refinement_count, matched_os_feature_count)`** (fix `650f0ef0`, `compatibility_score`) — the middle axis ranks a `variant`/`os_version`-exact offer above an unconstrained one, fixing the spurious `Ambiguous` on explicit `--platform linux/arm64/v8` (truth-table rows 8/9, 12/13 tied under the 2-tuple); scoring section, pseudocode, examples, and validation updated. (2) D5 gains the **recorded-platform binding** (fix `39ffaf56`): `AuthoringBundle.platform` (canonical-grammar string on the wire, optional in schema), `ocx package push`/`test` default to the recorded platform via `resolve_platform`, explicit `--platform` becomes a checked assertion (`PlatformMismatch` 65 / `MissingRecordedPlatform` 65) — closes the cross-compile host-default corruption. Surface map + validation updated; parity / canonical-key / escape / scoring validation rows marked implemented. |
 | 2026-07-17 | architect (opus) | Final gate-fix amendments (both verified against merged commit `9da15746`): (1) D5 **`any`-pin provenance check** — the push gate fetches each dependency's manifest by tag and requires an `any` entry whose digest equals the pin (flat manifest: own digest = pin); `PublishGateError::AnyPinNotAdvertisedAsAny` (65), `AnyPinProvenanceUnavailable` (fail-closed, chain-classified); one manifest GET per dep on any-target pushes. Sidecar keys are claims, not evidence. (2) D3 **write/load validation parity** — one `ProjectLock::validate` (declaration-hash version, bare repository, canonical keys) invoked by both `from_str_with_path` and `to_toml_string`/`save`; every serialized lock also loads (round-trip property test). |
 | 2026-07-17 | architect (sonnet) | **`os_version` axis removed from the model entirely** — no producer (authoring records `Platform::current()`, which never set it), no consumer (all five ship platforms bare), and anti-positioning (OS-version-tied binaries are the Homebrew-bottle disease OCX rejects, see `product-context.md`). Canonical grammar drops to `os/arch[/variant][+feature[,feature...]]` \| `any`; `@` loses reserved status in the percent-escape codec (legal literal, no escaping); `is_compatible`'s offer-gated strict equality and the scoring `matched_refinement_count` axis now apply to `variant` only. OCI boundary: an `os.version` key in a manifest `platform` entry is warn-dropped at the `TryFrom<native::Platform>` boundary, same pattern as the CPU `features` warn-drop — verbatim-observed foreign data, reversible without migration. Grammar, EBNF, escape table, truth table (renumbered #1–#16), scoring, round-trip, and validation sections updated to read as designed without it. |
+| 2026-07-27 | architect (opus) | **D5 loses the create-time host default** (defect found in `package_create.rs::validation_platform`, which still resolved an absent `--platform` to `Platform::current()`). `--platform` is now required whenever `--metadata` is given — usage error, exit 64, naming both flags — and has no default at all; without `--metadata` it stays optional and filename-only. The host platform answers what the build machine *supplies* (libc included); the sidecar field states what the artifact *demands*, and `create` is the step that records it, so the guess corrupted the pins, the `bin_scan` executable convention, and the value `push`/`test` bind to. Empirically: a glibc host recorded `linux/amd64+libc.glibc` with no platform named anywhere. Alternative (b) — record nothing and let `MissingRecordedPlatform` fire at push — was rejected: it still needs a platform for the projection and the binaries scan, and `Platform::any()` there both misfires D5's any-target rules on concrete bundles and silently bakes a wrong `binaries` claim, moving the guess to a field with no downstream guard. Consequences: the D5 any-target digest-pin check now runs on every `--metadata` invocation (the no-`--platform` path had skipped `pin_dependencies` for already-pinned sidecars), and the "omitted ⇒ must be fully pinned" usage error is deleted with the branch it guarded. Pre-1.0 clean break — a fully-pinned bundle created without `--platform` now exits 64. |

--- a/crates/ocx_cli/src/command/package_create.rs
+++ b/crates/ocx_cli/src/command/package_create.rs
@@ -17,14 +17,15 @@ pub struct PackageCreate {
     identifier: Option<options::Identifier>,
     /// Platform of the package content (e.g. `linux/amd64`, or `any` for platform-agnostic content)
     ///
-    /// When metadata declares dependencies without a digest, this flag is
-    /// required: create resolves each one against the selected index to a
-    /// platform manifest digest and rewrites the metadata sidecar with the
-    /// resolved pins. Resolution honors `--remote`, `--offline`, and
-    /// `--frozen`. When `--metadata` is given, this platform is also
-    /// recorded in the sidecar; `ocx package push` and `ocx package test`
-    /// default to it and reject a `--platform` that disagrees. Also used
-    /// to infer the output filename.
+    /// Required whenever `--metadata` is given: it declares the platform the
+    /// packaged content runs on, which cannot be read off the machine doing
+    /// the build. Dependencies carrying no digest are resolved against the
+    /// selected index to a platform manifest digest for this platform, the
+    /// content tree is scanned under this platform's executable convention,
+    /// and the value is recorded in the metadata sidecar; `ocx package push`
+    /// and `ocx package test` default to the recorded value and reject a
+    /// `--platform` that disagrees. Resolution honors `--remote`,
+    /// `--offline`, and `--frozen`. Also used to infer the output filename.
     #[clap(short, long)]
     platform: Option<oci::Platform>,
     /// Output file or directory, if a directory is provided the filename will be inferred
@@ -35,9 +36,9 @@ pub struct PackageCreate {
     force: bool,
     /// Path to a `metadata.json` file to validate, resolve, and write alongside the output bundle
     ///
-    /// Dependencies without a digest are pinned to platform manifest digests
-    /// (requires `--platform`); the resolved sidecar is written next to the
-    /// output bundle in canonical form.
+    /// Requires `--platform`. Dependencies without a digest are pinned to
+    /// that platform's manifest digests; the resolved sidecar is written next
+    /// to the output bundle in canonical form.
     #[clap(short, long)]
     metadata: Option<std::path::PathBuf>,
     /// Compression level to use for the package bundle
@@ -56,6 +57,7 @@ pub struct PackageCreate {
 impl PackageCreate {
     pub async fn execute(&self, context: crate::app::Context) -> anyhow::Result<ExitCode> {
         self.validate_bin_scan()?;
+        let declared_platform = self.declared_platform()?;
 
         let identifier = options::Identifier::transform_optional(self.identifier.clone(), context.default_registry())?;
         let output = match &self.output {
@@ -82,19 +84,17 @@ impl PackageCreate {
         // empty platform intersection), and a failure must leave no orphan
         // bundle on disk (Codex #3). Only after the metadata is fully validated
         // do we build the archive and, last, write the resolved sidecar.
-        let resolved_metadata = match &self.metadata {
-            Some(metadata_source) => {
-                let metadata = AuthoringMetadata::read_json(metadata_source.as_path()).await?;
-                let metadata = self.resolve_dependency_pins(metadata, &context).await?;
-                let platform = self.validation_platform();
+        let resolved_metadata = match self.metadata.as_deref().zip(declared_platform) {
+            Some((metadata_source, platform)) => {
+                let metadata = AuthoringMetadata::read_json(metadata_source).await?;
+                let metadata = self.resolve_dependency_pins(metadata, &context, &platform).await?;
                 let metadata = self.resolve_binaries(metadata, &platform).await?;
                 // Validate the projection the publisher will actually push:
                 // run the publish-time env/entrypoint checks against the
                 // declared platform.
                 package::metadata::ValidMetadata::try_from(metadata.to_published(&platform)?)?;
                 // Record the platform dependency pins were resolved against
-                // so `ocx package push`/`ocx package test` can bind to it
-                // instead of silently defaulting to the host platform.
+                // so `ocx package push`/`ocx package test` bind to it.
                 Some(metadata.with_platform(platform))
             }
             None => None,
@@ -148,36 +148,40 @@ impl PackageCreate {
         Ok(())
     }
 
-    /// Pick the platform to run publish-time validation against: the declared
-    /// `--platform`, or the host platform (falling back to `any`) when a
-    /// pre-pinned sidecar was supplied without one.
-    fn validation_platform(&self) -> oci::Platform {
-        self.platform
-            .clone()
-            .unwrap_or_else(|| oci::Platform::current().unwrap_or_else(oci::Platform::any))
+    /// The platform `--metadata` is compiled for: dependency pins resolve
+    /// against it, the binaries scan applies its executable convention, and
+    /// it is recorded in the sidecar for `ocx package push` / `ocx package
+    /// test` to read back. `None` when no sidecar was supplied — `--platform`
+    /// then only shapes the inferred output filename.
+    ///
+    /// There is no default. The host platform describes what the build
+    /// machine *supplies*; the recorded platform describes what the packaged
+    /// artifact *demands* — a static musl binary cross-built on a glibc host
+    /// demands neither the host's libc nor its architecture. Guessing one
+    /// from the other corrupts every downstream consumer of the recorded
+    /// value, so an absent `--platform` is a usage error rather than a
+    /// silent host default.
+    fn declared_platform(&self) -> anyhow::Result<Option<oci::Platform>> {
+        match (&self.metadata, &self.platform) {
+            (None, _) => Ok(None),
+            (Some(_), Some(platform)) => Ok(Some(platform.clone())),
+            (Some(_), None) => Err(ocx_lib::cli::UsageError::new(
+                "--platform (-p) is required with --metadata (-m); the sidecar records the platform \
+                 the packaged content runs on, which cannot be inferred from the build host",
+            )
+            .into()),
+        }
     }
 
-    /// Resolve unpinned dependencies against the selected index.
-    ///
-    /// - `--platform` given: resolve every unpinned dependency against it
-    ///   (already-pinned dependencies pass through untouched, no network).
-    /// - `--platform` omitted: metadata must already be fully pinned (usage
-    ///   error otherwise); passes through for canonical rewrite only.
+    /// Resolve unpinned dependencies against the selected index for
+    /// `platform`. Already-pinned dependencies pass through untouched (no
+    /// network).
     async fn resolve_dependency_pins(
         &self,
         metadata: AuthoringMetadata,
         context: &crate::app::Context,
+        platform: &oci::Platform,
     ) -> anyhow::Result<AuthoringMetadata> {
-        let Some(platform) = &self.platform else {
-            if !metadata.is_fully_pinned() {
-                return Err(ocx_lib::cli::UsageError::new(
-                    "metadata declares dependencies that are not pinned to a manifest digest; \
-                     pass --platform (-p) so ocx package create can resolve them",
-                )
-                .into());
-            }
-            return Ok(metadata);
-        };
         let _spin = context.progress().spinner("Resolving dependency pins");
         Ok(package::dependency_pinning::pin_dependencies(metadata, context.default_index(), platform).await?)
     }
@@ -258,5 +262,69 @@ mod tests {
     fn auto_mode_without_metadata_is_accepted() {
         let create = PackageCreate::try_parse_from(["package-create", "."]).expect("parse");
         assert!(create.validate_bin_scan().is_ok());
+    }
+
+    /// `--metadata` without `--platform` must not fall back to the host
+    /// platform. The host describes what the build machine supplies; the
+    /// sidecar field describes what the artifact demands. A musl bundle
+    /// cross-built on a glibc host would otherwise be recorded as demanding
+    /// `libc.glibc`, and `ocx package push` / `ocx package test` bind to that
+    /// recorded value — so the corruption is unrecoverable downstream.
+    #[test]
+    fn metadata_without_platform_is_rejected_instead_of_defaulting_to_the_host() {
+        let create = PackageCreate::try_parse_from(["package-create", "-m", "metadata.json", "."]).expect("parse");
+        let error = create
+            .declared_platform()
+            .expect_err("--metadata without --platform must not resolve to the host platform");
+        let message = error.to_string();
+        assert!(
+            message.contains("--platform") && message.contains("--metadata"),
+            "usage error must name both flags: {message}"
+        );
+    }
+
+    /// The rejection above is a usage error (64), not a data error — the
+    /// invocation is malformed, nothing was read or parsed yet. Classified
+    /// through the same path `main` uses.
+    #[test]
+    fn metadata_without_platform_exits_with_usage_error() {
+        let create = PackageCreate::try_parse_from(["package-create", "-m", "metadata.json", "."]).expect("parse");
+        let error = create.declared_platform().expect_err("rejected above");
+        assert_eq!(
+            crate::app::classify_error(error.as_ref()),
+            ocx_lib::cli::ExitCode::UsageError
+        );
+    }
+
+    /// Control for the two tests above: with `--platform` given, the declared
+    /// value is what gets recorded — verbatim, including a libc feature the
+    /// build host does not have.
+    #[test]
+    fn declared_platform_is_the_flag_value_verbatim() {
+        let create = PackageCreate::try_parse_from([
+            "package-create",
+            "-m",
+            "metadata.json",
+            "-p",
+            "linux/amd64+libc.musl",
+            ".",
+        ])
+        .expect("parse");
+        let platform = create.declared_platform().expect("explicit platform is accepted");
+        assert_eq!(
+            platform.map(|platform| platform.to_string()),
+            Some("linux/amd64+libc.musl".to_string())
+        );
+    }
+
+    /// No sidecar, no recorded platform: `--platform` stays optional there,
+    /// where it only shapes the inferred output filename.
+    #[test]
+    fn no_metadata_needs_no_platform() {
+        let create = PackageCreate::try_parse_from(["package-create", "."]).expect("parse");
+        assert!(
+            create.declared_platform().expect("no sidecar is ok").is_none(),
+            "without --metadata there is nothing to record a platform on"
+        );
     }
 }

--- a/crates/ocx_cli/src/command/package_create.rs
+++ b/crates/ocx_cli/src/command/package_create.rs
@@ -95,6 +95,19 @@ impl PackageCreate {
                 package::metadata::ValidMetadata::try_from(metadata.to_published(&platform)?)?;
                 // Record the platform dependency pins were resolved against
                 // so `ocx package push`/`ocx package test` bind to it.
+                //
+                // This overwrites a `platform` already present in the input
+                // sidecar rather than asserting agreement with it, which is
+                // the opposite of what `push`/`test` do with a disagreeing
+                // `--platform` (`PlatformMismatch`, exit 65). Intended: the
+                // asymmetry is declare-vs-assert. `create` DECLARES the
+                // target — `--platform` is this invocation's statement of
+                // what the content runs on, and everything below it (pins,
+                // binaries scan, projection) is resolved for that value, so
+                // the field it writes is an output. `push`/`test` ASSERT
+                // against that output. Re-creating an existing sidecar for a
+                // different target is the ordinary cross-compile case, not
+                // an error to be caught here.
                 Some(metadata.with_platform(platform))
             }
             None => None,

--- a/test/doc_scripts/package-create.sh
+++ b/test/doc_scripts/package-create.sh
@@ -6,5 +6,5 @@
 set -euo pipefail
 cd "$SCENARIO_TMP"
 # region cast
-ocx package create build -m metadata.json -o mytool-1.0.0.tar.xz
+ocx package create build -p linux/amd64 -m metadata.json -o mytool-1.0.0.tar.xz
 # endregion cast

--- a/test/manual/README.md
+++ b/test/manual/README.md
@@ -106,7 +106,7 @@ Substitute `$NS` with `dojo` (the default namespace).
 
 ```sh
 cd test/manual/packages/single-layer-hello
-ocx package create build -m metadata.json -o /tmp/hello-1.0.0.tar.xz
+ocx package create build -p linux/amd64 -m metadata.json -o /tmp/hello-1.0.0.tar.xz
 ocx package test -p linux/amd64 -m metadata.json \
     -i $OCX_DEFAULT_REGISTRY/dojo/single-layer-hello:1.0.0 \
     /tmp/hello-1.0.0.tar.xz -- hello
@@ -166,9 +166,9 @@ Look for the absence of `SOMEVAR=present` in the printed env.
 ```sh
 # Bundle each layer.
 m=test/manual/packages/multi-layer-app/metadata.json
-ocx package create -m $m -o /tmp/base.tar.gz test/manual/packages/multi-layer-app/layer-base
-ocx package create -m $m -o /tmp/libs.tar.gz test/manual/packages/multi-layer-app/layer-libs
-ocx package create -m $m -o /tmp/app.tar.gz  test/manual/packages/multi-layer-app/layer-app
+ocx package create -p linux/amd64 -m $m -o /tmp/base.tar.gz test/manual/packages/multi-layer-app/layer-base
+ocx package create -p linux/amd64 -m $m -o /tmp/libs.tar.gz test/manual/packages/multi-layer-app/layer-libs
+ocx package create -p linux/amd64 -m $m -o /tmp/app.tar.gz  test/manual/packages/multi-layer-app/layer-app
 
 # Push v1 with three file layers.
 fq=$OCX_DEFAULT_REGISTRY/dojo/multi-layer-app:1.0.0

--- a/test/manual/scripts/bootstrap.sh
+++ b/test/manual/scripts/bootstrap.sh
@@ -30,7 +30,7 @@ MANUAL_ROOT="${REPO_ROOT}/test/manual"
 
 # Run from test/manual/packages/<repo>/ for each package so echoed `ocx`
 # calls look like the real-world workflow: `cd packages/foo`, then
-# `ocx package create -m metadata.json -o out/foo-1.0.0.tar.xz build`.
+# `ocx package create -p "$PLATFORM" -m metadata.json -o out/foo-1.0.0.tar.xz build`.
 # `out/` is gitignored.
 cd "$MANUAL_ROOT"
 PKG_ROOT="packages"

--- a/test/manual/scripts/setup-patches.sh
+++ b/test/manual/scripts/setup-patches.sh
@@ -158,7 +158,7 @@ push_patch_pkg() {
     (
         ocx_cd "${bundle_dir}"
         mkdir -p out
-        ocx package create --force -m metadata.json -o "${bundle}" build
+        ocx package create --force -p "${PLATFORM}" -m metadata.json -o "${bundle}" build
         ocx package push -n -c -p "${PLATFORM}" -m metadata.json \
             -i "$(id_of "patches/${subpath##*/}")" "${bundle}"
     )

--- a/test/src/helpers.py
+++ b/test/src/helpers.py
@@ -333,6 +333,8 @@ def make_package(
             str(metadata_path),
             "-o",
             str(bundle_ln),
+            "-p",
+            plat,
             str(layer_dir),
         )
         all_bundles.append(bundle_ln)

--- a/test/src/scenarios/multi_layer.py
+++ b/test/src/scenarios/multi_layer.py
@@ -62,7 +62,7 @@ class MultiLayer(Scenario):
             bundle = self.tmp_path / f"{layer_dir.name}.tar.gz"
             self.ocx.plain(
                 "package", "create",
-                "-m", str(metadata_path), "-o", str(bundle), str(layer_dir),
+                "-m", str(metadata_path), "-o", str(bundle), "-p", plat, str(layer_dir),
             )
             bundles.append(bundle)
 

--- a/test/tests/test_assembly.py
+++ b/test/tests/test_assembly.py
@@ -229,6 +229,8 @@ def _make_two_packages_sharing_layer(
         str(metadata_path),
         "-o",
         str(bundle_path),
+        "-p",
+        current_platform(),
         str(pkg_dir),
     )
 
@@ -595,7 +597,10 @@ def test_strip_applied_at_assemble_registry_path(
     base_meta = tmp_path / "registry-base-meta.json"
     base_meta.write_text(json.dumps({"type": "bundle", "version": 1}))
     bundle = tmp_path / "registry-topdir-bundle.tar.xz"
-    ocx.plain("package", "create", "-m", str(base_meta), "-o", str(bundle), str(pkg_dir))
+    ocx.plain(
+        "package", "create", "-m", str(base_meta), "-o", str(bundle),
+        "-p", current_platform(), str(pkg_dir),
+    )
 
     for repo, strip in ((repo_strip1, 1), (repo_strip0, 0)):
         meta = tmp_path / f"registry-meta-{repo}.json"
@@ -662,7 +667,10 @@ def test_strip_applied_at_assemble_local_path(
     base_meta = tmp_path / "local-base-meta.json"
     base_meta.write_text(json.dumps({"type": "bundle", "version": 1, "platform": current_platform()}))
     bundle = tmp_path / "local-topdir-bundle.tar.xz"
-    ocx.plain("package", "create", "-m", str(base_meta), "-o", str(bundle), str(pkg_dir))
+    ocx.plain(
+        "package", "create", "-m", str(base_meta), "-o", str(bundle),
+        "-p", current_platform(), str(pkg_dir),
+    )
 
     # Push once so the identifier resolves cleanly; the local metadata (-m) is
     # what drives assemble strip, not the pushed config.
@@ -739,7 +747,10 @@ def test_single_package_strip_components_regression(
     meta = tmp_path / "regress-meta.json"
     _strip_metadata(meta, 1)
     bundle = tmp_path / "regress-bundle.tar.xz"
-    ocx.plain("package", "create", "-m", str(meta), "-o", str(bundle), str(pkg_dir))
+    ocx.plain(
+        "package", "create", "-m", str(meta), "-o", str(bundle),
+        "-p", current_platform(), str(pkg_dir),
+    )
 
     fq = f"{ocx.registry}/{unique_repo}:{tag}"
     ocx.plain("package", "push", "-n", "-p", current_platform(), "-m", str(meta), "-i", fq, str(bundle))

--- a/test/tests/test_cross_repo_dedup.py
+++ b/test/tests/test_cross_repo_dedup.py
@@ -65,7 +65,9 @@ def test_cross_repo_dedup_preserves_query_repository(
         )
     )
     bundle = tmp_path / "bundle.tar.xz"
-    ocx.plain("package", "create", "-m", str(metadata), "-o", str(bundle), str(pkg_dir))
+    ocx.plain(
+        "package", "create", "-m", str(metadata), "-o", str(bundle), "-p", plat, str(pkg_dir)
+    )
 
     def push(repo: str) -> None:
         fq = f"{ocx.registry}/{repo}:{tag}"

--- a/test/tests/test_doc_scripts.py
+++ b/test/tests/test_doc_scripts.py
@@ -18,7 +18,9 @@ Design contract reference: design_spec_doc_command_scripts.md
 """
 from __future__ import annotations
 
+import re
 import sys
+from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
@@ -38,36 +40,88 @@ pytestmark = pytest.mark.skipif(
 DOC_SCRIPTS_DIR: Path = PROJECT_ROOT / "test" / "doc_scripts"
 
 
+SHARED_SLOT_GROUPS: dict[str, str] = {
+    # `ocx patch sync` with no `--platform` also probes the registry-wide
+    # reserved `global` patch-descriptor repository — the same shared slot
+    # `tests/test_patches.py` serializes itself against.
+    "patches__consumer.sh": "patch_global_slot",
+    # Fixed, non-`unique_repo` identifier `corp/ocx-config` (the on-screen
+    # example in the docs).
+    "user-guide__managed-config-rollout.sh": "managed_config_corp_slot",
+    "user-guide__managed-config-publish.sh": "managed_config_corp_slot",
+    # Fixed identifier `mytool` — the on-screen name on the authoring pages.
+    # Six publisher scripts share it; without a group, two xdist workers push
+    # manifests into one repo and the loser sees DIGEST_INVALID /
+    # MANIFEST_BLOB_UNKNOWN.
+    "package-cascade.sh": "mytool_repo_slot",
+    "package-describe.sh": "mytool_repo_slot",
+    "package-layer-reuse.sh": "mytool_repo_slot",
+    "package-multi-platform.sh": "mytool_repo_slot",
+    "package-push.sh": "mytool_repo_slot",
+    "package-test.sh": "mytool_repo_slot",
+}
+"""Doc scripts that touch a registry resource no per-worker prefix isolates.
+
+A script that only *consumes* provisioned packages is isolated for free: it
+reaches them through `$PKG_*` / `$REPO_*`, whose values carry the SP7
+`t_<8hex>_` prefix. A script that *publishes* under a name spelled out in the
+docs bypasses that entirely, so every script pushing to the same fixed name
+must share one xdist group and run serially.
+
+Hand-maintained, and `test_fixed_repo_publishers_are_slot_grouped` keeps it
+honest for the class it can see. Renaming these repos is not the fix — the
+identifier is the artifact the docs page renders.
+"""
+
+# `ocx package push -i <ident>` / `ocx config push -i <ident>`. A `$`-prefixed
+# value is a provisioned, per-worker-unique repo; anything else is literal.
+_PUBLISH_IDENTIFIER = re.compile(r"ocx (?:package|config) push\b[^\n]*?\s(?:-i|--identifier)[= ]\s*(\S+)")
+
+
+def fixed_repo_publishers(scripts: Iterable[Path]) -> set[str]:
+    """Names of scripts that publish under a literal (non-`$`) identifier."""
+    return {
+        script.name
+        for script in scripts
+        if any(not ident.startswith("$") for ident in _PUBLISH_IDENTIFIER.findall(script.read_text()))
+    }
+
+
+def test_fixed_repo_publishers_are_slot_grouped() -> None:
+    """Every script publishing to a fixed identifier must carry an xdist group.
+
+    The map above is hand-maintained, and six `mytool` publishers sat outside
+    it long enough to read as flake rather than as a missing entry. This is the
+    check that makes script number seven red instead of intermittent.
+
+    Ceiling: it sees the `push -i <literal>` class only. A script racing a
+    reserved name it never names as an identifier — `patches__consumer.sh` and
+    the `global` patch-descriptor slot — is invisible here and stays a
+    hand-added entry. Detecting *that* would mean knowing which commands touch
+    which registry-wide singletons, which is not readable off the script.
+    """
+    ungrouped = sorted(fixed_repo_publishers(discover_doc_scripts(DOC_SCRIPTS_DIR)) - set(SHARED_SLOT_GROUPS))
+    assert not ungrouped, (
+        f"doc scripts publish to a fixed identifier but carry no xdist group: {ungrouped}. "
+        f"Add each to SHARED_SLOT_GROUPS, sharing one group per identifier, or they will "
+        f"race another worker pushing the same repo."
+    )
+
+
 def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
     """Parametrize ``test_doc_script`` over every ``.sh`` file under ``DOC_SCRIPTS_DIR``.
 
     Empty or missing root ⇒ zero parameters ⇒ zero cases, no error.
     Case IDs are paths relative to ``DOC_SCRIPTS_DIR`` (parity with
-    ``test_scenarios_smoke.py``).
-
-    ``patches__consumer.sh`` runs ``ocx patch sync`` with no ``--platform``,
-    which (per D4 of `adr_platform_model_unification.md`) also probes the
-    registry-wide reserved ``global`` patch-descriptor repository — the same
-    shared slot `tests/test_patches.py` serializes itself against via the
-    ``patch_global_slot`` xdist group. Join that group here too so this case
-    never races a concurrent global-descriptor publish from that module.
-
-    ``user-guide__managed-config-{rollout,publish}.sh`` both push to the
-    fixed, non-``unique_repo`` identifier ``corp/ocx-config`` (the on-screen
-    example in the docs) — join a shared group so the two never run
-    concurrently on different xdist workers and race the same registry repo.
+    ``test_scenarios_smoke.py``). Scripts named in ``SHARED_SLOT_GROUPS`` are
+    marked into their group so they never run concurrently.
     """
-    _SHARED_SLOT_GROUPS = {
-        "patches__consumer.sh": "patch_global_slot",
-        "user-guide__managed-config-rollout.sh": "managed_config_corp_slot",
-        "user-guide__managed-config-publish.sh": "managed_config_corp_slot",
-    }
     if "script" in metafunc.fixturenames:
         scripts = discover_doc_scripts(DOC_SCRIPTS_DIR)
         ids = [str(p.relative_to(DOC_SCRIPTS_DIR)) for p in scripts]
         params = [
-            pytest.param(script, marks=pytest.mark.xdist_group(_SHARED_SLOT_GROUPS[script.name]))
-            if script.name in _SHARED_SLOT_GROUPS
+            pytest.param(script, marks=pytest.mark.xdist_group(SHARED_SLOT_GROUPS[script.name]))
+            if script.name in SHARED_SLOT_GROUPS
             else script
             for script in scripts
         ]

--- a/test/tests/test_entrypoints.py
+++ b/test/tests/test_entrypoints.py
@@ -18,7 +18,7 @@ import pytest
 
 from src.helpers import make_package, make_package_with_entrypoints
 from src.registry import fetch_platform_manifest_digest
-from src.runner import OcxRunner, PackageInfo
+from src.runner import OcxRunner, PackageInfo, current_platform
 
 
 # ---------------------------------------------------------------------------
@@ -159,7 +159,8 @@ def test_invalid_entrypoint_name_rejected_at_validation(
 
     bundle = tmp_path / "bundle-invalid-ep.tar.xz"
     result = ocx.run(
-        "package", "create", "-m", str(metadata_path), "-o", str(bundle), str(pkg_dir),
+        "package", "create", "-m", str(metadata_path), "-o", str(bundle),
+        "-p", current_platform(), str(pkg_dir),
         check=False,
     )
     assert result.returncode != 0, (

--- a/test/tests/test_layer_layout.py
+++ b/test/tests/test_layer_layout.py
@@ -44,7 +44,10 @@ def _bundle_layer(ocx: OcxRunner, layer_dir: Path, tmp_path: Path) -> Path:
             {"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"},
         ],
     }))
-    ocx.plain("package", "create", "-m", str(metadata_path), "-o", str(bundle), str(layer_dir))
+    ocx.plain(
+        "package", "create", "-m", str(metadata_path), "-o", str(bundle),
+        "-p", current_platform(), str(layer_dir),
+    )
     return bundle
 
 

--- a/test/tests/test_multi_layer.py
+++ b/test/tests/test_multi_layer.py
@@ -56,7 +56,10 @@ def _bundle_layer(
             {"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"},
         ],
     }))
-    ocx.plain("package", "create", "-m", str(metadata_path), "-o", str(bundle), str(layer_dir))
+    ocx.plain(
+        "package", "create", "-m", str(metadata_path), "-o", str(bundle),
+        "-p", current_platform(), str(layer_dir),
+    )
     return bundle
 
 

--- a/test/tests/test_package_create_pinning.py
+++ b/test/tests/test_package_create_pinning.py
@@ -244,12 +244,18 @@ def test_create_metadata_without_platform_is_usage_error(
     pkg_dir, metadata = _write_app(
         tmp_path, "noplat", [{"identifier": f"{leaf.fq}@{manifest_digest}"}]
     )
-    out = tmp_path / "app-noplat.tar.xz"
+    # Deliberately NOT `app-noplat.tar.xz`: `_write_app` names the authored
+    # sidecar `app-noplat-metadata.json`, which is byte-for-byte the path
+    # `create -o app-noplat.tar.xz` derives for the sidecar it writes. Under
+    # the colliding name the "no sidecar" assertion below observes the
+    # fixture's own input file and fires whatever `create` did.
+    out = tmp_path / "app-noplat-bundle.tar.xz"
 
     result = _create(ocx, pkg_dir, metadata, out, check=False)
     assert result.returncode == EXIT_USAGE, result.stderr
     assert "--platform" in result.stderr, "error must hint at --platform"
     assert not _sidecar_path(out).exists(), "a rejected create must write no sidecar"
+    assert not out.exists(), "a rejected create must leave no orphan bundle"
 
 
 def test_create_concrete_platform_passes_through_pinned_dep(

--- a/test/tests/test_package_create_pinning.py
+++ b/test/tests/test_package_create_pinning.py
@@ -40,7 +40,13 @@ def _write_app(tmp_path: Path, name: str, deps: list[dict]) -> tuple[Path, Path]
     pkg_dir = tmp_path / f"app-{name}"
     (pkg_dir / "bin").mkdir(parents=True)
     (pkg_dir / "bin" / "app").write_text("#!/bin/sh\necho app\n")
-    metadata = tmp_path / f"app-{name}-metadata.json"
+    # NOT `app-{name}-metadata.json`: that is exactly the path
+    # `create -o app-{name}.tar.xz` derives for the sidecar it WRITES. Sharing
+    # it would make every `_sidecar(out)` assertion below read a file the
+    # fixture authored, so a create that wrote nothing — or wrote back to its
+    # `-m` input instead of next to `-o` (helpers.py documents it must not) —
+    # would still look green.
+    metadata = tmp_path / f"app-{name}-input.json"
     metadata.write_text(
         json.dumps({"type": "bundle", "version": 1, "dependencies": deps})
     )
@@ -244,12 +250,7 @@ def test_create_metadata_without_platform_is_usage_error(
     pkg_dir, metadata = _write_app(
         tmp_path, "noplat", [{"identifier": f"{leaf.fq}@{manifest_digest}"}]
     )
-    # Deliberately NOT `app-noplat.tar.xz`: `_write_app` names the authored
-    # sidecar `app-noplat-metadata.json`, which is byte-for-byte the path
-    # `create -o app-noplat.tar.xz` derives for the sidecar it writes. Under
-    # the colliding name the "no sidecar" assertion below observes the
-    # fixture's own input file and fires whatever `create` did.
-    out = tmp_path / "app-noplat-bundle.tar.xz"
+    out = tmp_path / "app-noplat.tar.xz"
 
     result = _create(ocx, pkg_dir, metadata, out, check=False)
     assert result.returncode == EXIT_USAGE, result.stderr

--- a/test/tests/test_package_create_pinning.py
+++ b/test/tests/test_package_create_pinning.py
@@ -70,9 +70,14 @@ def _create(
     )
 
 
+def _sidecar_path(out: Path) -> Path:
+    """Where `create` writes the rewritten sidecar for output bundle `out`."""
+    return out.parent / (out.name.replace(".tar.xz", "") + "-metadata.json")
+
+
 def _sidecar(out: Path) -> dict:
     """Read the rewritten metadata sidecar next to the output bundle."""
-    sidecar = out.parent / (out.name.replace(".tar.xz", "") + "-metadata.json")
+    sidecar = _sidecar_path(out)
     assert sidecar.exists(), f"expected rewritten sidecar at {sidecar}"
     return json.loads(sidecar.read_text())
 
@@ -225,41 +230,34 @@ def test_create_empty_intersection_fails(ocx: OcxRunner, unique_repo: str, tmp_p
 # ---------------------------------------------------------------------------
 
 
-def test_create_unpinned_without_platform_is_usage_error(
+def test_create_metadata_without_platform_is_usage_error(
     ocx: OcxRunner, unique_repo: str, tmp_path: Path
 ):
+    """``--metadata`` without ``--platform`` is rejected even when every
+    dependency is already pinned — the sidecar records the platform the
+    packaged content runs on, and the build host cannot supply that answer.
+    The pinned sidecar is the discriminating case: it is the invocation that
+    would otherwise silently record the host's own platform (libc included)
+    as the artifact's target."""
     leaf = make_package(ocx, f"{unique_repo}_leaf", "1.0.0", tmp_path)
-    pkg_dir, metadata = _write_app(tmp_path, "noplat", [{"identifier": leaf.fq}])
+    manifest_digest = _child_manifest_digest(ocx, leaf.repo, leaf.tag)
+    pkg_dir, metadata = _write_app(
+        tmp_path, "noplat", [{"identifier": f"{leaf.fq}@{manifest_digest}"}]
+    )
     out = tmp_path / "app-noplat.tar.xz"
 
     result = _create(ocx, pkg_dir, metadata, out, check=False)
     assert result.returncode == EXIT_USAGE, result.stderr
     assert "--platform" in result.stderr, "error must hint at --platform"
-
-
-def test_create_prepinned_offline_succeeds(ocx: OcxRunner, unique_repo: str, tmp_path: Path):
-    """Fully pinned metadata needs no network — `--offline` create passes and
-    rewrites the sidecar canonically."""
-    leaf = make_package(ocx, f"{unique_repo}_leaf", "1.0.0", tmp_path)
-    manifest_digest = _child_manifest_digest(ocx, leaf.repo, leaf.tag)
-    pkg_dir, metadata = _write_app(
-        tmp_path, "offline", [{"identifier": f"{leaf.fq}@{manifest_digest}"}]
-    )
-    out = tmp_path / "app-offline.tar.xz"
-
-    _create(ocx, pkg_dir, metadata, out, root_flags=("--offline",))
-
-    dep = _sidecar(out)["dependencies"][0]
-    assert dep["identifier"].endswith(f"@{manifest_digest}")
+    assert not _sidecar_path(out).exists(), "a rejected create must write no sidecar"
 
 
 def test_create_concrete_platform_passes_through_pinned_dep(
     ocx: OcxRunner, unique_repo: str, tmp_path: Path
 ):
-    """A dep pre-pinned to its manifest digest needs no index consultation
-    when ``--platform`` names a CONCRETE platform — not just when
-    ``--platform`` is omitted entirely (see the sibling offline test above).
-    The identical digest survives the canonical sidecar rewrite untouched."""
+    """A dep pre-pinned to its manifest digest needs no index consultation:
+    an ``--offline`` create against a concrete ``--platform`` passes, and the
+    identical digest survives the canonical sidecar rewrite untouched."""
     leaf = make_package(ocx, f"{unique_repo}_leaf", "1.0.0", tmp_path)
     manifest_digest = _child_manifest_digest(ocx, leaf.repo, leaf.tag)
     pkg_dir, metadata = _write_app(

--- a/test/tests/test_package_lifecycle.py
+++ b/test/tests/test_package_lifecycle.py
@@ -46,7 +46,9 @@ def test_create_push_install_find(ocx: OcxRunner, unique_repo: str, tmp_path: Pa
 
     # --- Create bundle ---
     bundle = tmp_path / "bundle.tar.xz"
-    ocx.plain("package", "create", "-m", str(metadata), "-o", str(bundle), str(pkg_dir))
+    ocx.plain(
+        "package", "create", "-m", str(metadata), "-o", str(bundle), "-p", plat, str(pkg_dir)
+    )
     assert bundle.exists()
 
     # --- Push ---

--- a/test/tests/test_package_test.py
+++ b/test/tests/test_package_test.py
@@ -711,7 +711,10 @@ def test_invalid_metadata_data_error(
     # Use a valid minimal metadata to create the bundle, then override the path.
     valid_meta = tmp_path / "valid-meta.json"
     valid_meta.write_text('{"type":"bundle","version":1}')
-    ocx.plain("package", "create", "-m", str(valid_meta), "-o", str(bundle), str(bundle_dir))
+    ocx.plain(
+        "package", "create", "-m", str(valid_meta), "-o", str(bundle),
+        "-p", _PLATFORM, str(bundle_dir),
+    )
 
     fq = f"{ocx.registry}/{unique_repo}-invalid:1.0.0"
     result = ocx.plain(

--- a/test/tests/test_push_pull_three_layers.py
+++ b/test/tests/test_push_pull_three_layers.py
@@ -46,7 +46,10 @@ def _bundle_layer(ocx: OcxRunner, layer_dir: Path, tmp_path: Path, *, ext: str =
             {"key": "PATH", "type": "path", "required": True, "value": "${installPath}/bin"},
         ],
     }))
-    ocx.plain("package", "create", "-m", str(metadata_path), "-o", str(bundle), str(layer_dir))
+    ocx.plain(
+        "package", "create", "-m", str(metadata_path), "-o", str(bundle),
+        "-p", current_platform(), str(layer_dir),
+    )
     return bundle
 
 

--- a/website/src/docs/authoring/bundle-anatomy.md
+++ b/website/src/docs/authoring/bundle-anatomy.md
@@ -20,7 +20,7 @@ Archive creation is sensitive to inputs that vary between runs. [`ocx package cr
 That matters because [layer reuse][in-depth-storage-layers] hinges on digest equality: bundle the same content twice and you get two layers in the registry, two downloads at install time, and zero dedup. The fix is not byte-reproducibility — it is to capture the digest after the first push and reference it explicitly on every subsequent push:
 
 ```sh
-ocx package create build -m metadata.json -o mytool-1.0.0.tar.xz
+ocx package create build -p linux/amd64 -m metadata.json -o mytool-1.0.0.tar.xz
 ocx package push -n -p linux/amd64 -m metadata.json mytool:1.0.0 mytool-1.0.0.tar.xz
 
 # Record the layer digest. The on-disk archive is the same blob the registry stores,
@@ -50,7 +50,7 @@ Compression level (`fast`, `default`, `best`) trades publish-time CPU for archiv
 [`ocx package create`][cmd-package-create] follows a sidecar convention so the metadata travels with the archive. Pass `-m metadata.json` and the command copies that file to a sibling next to the output archive, named after the archive itself:
 
 ```sh
-ocx package create build -m metadata.json -o mytool-1.0.0.tar.xz
+ocx package create build -p linux/amd64 -m metadata.json -o mytool-1.0.0.tar.xz
 ```
 
 Produces:

--- a/website/src/docs/authoring/index.md
+++ b/website/src/docs/authoring/index.md
@@ -49,7 +49,7 @@ The sidecar declares one [public env entry][authoring-env-visibility] that prepe
 Bundle `build/` into a deterministic archive, then push it to any registry you can authenticate against. The push attaches `metadata.json` as the manifest config blob — there is no copy inside the archive:
 
 ```sh
-ocx package create build -m metadata.json -o mytool-1.0.0.tar.xz
+ocx package create build -p linux/amd64 -m metadata.json -o mytool-1.0.0.tar.xz
 ocx package push -n -p linux/amd64 -m metadata.json \
   ghcr.io/me/mytool:1.0.0 mytool-1.0.0.tar.xz
 ```

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -2121,8 +2121,14 @@ When `--metadata` is given, `create` is also the compiler for [dependency pins][
 it validates the sidecar and always rewrites it, in canonical form, next to the output bundle — never a
 byte copy of the input file.
 
-- `--platform` omitted: every dependency in the sidecar must already carry a manifest digest (else
-  usage error, exit 64, hinting `--platform`); no network access.
+`--platform` is **required** whenever `--metadata` is given (else usage error, exit 64). It declares the
+platform the packaged content runs on, and `create` records it in the sidecar for
+[`ocx package push`][cmd-package-push] and [`ocx package test`][cmd-package-test] to read back. That
+answer cannot come from the build host: the host describes what the build machine *supplies*, while the
+sidecar states what the artifact *demands* — a static musl binary cross-built on a glibc host demands
+neither the host's libc nor its architecture. Every dependency is pinned for the platform you name, and
+whatever you name is the label the package is published under.
+
 - `--platform <PLATFORM>` (a concrete platform): each dependency without a digest is resolved
   against the selected index to the one manifest [compatible][reference-platforms-compatibility]
   with `<PLATFORM>`. Zero compatible candidates fails with exit 65 (lists what is available); more
@@ -2194,10 +2200,10 @@ ocx package create [OPTIONS] <PATH>
 **Options**
 
 - `-i`, `--identifier <IDENTIFIER>`: Package identifier, used to infer the output filename when `--output` is a directory.
-- `-p`, `--platform <PLATFORM>`: Platform of the package content (e.g. `linux/amd64`, or `any` for platform-agnostic content). Used to infer the output filename, and required whenever `--metadata` declares a dependency without a digest (see above).
+- `-p`, `--platform <PLATFORM>`: Platform of the package content (e.g. `linux/amd64`, or `any` for platform-agnostic content) — see [Platforms][reference-platforms] for the grammar. Required whenever `--metadata` is given, with no host default (see above); optional otherwise, where it only shapes the inferred output filename.
 - `-o`, `--output <PATH>`: Output file or directory. If a directory is given, the filename is inferred from the identifier and platform. The file extension controls the compression algorithm: `.tar.xz` (LZMA, default), `.tar.gz` (Gzip), or `.tar.zst` (Zstandard).
 - `-f`, `--force`: Overwrite the output file if it already exists.
-- `-m`, `--metadata <PATH>`: Path to a `metadata.json` sidecar to validate, resolve, and write alongside the output bundle. Dependencies without a digest are pinned to platform manifest digests (requires `--platform`, see above); the resolved sidecar is written next to the output bundle in canonical form. If omitted, no metadata sidecar is written.
+- `-m`, `--metadata <PATH>`: Path to a `metadata.json` sidecar to validate, resolve, and write alongside the output bundle. Requires `--platform` (see above); dependencies without a digest are pinned to that platform's manifest digests, and the resolved sidecar is written next to the output bundle in canonical form. If omitted, no metadata sidecar is written.
 - `-l`, `--compression-level <LEVEL>`: Compression level (`fast`, `default`, `best`). Default: `default`. Applies to whichever algorithm is selected.
 - `-j`, `--threads <N>`: Number of compression threads. `0` (default) auto-detects from available CPU cores (capped at 16). `1` forces single-threaded compression. Affects LZMA (`.tar.xz`) and Zstandard (`.tar.zst`) compression; Gzip is always single-threaded.
 - `--bin-scan`, `--no-bin-scan`: Scan the content tree for executables the package puts on `PATH` to fill or verify the [`binaries`][reference-binaries] metadata claim — see the mode table above. Paired, last-wins flags; neither given (the default) fills an absent claim and passes a declared one through untouched.


### PR DESCRIPTION
## What

`ocx package create` resolved an absent `--platform` to `Platform::current()`. That value is recorded into the metadata sidecar (`with_platform`), is what `resolve_binaries` scans for, and is what `to_published` validates the publish projection against. `ocx package push` / `ocx package test` then **bind** to the recorded value and reject a disagreeing `--platform` with exit 65.

The host platform describes what the build machine **supplies** — libc family included. The sidecar field describes what the artifact **demands**. Different quantities.

Reproduced on a glibc host, no `--platform` anywhere in the invocation:

```
$ ocx package create build -m metadata.json -o mytool-1.0.0.tar.xz
$ grep platform mytool-1.0.0-metadata.json
  "platform": "linux/amd64+libc.glibc",
```

A static musl bundle cross-built there is published as demanding `libc.glibc`. This reopens, at create time, the cross-compile host-default corruption that `adr_platform_model_unification.md` D5 records as closed by the recorded-platform binding (fix `39ffaf56`). Create is the step that *records* the platform, so a guess there corrupts every downstream consumer. It matters more now that Linux packages carry `libc.glibc` / `libc.musl` in `os.features`.

## Decision

**`--platform` is required whenever `--metadata` is given, with no default** (usage error, exit 64, naming both flags). Without `--metadata` it stays optional — nothing is recorded, and it only shapes the inferred output filename.

The alternative (record nothing; let `MissingRecordedPlatform` fire at push) was rejected: `create` still needs a platform for the publish projection and the binaries scan, and `Platform::any()` there is not free. `pin_dependencies(any)` applies D5's any-target rules — so a concrete bundle with direct digest pins would be rejected as `DirectDigestPinInAnyTarget`, and a concrete-keyed `platforms` map would fail `MissingPlatformPin`. Meanwhile `bin_scan` under `any` falls back to the Unix exec-bit convention, silently baking a wrong `binaries` claim for a Windows target — moving the guess to a field with **no** downstream guard. It also only defers the error: the publisher must re-run `create` with `--platform` anyway, after a bundle was already written.

## Falls out for free

`pin_dependencies` now runs on every `--metadata` invocation. The no-`--platform` path previously skipped it entirely for an already-pinned sidecar, so an `any`-targeted bundle carrying a hand-written digest pin slipped past the D5 check this ADR requires it to fail. The "omitted implies fully pinned" usage error is deleted with the branch it guarded.

## Regression test + discriminating mutation

`command::package_create::tests::metadata_without_platform_is_rejected_instead_of_defaulting_to_the_host` (plus an exit-code sibling asserting 64 through `app::classify_error`, the path `main` uses).

Mutation — restore the host default:

```rust
(Some(_), None) => Ok(Some(oci::Platform::current().unwrap_or_else(oci::Platform::any))),
```

Both guards go red, naming the host value they refused to accept:

```
FAILED metadata_without_platform_is_rejected_instead_of_defaulting_to_the_host
  --metadata without --platform must not resolve to the host platform:
  Some(Specific { os: Linux, arch: Amd64, variant: None, os_features: [] })
FAILED metadata_without_platform_exits_with_usage_error
test result: FAILED. 6 passed; 2 failed
```

End-to-end against the built binary: the mutated binary exits 0 and writes `"platform": "linux/amd64+libc.glibc"`; the fixed binary exits 64 and writes no sidecar; with `-p linux/amd64+libc.musl` on the same glibc host it records `linux/amd64+libc.musl`.

Acceptance level: `test_create_metadata_without_platform_is_usage_error` (retargeted from `test_create_unpinned_without_platform_is_usage_error`) now uses a **fully pinned** sidecar — the invocation that used to succeed — and asserts exit 64 with no sidecar written. `test_create_prepinned_offline_succeeds` was deleted: with `-p` added it became a byte-for-byte duplicate of `test_create_concrete_platform_passes_through_pinned_dep`.

## Breaking change

A fully-pinned sidecar bundled without `--platform` used to succeed and now exits 64. Pre-1.0 clean break per D5 — no shim, no fallback. Every call site in the repo gains the platform it was already targeting (14 acceptance-test sites, the manual scenario catalogue, the `package-create` doc script).

## Doc surfaces

- `website/src/docs/reference/command-line.md` — `create` prose (the `--platform` omitted bullet is gone), `-p` and `-m` option entries
- `website/src/docs/authoring/index.md`, `authoring/bundle-anatomy.md` (2 snippets)
- `test/doc_scripts/package-create.sh` (backs the cast + the published snippet)
- `test/manual/README.md`, `test/manual/scripts/{bootstrap,setup-patches}.sh`
- `.claude/artifacts/adr_platform_model_unification.md` — D5 amended, validation row, decision-log entry 2026-07-27 (separate commit)

## Verification

`task rust:verify --force` green (3540 tests). `task shell:verify` green. The pytest acceptance suite was **not** run — another agent owns the test registry. The acceptance-test edits are unexecuted and need a scheduled run.