### PR TITLE
feat(announce): observe __ocx.desc into the index root

### DIFF
--- a/crates/ocx_cli/src/api/data/announce.rs
+++ b/crates/ocx_cli/src/api/data/announce.rs
@@ -16,9 +16,11 @@ use crate::api::Printable;
 /// command warns about them on stderr when there are any.
 ///
 /// JSON format:
-/// `{ "package", "status", "pull_request_url", "pull_request_number", "fork",
-/// "written_paths", "reserved_tags_dropped" }`.
-/// `status` is exactly `"unchanged"` or `"updated"`. `pull_request_url` /
+/// `{ "package", "status", "desc_status", "pull_request_url",
+/// "pull_request_number", "fork", "written_paths", "reserved_tags_dropped" }`.
+/// `status` and `desc_status` are each exactly `"unchanged"` or `"updated"`;
+/// `desc_status` is JSON-only, the plain table being at its column budget.
+/// `pull_request_url` /
 /// `pull_request_number` / `fork` are always `null` for `--out`; in `--fork`
 /// mode they are `null` only when the run made no pull request — an unchanged
 /// run whose announce branch is ahead of the index base still ensures, and
@@ -33,6 +35,11 @@ pub struct AnnounceReport {
     /// `--fork` run still ensures a pull request when its announce branch is
     /// ahead of the index base.
     pub status: String,
+    /// `"updated"` when the package's `__ocx.desc` artifact moved, so the
+    /// root's `desc` object was rebuilt and its readme (and logo) written as
+    /// new content-addressed objects; `"unchanged"` when the description sits
+    /// where the committed root already recorded it, or there is none.
+    pub desc_status: String,
     /// The opened/updated pull request's web URL.
     pub pull_request_url: Option<String>,
     /// The opened/updated pull request's number.
@@ -51,19 +58,25 @@ pub struct AnnounceReport {
 impl AnnounceReport {
     /// Builds a report from an [`AnnounceOutcome`].
     pub fn from_outcome(outcome: AnnounceOutcome) -> Self {
-        let status = match outcome.status {
-            AnnounceStatus::Unchanged => "unchanged",
-            AnnounceStatus::Updated => "updated",
-        };
         Self {
             package: outcome.package,
-            status: status.to_string(),
+            status: status_label(outcome.status).to_string(),
+            desc_status: status_label(outcome.desc_status).to_string(),
             pull_request_url: outcome.pull_request.as_ref().map(|pr| pr.html_url.clone()),
             pull_request_number: outcome.pull_request.as_ref().map(|pr| pr.number),
             fork: outcome.fork.as_ref().map(|fork| fork.full_name.clone()),
             written_paths: outcome.written_paths,
             reserved_tags_dropped: outcome.reserved_tags_dropped,
         }
+    }
+}
+
+/// The wire spelling of a status — the same two words for the root and for the
+/// description, so a consumer parses one vocabulary.
+fn status_label(status: AnnounceStatus) -> &'static str {
+    match status {
+        AnnounceStatus::Unchanged => "unchanged",
+        AnnounceStatus::Updated => "updated",
     }
 }
 
@@ -119,6 +132,7 @@ mod tests {
             }),
             written_paths: Vec::new(),
             reserved_tags_dropped: Vec::new(),
+            desc_status: AnnounceStatus::Unchanged,
         }
     }
 
@@ -130,6 +144,7 @@ mod tests {
             fork: None,
             written_paths: Vec::new(),
             reserved_tags_dropped: Vec::new(),
+            desc_status: AnnounceStatus::Unchanged,
         }
     }
 
@@ -146,6 +161,11 @@ mod tests {
         assert_eq!(value.get("pull_request_number").and_then(|v| v.as_u64()), Some(42));
         assert_eq!(value.get("fork").and_then(|v| v.as_str()), Some("forkuser/index"));
         assert_eq!(value.get("written_paths").and_then(|v| v.as_array()), Some(&vec![]));
+        assert_eq!(
+            value.get("desc_status").and_then(|v| v.as_str()),
+            Some("unchanged"),
+            "the description status is reported on every run, not only when it moved"
+        );
         assert_eq!(
             value.get("reserved_tags_dropped").and_then(|v| v.as_array()),
             Some(&vec![]),
@@ -212,6 +232,7 @@ mod tests {
             fork: None,
             written_paths: vec!["p/acme/widget.json".to_string()],
             reserved_tags_dropped: Vec::new(),
+            desc_status: AnnounceStatus::Unchanged,
         };
         let report = AnnounceReport::from_outcome(outcome);
         let value = serde_json::to_value(&report).unwrap();
@@ -220,6 +241,20 @@ mod tests {
             value.get("written_paths").and_then(|v| v.as_array()),
             Some(&vec![serde_json::Value::String("p/acme/widget.json".to_string())])
         );
+    }
+
+    /// The description moves on its own axis: a run can rewrite `desc` (and its
+    /// blobs) while the root's own status says `updated` for either reason, so
+    /// the two statuses are reported independently.
+    #[test]
+    fn a_moved_description_reports_its_own_updated_status() {
+        let outcome = AnnounceOutcome {
+            desc_status: AnnounceStatus::Updated,
+            ..outcome_updated()
+        };
+        let report = AnnounceReport::from_outcome(outcome);
+        let value = serde_json::to_value(&report).unwrap();
+        assert_eq!(value.get("desc_status").and_then(|v| v.as_str()), Some("updated"));
     }
 
     #[test]

--- a/crates/ocx_lib/src/announce.rs
+++ b/crates/ocx_lib/src/announce.rs
@@ -117,7 +117,9 @@ pub async fn announce(
         files,
         observed,
         mut reserved_dropped,
+        desc_updated,
     } = observe_and_rebuild(publisher, &committed_root, &request, &now, &root_path, &package).await?;
+    let mut desc_status = AnnounceStatus::from_changed(desc_updated);
 
     // C6: byte-identical root AND no new CAS object ⇒ nothing moved.
     let unchanged = new_root_bytes == committed_bytes && pipeline::new_cas_count(&committed_root, &observed) == 0;
@@ -146,6 +148,7 @@ pub async fn announce(
                 fork: None,
                 written_paths,
                 reserved_tags_dropped: reserved_dropped,
+                desc_status,
             })
         }
         AnnounceTarget::Fork(target) => {
@@ -180,6 +183,7 @@ pub async fn announce(
                         fork: Some(fork.clone()),
                         written_paths: Vec::new(),
                         reserved_tags_dropped: reserved_dropped,
+                        desc_status,
                     });
                 }
                 return Ok(AnnounceOutcome {
@@ -189,6 +193,7 @@ pub async fn announce(
                     fork: None,
                     written_paths: Vec::new(),
                     reserved_tags_dropped: reserved_dropped,
+                    desc_status,
                 });
             }
             // C8: reuse the already-resolved fork, else create one under the
@@ -255,6 +260,7 @@ pub async fn announce(
                     // root differs between passes, so the two lists legitimately
                     // differ and only the second describes what was announced.
                     reserved_dropped = merged.reserved_dropped;
+                    desc_status = AnnounceStatus::from_changed(merged.desc_updated);
                     // Re-apply C6 against the head that WON the race: two
                     // identical racing announces both regenerate the same
                     // bytes, so committing again would push a commit whose tree
@@ -302,6 +308,7 @@ pub async fn announce(
                 fork: Some(fork),
                 written_paths: Vec::new(),
                 reserved_tags_dropped: reserved_dropped,
+                desc_status,
             })
         }
     }
@@ -320,6 +327,9 @@ struct Rebuilt {
     observed: Vec<pipeline::Observed>,
     /// Reserved tags this pass dropped from the curated set (D7).
     reserved_dropped: Vec<String>,
+    /// Whether the `__ocx.desc` observation moved this pass (D6) — false when
+    /// the description is unchanged or the package has none.
+    desc_updated: bool,
 }
 
 /// One full regeneration pass over `base_root`: resolve the curated tag universe
@@ -366,15 +376,30 @@ async fn observe_and_rebuild(
         reserved_dropped,
     } = pipeline::resolve_curated_tags(&request.curated, &base_tags, &discovered)?;
     let observed = pipeline::observe_curated(publisher, &physical, &curated).await?;
+    // D6: the description is a floating tag of its own, observed after the
+    // curated set (reference parity) and behind the same pre-flight — the root's
+    // `desc` object is rewritten only when its tag digest moved, so `--refresh`
+    // on a package whose description never changes stays byte-identical. Its CAS
+    // blobs ride along on every run regardless, exactly as the curated tags' do.
+    let desc = pipeline::observe_desc(publisher, &physical, base_root).await?;
     let mut root = pipeline::regenerate(base_root, &observed, now);
+    if let Some(updated) = &desc.desc
+        && let Some(object) = root.as_object_mut()
+    {
+        // Replacing an existing key keeps its position (preserve_order), the
+        // same mechanism `regenerate` relies on for `tags`. Every root carries
+        // `desc` — the index schema requires the key, `null` when unset.
+        object.insert("desc".to_string(), updated.clone());
+    }
     pipeline::apply_yank_markers(&mut root, &request.yank, &request.unyank, &request.yank_reason, now)?;
     let root_bytes = serialize_root(&root);
-    let files = pipeline::build_files(root_path, &root_bytes, package, &observed);
+    let files = pipeline::build_files(root_path, &root_bytes, package, &observed, &desc.blobs);
     Ok(Rebuilt {
         root_bytes,
         files,
         observed,
         reserved_dropped,
+        desc_updated: desc.desc.is_some(),
     })
 }
 
@@ -578,6 +603,80 @@ mod tests {
             .insert(format!("127.0.0.1/x:{tag}"), (bytes, digest.to_string()));
     }
 
+    /// Seed a `__ocx.desc` artifact (readme layer only) at `127.0.0.1/x`, and
+    /// return the readme bytes' own hex digest — the CAS name the announce must
+    /// write it under.
+    fn seed_description(data: &StubTransportData) -> String {
+        let readme = b"# widget\n".as_slice();
+        let readme_digest = oci::Algorithm::Sha256.hash(readme);
+        data.write().blobs.insert(readme_digest.to_string(), readme.to_vec());
+        let manifest = oci::Manifest::Image(oci::ImageManifest {
+            artifact_type: Some(crate::MEDIA_TYPE_DESCRIPTION_V1.to_string()),
+            layers: vec![oci::Descriptor {
+                media_type: crate::MEDIA_TYPE_MARKDOWN.to_string(),
+                digest: readme_digest.to_string(),
+                size: i64::try_from(readme.len()).expect("test blob fits i64"),
+                urls: None,
+                artifact_type: None,
+                annotations: None,
+            }],
+            annotations: Some([(oci::annotations::TITLE.to_string(), "Widget".to_string())].into()),
+            ..Default::default()
+        });
+        let bytes = serde_json::to_vec_pretty(&manifest).expect("manifest serializes");
+        let digest = oci::Algorithm::Sha256.hash(&bytes);
+        data.write()
+            .manifests
+            .insert("127.0.0.1/x:__ocx.desc".to_string(), (bytes, digest.to_string()));
+        readme_digest.hex().to_string()
+    }
+
+    /// A moved description is written back into the root's EXISTING `desc` slot,
+    /// not appended: the index CI re-serializes the committed root and rejects
+    /// any byte that differs, so a `desc` landing after `tags` fails the PR.
+    /// Its readme rides along in the same atomic file set (C15).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_moved_description_rewrites_desc_in_place_and_carries_its_readme() {
+        let data = StubTransportData::new();
+        seed_index(&data, "1.0.0");
+        let readme_hex = seed_description(&data);
+        let publisher = Publisher::new(oci::Client::with_transport(Box::new(StubTransport::new(data))));
+        let root = committed_root(serde_json::json!({}));
+
+        let rebuilt = observe_and_rebuild(
+            &publisher,
+            &root,
+            &request(TagSelection::Replace(vec!["1.0.0".to_string()])),
+            "2026-07-25T00:00:00Z",
+            "p/acme/widget.json",
+            "acme/widget",
+        )
+        .await
+        .expect("the description observes alongside the tag");
+
+        assert!(rebuilt.desc_updated, "the description moved from null to an object");
+        let announced: Value = serde_json::from_slice(&rebuilt.root_bytes).expect("the root is JSON");
+        let fields: Vec<&str> = announced
+            .as_object()
+            .expect("the root is an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            fields,
+            vec!["name", "repository", "owners", "status", "created", "desc", "tags"],
+            "desc keeps its committed position — CONTRACTS field order is a wire contract"
+        );
+        assert!(announced["desc"]["digest"].is_string(), "desc is no longer null");
+        assert!(
+            rebuilt
+                .files
+                .contains_key(&format!("p/acme/widget/o/sha256/{readme_hex}.md")),
+            "the readme blob ships in the same commit as the root: {:?}",
+            rebuilt.files.keys().collect::<Vec<_>>()
+        );
+    }
+
     /// The D7 drop list is threaded out of the regeneration pass, not recomputed
     /// or dropped on the floor: every `AnnounceOutcome` construction site reads
     /// it from here, and the retry pass supersedes it from the same field.
@@ -685,11 +784,14 @@ mod tests {
     /// `--tags-from-registry` the **tag listing** is the first registry request,
     /// so a pre-flight left inside the observe loop would have guarded nothing.
     /// A forbidden host must therefore cost zero registry calls of any kind —
-    /// not merely zero observes.
+    /// not merely zero observes. The `__ocx.desc` probe is the third kind of
+    /// request in the pass and is seeded here so a mis-ordered one would show up
+    /// as a recorded call rather than a silent absence.
     #[tokio::test(flavor = "multi_thread")]
     async fn from_registry_refuses_a_forbidden_host_before_listing_any_tag() {
         let data = StubTransportData::new();
         data.write().tags = vec![vec!["1.0.0".to_string()]];
+        seed_description(&data);
         let publisher = Publisher::new(oci::Client::with_transport(Box::new(StubTransport::new(data.clone()))));
         let root = committed_root(serde_json::json!({}));
         // The default `request` trusts loopback; this one does not, so the

--- a/crates/ocx_lib/src/announce/error.rs
+++ b/crates/ocx_lib/src/announce/error.rs
@@ -106,6 +106,25 @@ pub enum AnnounceError {
         source: Box<crate::oci::client::error::ClientError>,
     },
 
+    /// Fetching or decoding the `__ocx.desc` artifact failed (D6): a transport
+    /// failure, a manifest that is not a description artifact, or one carrying
+    /// no markdown readme layer.
+    ///
+    /// Boxed for the same reason as [`Self::Observe`].
+    #[error("failed to observe the description of {repository}")]
+    ObserveDesc {
+        repository: String,
+        #[source]
+        source: Box<crate::oci::client::error::ClientError>,
+    },
+
+    /// The committed root records a description the physical repository no
+    /// longer serves. Retraction semantics are unspecified, so announce stops
+    /// loudly rather than silently clearing `desc` back to null (reference
+    /// parity).
+    #[error("__ocx.desc disappeared from {repository} (was {digest})")]
+    DescDisappeared { repository: String, digest: String },
+
     /// Listing the physical repository's tags failed (`--tags-from-registry`).
     ///
     /// Boxed for the same reason as [`Self::Observe`].
@@ -178,7 +197,15 @@ impl crate::cli::ClassifyExitCode for AnnounceError {
             Self::Ssrf(inner) => inner.classify(),
             Self::Forge(inner) => inner.classify(),
             Self::Observe { source, .. } => source.classify(),
+            Self::ObserveDesc { source, .. } => source.classify(),
             Self::ListTags { source, .. } => source.classify(),
+            // The description tag resolved once (it is recorded in the
+            // committed root) and does not now. Nothing is malformed on the
+            // wire and nothing the publisher typed is at fault, but the two
+            // sides of the announce genuinely disagree — the malformed-input
+            // category, same as `TagIsNotAnImageIndex`, and discriminable from
+            // an unclassified crash.
+            Self::DescDisappeared { .. } => Some(crate::cli::ExitCode::DataError),
             // A publisher typo — the tag genuinely does not exist on the
             // physical registry. Same category as `ClientError::ManifestNotFound`.
             Self::UnresolvedTag { .. } => Some(crate::cli::ExitCode::NotFound),
@@ -314,6 +341,45 @@ mod tests {
         };
         assert_eq!(error.to_string(), "no curated tags given");
         assert_eq!(error.classify(), Some(ExitCode::UsageError));
+    }
+
+    /// The description fetch reaches the same registry as the observe loop, so
+    /// its failures classify the same way — an unreachable registry must not
+    /// collapse to exit 1 just because it was the description being fetched.
+    #[test]
+    fn observe_desc_variant_classifies_via_the_inner_error() {
+        let inner = crate::oci::client::error::ClientError::ManifestNotFound("x".to_string());
+        let expected = inner.classify();
+        let error = AnnounceError::ObserveDesc {
+            repository: "oci://ghcr.io/acme/widget".to_string(),
+            source: Box::new(inner),
+        };
+        assert_eq!(error.classify(), expected);
+        assert!(
+            error.to_string().contains("oci://ghcr.io/acme/widget"),
+            "the message must name the repository: {error}"
+        );
+    }
+
+    /// A vanished description is a disagreement between the committed root and
+    /// the registry, not an absence and not a crash — a release wrapper must be
+    /// able to tell it apart from both.
+    #[test]
+    fn desc_disappeared_classifies_as_data_error() {
+        let error = AnnounceError::DescDisappeared {
+            repository: "oci://ghcr.io/acme/widget".to_string(),
+            digest: format!("sha256:{}", "a".repeat(64)),
+        };
+        assert_eq!(error.classify(), Some(ExitCode::DataError));
+        let message = error.to_string();
+        assert!(
+            message.contains("__ocx.desc"),
+            "the message must name the tag: {message}"
+        );
+        assert!(
+            message.contains(&format!("sha256:{}", "a".repeat(64))),
+            "the message must name the digest the root recorded: {message}"
+        );
     }
 
     #[test]

--- a/crates/ocx_lib/src/announce/pipeline.rs
+++ b/crates/ocx_lib/src/announce/pipeline.rs
@@ -19,7 +19,8 @@ use serde_json::{Map, Value, json};
 use super::error::AnnounceError;
 use super::request::TagSelection;
 use crate::oci;
-use crate::package::tag::Tag;
+use crate::oci::annotations;
+use crate::package::tag::{InternalTag, Tag};
 use crate::publisher::Publisher;
 
 /// One curated tag's freshly observed state — the registry's own image-index
@@ -35,6 +36,40 @@ pub struct Observed {
     /// The image-index digest the registry served (the tag's new `content`).
     pub content: oci::Digest,
     /// The registry's image-index bytes, unmodified (the CAS payload).
+    pub bytes: Vec<u8>,
+}
+
+/// The observed `__ocx.desc` artifact: the rebuilt `desc` object when it moved,
+/// plus the payload blobs the root points at.
+pub struct ObservedDesc {
+    /// The new `desc` object in the index bot's field order (CONTRACTS §14):
+    /// `digest`, `title`, `description`, `keywords`, then `readme`, then `logo`
+    /// when the artifact carries one. An absent logo omits the key outright —
+    /// the index schema types it as a digest string, so `null` is not a form it
+    /// has.
+    ///
+    /// `None` when the `__ocx.desc` tag digest did not move (D6) — the
+    /// committed `desc` then rides through verbatim.
+    pub desc: Option<Value>,
+    /// The readme blob, and the logo blob when there is one, verbatim.
+    ///
+    /// Carried on **every** run of a package that publishes a description, not
+    /// only the runs where it moved, exactly as the curated tags' CAS objects
+    /// are. `--out` materializes the whole entry per run (`announce --out dir &&
+    /// publish dir`), so a root naming a `desc.readme` object the run did not
+    /// write is a dangling CAS reference the index rejects.
+    pub blobs: Vec<DescBlob>,
+}
+
+/// One `__ocx.desc` payload blob, stored as this package's own CAS object.
+pub struct DescBlob {
+    /// The index's own SHA-256 over `bytes`, deliberately independent of the
+    /// registry's blob digest for the same content (a different digest
+    /// namespace, mirroring the tag `content` pointer).
+    pub digest: oci::Digest,
+    /// The CAS filename extension: `md` for the readme, `png`/`svg` for a logo.
+    pub extension: &'static str,
+    /// The blob bytes exactly as the registry served them.
     pub bytes: Vec<u8>,
 }
 
@@ -298,6 +333,193 @@ async fn observe_one_tag(publisher: &Publisher, physical: &Physical, tag: &str) 
     })
 }
 
+/// Observe the `__ocx.desc` artifact against the physical repository (D6).
+///
+/// The comparison is a **floating-tag** one: the `__ocx.desc` tag digest the
+/// registry currently serves against the committed root's `desc.digest`. Equal
+/// — both-absent included — means the description did not move, so the
+/// committed `desc` rides through verbatim ([`ObservedDesc::desc`] is `None`).
+///
+/// The payload blobs are fetched regardless, whenever the registry serves a
+/// description at all: [`ObservedDesc::blobs`] is the *file set* half, not the
+/// *change* half, and the `--out` contract writes the whole entry every run.
+/// A package with no `__ocx.desc` costs one HEAD and nothing else.
+///
+/// `desc.digest` is that observed tag digest itself, never a recomputed content
+/// hash; `desc.readme` / `desc.logo` are the opposite — this index's own SHA-256
+/// over the exact bytes the registry served, which is what the index CI
+/// re-derives from the committed CAS objects.
+///
+/// `physical` must come from [`guarded_physical`]: this makes registry requests
+/// and runs no pre-flight of its own.
+///
+/// # Errors
+///
+/// [`AnnounceError::DescDisappeared`] when the committed root records a
+/// description the registry no longer serves — retraction semantics are
+/// unspecified, so the run stops loudly rather than silently clearing `desc`
+/// back to null (reference parity). [`AnnounceError::ObserveDesc`] for any
+/// transport failure, and for a malformed artifact: a manifest that is not a
+/// description, or one carrying no markdown readme layer.
+pub async fn observe_desc(
+    publisher: &Publisher,
+    physical: &Physical,
+    committed_root: &Value,
+) -> Result<ObservedDesc, AnnounceError> {
+    let committed_digest = committed_root
+        .get("desc")
+        .and_then(|desc| desc.get("digest"))
+        .and_then(Value::as_str);
+    let desc_identifier = physical.identifier.clone_with_tag(InternalTag::DESCRIPTION_TAG);
+    let observed = publisher
+        .client()
+        .probe_manifest_digest(&desc_identifier)
+        .await
+        .map_err(|source| AnnounceError::ObserveDesc {
+            repository: physical.display.clone(),
+            source: Box::new(source),
+        })?
+        .map(|digest| digest.to_string());
+    let Some(observed_digest) = observed else {
+        if let Some(committed_digest) = committed_digest {
+            return Err(AnnounceError::DescDisappeared {
+                repository: physical.display.clone(),
+                digest: committed_digest.to_string(),
+            });
+        }
+        // No description on either side — the overwhelmingly common case.
+        return Ok(ObservedDesc {
+            desc: None,
+            blobs: Vec::new(),
+        });
+    };
+    let moved = Some(observed_digest.as_str()) != committed_digest;
+
+    // The one description fetcher in the codebase: it applies the artifact-type
+    // and readme-layer rules and hands back the decoded payload. It downloads
+    // the layers through a temporary directory, so announce supplies a private
+    // one rather than sharing filenames with a concurrent run.
+    let temporary = tempfile::tempdir().map_err(|source| AnnounceError::OutputWrite {
+        path: std::env::temp_dir().display().to_string(),
+        source,
+    })?;
+    let description = publisher
+        .client()
+        .pull_description(&physical.identifier, temporary.path())
+        .await
+        .map_err(|source| AnnounceError::ObserveDesc {
+            repository: physical.display.clone(),
+            source: Box::new(source),
+        })?
+        // The tag answered the HEAD and was gone by the GET — the same
+        // retraction the branch above refuses, one round trip later.
+        .ok_or_else(|| AnnounceError::DescDisappeared {
+            repository: physical.display.clone(),
+            digest: observed_digest.clone(),
+        })?;
+
+    let manifest_annotations = description.annotations;
+    let readme = description.readme.into_bytes();
+    let readme_digest = oci::Algorithm::Sha256.hash(&readme);
+    let logo = description.logo.map(|logo| {
+        // The layer's own media type names the extension. The reference tool
+        // sniffs the PNG magic number instead, having dropped the media type by
+        // this point; the two agree for the two media types the format allows.
+        let extension = if logo.media_type == crate::MEDIA_TYPE_PNG {
+            "png"
+        } else {
+            "svg"
+        };
+        DescBlob {
+            digest: oci::Algorithm::Sha256.hash(&logo.data),
+            extension,
+            bytes: logo.data,
+        }
+    });
+
+    let mut desc = Map::new();
+    desc.insert("digest".to_string(), Value::String(observed_digest));
+    desc.insert(
+        "title".to_string(),
+        Value::String(title(&manifest_annotations, committed_root, physical)),
+    );
+    desc.insert(
+        "description".to_string(),
+        annotation(&manifest_annotations, annotations::DESCRIPTION),
+    );
+    desc.insert(
+        "keywords".to_string(),
+        Value::Array(parse_keywords(manifest_annotations.get(annotations::KEYWORDS))),
+    );
+    desc.insert("readme".to_string(), Value::String(readme_digest.to_string()));
+    if let Some(logo) = &logo {
+        desc.insert("logo".to_string(), Value::String(logo.digest.to_string()));
+    }
+
+    let mut blobs = vec![DescBlob {
+        digest: readme_digest,
+        extension: "md",
+        bytes: readme,
+    }];
+    blobs.extend(logo);
+    Ok(ObservedDesc {
+        desc: moved.then(|| Value::Object(desc)),
+        blobs,
+    })
+}
+
+/// A manifest annotation as a JSON string, empty when absent — `description` is
+/// a required field of a non-null `desc`, so it may not be omitted just because
+/// the publisher left the annotation off.
+fn annotation(annotations: &BTreeMap<String, String>, key: &str) -> Value {
+    Value::String(annotations.get(key).cloned().unwrap_or_default())
+}
+
+/// The `desc.title`: the `org.opencontainers.image.title` annotation, falling
+/// back to the root's own `name`, then to the physical repository.
+///
+/// `title` is required *and* typed `minLength: 1` by the index root schema, so
+/// the empty string is not a value it has. A root carrying one passes the pull
+/// request checks — neither `indexbot validate` nor the claim re-derivation
+/// looks at title length — and then fails `schema:validate:rendered`, blocking
+/// the deploy for every package in the index. `ocx package describe --readme`
+/// over a readme with no frontmatter title pushes exactly that artifact, so the
+/// annotation is genuinely optional and the fallback carries the invariant.
+///
+/// `name` first because it is what the index's own catalog renderer already
+/// shows as the title of a package with no description at all — the fallback
+/// shows what the card would have shown anyway. The repository closes the last
+/// hole: `name` is schema-required of every real root, but reading a non-empty
+/// title out of remote data that merely *ought* to carry one is the same bet
+/// this function exists to stop making.
+fn title(annotations: &BTreeMap<String, String>, committed_root: &Value, physical: &Physical) -> String {
+    let annotated = annotations
+        .get(annotations::TITLE)
+        .map(String::as_str)
+        .unwrap_or_default();
+    let name = committed_root.get("name").and_then(Value::as_str).unwrap_or_default();
+    for candidate in [annotated, name, physical.identifier.repository()] {
+        if !candidate.is_empty() {
+            return candidate.to_string();
+        }
+    }
+    // Unreachable via `guarded_physical`: an `oci://host/repo` pointer with no
+    // repository does not parse. Never emit the one value the schema refuses.
+    physical.display.clone()
+}
+
+/// Split the comma-separated `sh.ocx.keywords` annotation: each keyword
+/// trimmed, empties dropped, an absent annotation yielding the empty array.
+fn parse_keywords(raw: Option<&String>) -> Vec<Value> {
+    raw.map(String::as_str)
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|keyword| !keyword.is_empty())
+        .map(|keyword| Value::String(keyword.to_string()))
+        .collect()
+}
+
 /// Rebuild the root's `tags` map from the observed curated set (design register
 /// C3/C6). A tag whose observed digest equals its committed `content` keeps its
 /// entry verbatim — same `observed` timestamp, same yank marker — so a no-op
@@ -416,13 +638,19 @@ pub fn new_cas_count(committed: &Value, observed: &[Observed]) -> usize {
         .count()
 }
 
-/// Assemble the atomic file set for an announce: the root plus one CAS object
-/// per observed tag, keyed by wire path (design register C15 — one commit).
+/// Assemble the atomic file set for an announce: the root, one CAS object per
+/// observed tag, and the description's payload blobs when it moved this run
+/// (design register C15 — one commit).
+///
+/// Every CAS object is keyed by wire path; only the extension distinguishes
+/// them, and it is descriptive only — the index derives a CAS file's claimed
+/// digest from the filename's hex half alone.
 pub fn build_files(
     root_path: &str,
     root_bytes: &[u8],
     package_repo: &str,
     observed: &[Observed],
+    desc_blobs: &[DescBlob],
 ) -> BTreeMap<String, Vec<u8>> {
     let mut files = BTreeMap::new();
     files.insert(root_path.to_string(), root_bytes.to_vec());
@@ -431,6 +659,14 @@ pub fn build_files(
         files.insert(
             format!("p/{package_repo}/o/{algorithm}/{hex}.json"),
             entry.bytes.clone(),
+        );
+    }
+    for blob in desc_blobs {
+        let (algorithm, hex) = blob.digest.parts();
+        let extension = blob.extension;
+        files.insert(
+            format!("p/{package_repo}/o/{algorithm}/{hex}.{extension}"),
+            blob.bytes.clone(),
         );
     }
     files
@@ -768,7 +1004,7 @@ mod tests {
 
         assert_eq!(observed.bytes, served_bytes, "the CAS payload must be the served bytes");
         assert_eq!(observed.content, served_digest, "the pointer must be the served digest");
-        let files = build_files("p/x.json", b"root", "x", std::slice::from_ref(&observed));
+        let files = build_files("p/x.json", b"root", "x", std::slice::from_ref(&observed), &[]);
         let (algorithm, hex) = served_digest.parts();
         assert_eq!(
             files.get(&format!("p/x/o/{algorithm}/{hex}.json")).map(Vec::as_slice),
@@ -812,6 +1048,301 @@ mod tests {
         let observed = observe_one_tag(&publisher, &physical, "1.0.0").await.unwrap();
 
         assert_eq!(observed.bytes, served_bytes, "no descriptor is dropped on the way in");
+    }
+
+    // ── observe_desc (D6) ────────────────────────────────────────────────────
+
+    /// Seed one `__ocx.desc` layer blob on the stub and describe it.
+    fn desc_layer(data: &StubTransportData, media_type: &str, bytes: &[u8]) -> oci::Descriptor {
+        let digest = oci::Algorithm::Sha256.hash(bytes);
+        data.write().blobs.insert(digest.to_string(), bytes.to_vec());
+        oci::Descriptor {
+            media_type: media_type.to_string(),
+            digest: digest.to_string(),
+            size: i64::try_from(bytes.len()).expect("test blob fits i64"),
+            urls: None,
+            artifact_type: None,
+            annotations: None,
+        }
+    }
+
+    /// Seed a description artifact at `127.0.0.1/x:__ocx.desc` — the manifest
+    /// and its layer blobs — and hand back the tag digest the registry serves.
+    fn seed_description(
+        data: &StubTransportData,
+        readme: &[u8],
+        logo: Option<(&str, &[u8])>,
+        annotations: &[(&str, &str)],
+    ) -> String {
+        let mut layers = vec![desc_layer(data, crate::MEDIA_TYPE_MARKDOWN, readme)];
+        if let Some((media_type, bytes)) = logo {
+            layers.push(desc_layer(data, media_type, bytes));
+        }
+        let manifest = oci::Manifest::Image(oci::ImageManifest {
+            artifact_type: Some(crate::MEDIA_TYPE_DESCRIPTION_V1.to_string()),
+            layers,
+            annotations: Some(
+                annotations
+                    .iter()
+                    .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                    .collect(),
+            ),
+            ..Default::default()
+        });
+        let bytes = serde_json::to_vec_pretty(&manifest).expect("manifest serializes");
+        let digest = oci::Algorithm::Sha256.hash(&bytes);
+        data.write().manifests.insert(
+            format!("127.0.0.1/x:{}", InternalTag::DESCRIPTION_TAG),
+            (bytes, digest.to_string()),
+        );
+        digest.to_string()
+    }
+
+    fn loopback_physical() -> Physical {
+        extract_physical(&committed_root("oci://127.0.0.1/x")).expect("root parses")
+    }
+
+    /// A committed root whose `desc` records tag digest `digest` and points at
+    /// CAS readme object `readme`.
+    fn root_with_desc(digest: &str, readme: &str) -> Value {
+        let mut root = committed_root("oci://127.0.0.1/x");
+        root["desc"] = serde_json::json!({
+            "digest": digest,
+            "title": "Widget",
+            "description": "A widget",
+            "keywords": [],
+            "readme": readme,
+        });
+        root
+    }
+
+    /// The full wire contract of a fresh observation: the `desc` object's field
+    /// order and values, and the CAS blobs it points at. `digest` is the
+    /// registry's floating `__ocx.desc` tag digest — never a content hash —
+    /// while `readme`/`logo` are this index's own hashes over the served bytes,
+    /// which the index CI re-derives from the committed files.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn observe_desc_builds_the_wire_object_and_its_cas_blobs() {
+        let data = StubTransportData::new();
+        let readme = b"# widget\n\nDoes widget things.\n".as_slice();
+        let logo = b"\x89PNG\r\n\x1a\nnot-really-a-png".as_slice();
+        let tag_digest = seed_description(
+            &data,
+            readme,
+            Some((crate::MEDIA_TYPE_PNG, logo)),
+            &[
+                (oci::annotations::TITLE, "Widget"),
+                (oci::annotations::DESCRIPTION, "A widget"),
+                (oci::annotations::KEYWORDS, " build ,, tool "),
+            ],
+        );
+        let publisher = stub_publisher(&data);
+
+        let observed = observe_desc(&publisher, &loopback_physical(), &committed_root("oci://127.0.0.1/x"))
+            .await
+            .expect("the description observes");
+        let rebuilt = observed
+            .desc
+            .clone()
+            .expect("a description where the root had none is a change");
+
+        let readme_digest = oci::Algorithm::Sha256.hash(readme);
+        let logo_digest = oci::Algorithm::Sha256.hash(logo);
+        let expected = serde_json::json!({
+            "digest": tag_digest,
+            "title": "Widget",
+            "description": "A widget",
+            "keywords": ["build", "tool"],
+            "readme": readme_digest.to_string(),
+            "logo": logo_digest.to_string(),
+        });
+        assert_eq!(
+            String::from_utf8(serialize_root(&rebuilt)).expect("UTF-8"),
+            String::from_utf8(serialize_root(&expected)).expect("UTF-8"),
+            "field order and values must match the index bot's Desc wire shape"
+        );
+
+        let files = build_files("p/acme/widget.json", b"root", "acme/widget", &[], &observed.blobs);
+        assert_eq!(
+            files
+                .get(&format!("p/acme/widget/o/sha256/{}.md", readme_digest.hex()))
+                .map(Vec::as_slice),
+            Some(readme),
+            "the readme rides into CAS verbatim, under its own hash and a .md name"
+        );
+        assert_eq!(
+            files
+                .get(&format!("p/acme/widget/o/sha256/{}.png", logo_digest.hex()))
+                .map(Vec::as_slice),
+            Some(logo),
+            "the logo's extension comes from its layer media type"
+        );
+    }
+
+    /// D6 is a floating-tag comparison: an unmoved `__ocx.desc` digest leaves the
+    /// committed `desc` object alone, so a `--refresh` of a package whose
+    /// description never changes keeps the C6 short-circuit intact.
+    ///
+    /// Its CAS blobs still ride along. The `--out` contract materializes the
+    /// whole entry every run (`announce --out dir && publish dir`), and the
+    /// curated tags' CAS objects are already re-written unconditionally — a
+    /// `desc.readme` the run alone omitted is a dangling reference the index
+    /// refuses.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unmoved_description_rewrites_no_desc_but_still_carries_its_blobs() {
+        let data = StubTransportData::new();
+        let readme = b"# widget\n".as_slice();
+        let tag_digest = seed_description(&data, readme, None, &[]);
+        let readme_digest = oci::Algorithm::Sha256.hash(readme);
+        let publisher = stub_publisher(&data);
+        let root = root_with_desc(&tag_digest, &readme_digest.to_string());
+
+        let observed = observe_desc(&publisher, &loopback_physical(), &root)
+            .await
+            .expect("the probe succeeds");
+
+        assert!(
+            observed.desc.is_none(),
+            "an unmoved description is not rewritten into the root"
+        );
+        let files = build_files("p/acme/widget.json", b"root", "acme/widget", &[], &observed.blobs);
+        let readme_path = format!("p/acme/widget/o/sha256/{}.md", readme_digest.hex());
+        assert_eq!(
+            files.get(&readme_path).map(Vec::as_slice),
+            Some(readme),
+            "the root still points at {readme_path}, so the unchanged run must write it too: {:?}",
+            files.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// The optional half of the format: no logo layer means no `logo` key at
+    /// all. The index types it as a digest string, so `null` is not a form it
+    /// has.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn observe_desc_omits_the_logo_field_when_the_artifact_carries_none() {
+        let data = StubTransportData::new();
+        seed_description(&data, b"# widget\n", None, &[(oci::annotations::TITLE, "Widget")]);
+        let publisher = stub_publisher(&data);
+
+        let observed = observe_desc(&publisher, &loopback_physical(), &committed_root("oci://127.0.0.1/x"))
+            .await
+            .expect("the description observes");
+        let rebuilt = observed.desc.expect("a new description is a change");
+
+        assert!(rebuilt.get("logo").is_none(), "an absent logo omits the key: {rebuilt}");
+        assert_eq!(observed.blobs.len(), 1, "only the readme blob is written");
+        assert_eq!(observed.blobs[0].extension, "md");
+    }
+
+    /// `keywords` is required, so an absent `sh.ocx.keywords` annotation is the
+    /// empty array — never a missing field.
+    ///
+    /// `title` is required too, but typed `minLength: 1`: the empty string is
+    /// not a value it has. An `__ocx.desc` pushed without a title annotation
+    /// (`ocx package describe --readme` on a readme with no frontmatter title)
+    /// therefore falls back to the root's `name` — what the index catalog
+    /// renderer already shows for a package with no description at all. Emitting
+    /// `""` builds a root the pull request checks pass and
+    /// `schema:validate:rendered` then rejects, blocking the whole index deploy.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn observe_desc_defaults_absent_annotations_to_valid_values() {
+        let data = StubTransportData::new();
+        seed_description(&data, b"# widget\n", None, &[]);
+        let publisher = stub_publisher(&data);
+        let root = committed_root("oci://127.0.0.1/x");
+
+        let observed = observe_desc(&publisher, &loopback_physical(), &root)
+            .await
+            .expect("the description observes");
+        let rebuilt = observed.desc.expect("a new description is a change");
+
+        assert_eq!(rebuilt.get("keywords"), Some(&serde_json::json!([])));
+        assert_eq!(
+            rebuilt.get("title"),
+            root.get("name"),
+            "an absent title annotation falls back to the root's name, never the empty string"
+        );
+        assert_eq!(
+            rebuilt.get("description"),
+            Some(&Value::String(String::new())),
+            "an absent description annotation is the empty string — the schema allows it"
+        );
+    }
+
+    /// The same fallback for a title annotation the publisher set to the empty
+    /// string (`ocx package describe --title ""`): present-but-empty is exactly
+    /// the value the schema refuses, so absence is not the only trigger.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn observe_desc_replaces_an_empty_title_annotation() {
+        let data = StubTransportData::new();
+        seed_description(&data, b"# widget\n", None, &[(oci::annotations::TITLE, "")]);
+        let publisher = stub_publisher(&data);
+        let root = committed_root("oci://127.0.0.1/x");
+
+        let observed = observe_desc(&publisher, &loopback_physical(), &root)
+            .await
+            .expect("the description observes");
+        let rebuilt = observed.desc.expect("a new description is a change");
+
+        assert_eq!(rebuilt.get("title"), root.get("name"));
+    }
+
+    /// The last rung. `name` is schema-required of every real root, but the
+    /// title fallback exists precisely because reading a non-empty string out of
+    /// data that merely ought to carry one is the bet that produced `""` in the
+    /// first place — so a root without `name` still yields a valid title.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn observe_desc_titles_a_root_without_a_name_from_its_repository() {
+        let data = StubTransportData::new();
+        seed_description(&data, b"# widget\n", None, &[]);
+        let publisher = stub_publisher(&data);
+        let mut root = committed_root("oci://127.0.0.1/x");
+        root.as_object_mut().expect("the root is an object").remove("name");
+
+        let observed = observe_desc(&publisher, &loopback_physical(), &root)
+            .await
+            .expect("the description observes");
+        let rebuilt = observed.desc.expect("a new description is a change");
+
+        assert_eq!(
+            rebuilt.get("title"),
+            Some(&Value::String("x".to_string())),
+            "the physical repository stands in; the empty string never ships"
+        );
+    }
+
+    /// The overwhelmingly common case today: no `__ocx.desc` published and a
+    /// `desc: null` root. Both absent is "no change", never an error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn observe_desc_of_a_package_without_a_description_is_a_no_op() {
+        let data = StubTransportData::new();
+        let publisher = stub_publisher(&data);
+
+        let observed = observe_desc(&publisher, &loopback_physical(), &committed_root("oci://127.0.0.1/x"))
+            .await
+            .expect("an absent description must not fail the announce");
+
+        assert!(observed.desc.is_none());
+        assert!(observed.blobs.is_empty());
+    }
+
+    /// A recorded description that has since vanished stops the run: retraction
+    /// semantics are unspecified, and silently clearing `desc` back to null
+    /// would destroy governed content on a publisher's routine tag announce.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn observe_desc_refuses_a_description_that_disappeared() {
+        let data = StubTransportData::new();
+        let publisher = stub_publisher(&data);
+        let recorded = digest_string('e');
+
+        let root = root_with_desc(&recorded, &digest_string('f'));
+        let result = observe_desc(&publisher, &loopback_physical(), &root).await;
+
+        let Err(AnnounceError::DescDisappeared { repository, digest }) = result else {
+            panic!("a vanished description must be refused, not silently cleared");
+        };
+        assert_eq!(repository, "oci://127.0.0.1/x");
+        assert_eq!(digest, recorded);
     }
 
     // ── regenerate (C6 no-churn) ─────────────────────────────────────────────
@@ -963,6 +1494,7 @@ mod tests {
             b"root-bytes",
             "acme/widget",
             std::slice::from_ref(&entry),
+            &[],
         );
         assert_eq!(
             files.get("p/acme/widget.json").map(Vec::as_slice),

--- a/crates/ocx_lib/src/announce/request.rs
+++ b/crates/ocx_lib/src/announce/request.rs
@@ -78,6 +78,13 @@ pub enum AnnounceStatus {
     Updated,
 }
 
+impl AnnounceStatus {
+    /// [`Self::Updated`] when something moved, [`Self::Unchanged`] otherwise.
+    pub fn from_changed(changed: bool) -> Self {
+        if changed { Self::Updated } else { Self::Unchanged }
+    }
+}
+
 /// The result of an announce run.
 #[derive(Debug)]
 pub struct AnnounceOutcome {
@@ -93,6 +100,12 @@ pub struct AnnounceOutcome {
     /// The relative paths written under the `--out` directory (sorted) — always
     /// the whole entry, unchanged runs included; empty in fork mode.
     pub written_paths: Vec<String>,
+    /// Whether the `__ocx.desc` observation moved this run (D6).
+    /// [`AnnounceStatus::Updated`] means the root's `desc` object was rebuilt
+    /// and its readme (and logo) blobs written as new CAS objects;
+    /// [`AnnounceStatus::Unchanged`] means the description tag sits where the
+    /// committed root already recorded it, or the package publishes none.
+    pub desc_status: AnnounceStatus,
     /// Reserved tags dropped from the curated set (D7) — the OCX-internal
     /// `__ocx` namespace and `<algorithm>.<hex>` canonical tags. Dropping them
     /// is not a failure, so they are reported here rather than refused; empty

--- a/test/tests/announce_helpers.py
+++ b/test/tests/announce_helpers.py
@@ -42,9 +42,17 @@ def configure_trusted_hosts(ocx: OcxRunner, registry: str, hosts: list[str]) -> 
 def seed_empty_root(fake_forge: FakeForge, package: str, physical_repository: str) -> None:
     """Seeds an empty-tags committed root at `p/<package>.json` on the index
     repo's `main` — the "namespace already claimed, nothing curated yet"
-    starting state every scenario announces against."""
+    starting state every scenario announces against.
+
+    `name` is carried because the index root schema requires it of every root:
+    announce reads it (it is the fallback for a description with no title
+    annotation), so a fixture omitting it exercises a root the index cannot
+    hold."""
     fake_forge.seed_root(
-        INDEX_OWNER, INDEX_REPO, f"p/{package}.json", {"repository": physical_repository, "tags": {}}
+        INDEX_OWNER,
+        INDEX_REPO,
+        f"p/{package}.json",
+        {"name": f"ocx.sh/{package}", "repository": physical_repository, "tags": {}},
     )
 
 

--- a/test/tests/test_announce.py
+++ b/test/tests/test_announce.py
@@ -173,8 +173,19 @@ def test_announce_out_writes_the_whole_entry_even_when_nothing_changed(
     so `--out` materializes the whole entry on every run. A pipeline shaped
     `announce --out dir && publish dir` must never find an empty directory just
     because nothing moved; only `status` reports that. The byte contract makes
-    the repeated write idempotent."""
+    the repeated write idempotent.
+
+    "The whole entry" includes the description's CAS objects, which is why this
+    package publishes an `__ocx.desc`: the curated tags' CAS objects are written
+    unconditionally, and a `desc.readme` the second run alone omitted would leave
+    the published directory carrying a dangling reference the index refuses. The
+    readme is deliberately pushed with no title (no frontmatter, no `--title`),
+    the state that produced a schema-invalid `desc.title: ""`.
+    """
     make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, cascade=False)
+    readme = tmp_path / "README.md"
+    readme.write_text("# widget\n\nDoes widget things.\n")
+    ocx.plain("package", "describe", "--readme", str(readme), f"{ocx.registry}/{unique_repo}")
     package = f"acme/{unique_repo}"
     physical = f"oci://{ocx.registry}/{unique_repo}"
     seed_empty_root(fake_forge, package, physical)
@@ -183,6 +194,15 @@ def test_announce_out_writes_the_whole_entry_even_when_nothing_changed(
     first_dir = tmp_path / "first"
     first = announce_json(ocx, fake_forge, "--package", package, "--tags", "1.0.0", "--out", str(first_dir))
     assert first["status"] == "updated"
+    assert first["desc_status"] == "updated", "the description moved from null to an object"
+
+    root_obj = json.loads((first_dir / "p" / f"{package}.json").read_bytes())
+    desc = root_obj["desc"]
+    assert desc["title"], f"the index schema types desc.title minLength 1, got {desc['title']!r}"
+    readme_relative = f"p/{package}/o/sha256/{desc['readme'].split(':', 1)[1]}.md"
+    assert readme_relative in first["written_paths"], (
+        f"the root points at {readme_relative}: {first['written_paths']}"
+    )
 
     # Seed the canonical bytes as the index-main root, so the next run rebuilds
     # something byte-identical to what is already committed.
@@ -192,8 +212,12 @@ def test_announce_out_writes_the_whole_entry_even_when_nothing_changed(
     second_dir = tmp_path / "second"
     second = announce_json(ocx, fake_forge, "--package", package, "--tags", "1.0.0", "--out", str(second_dir))
     assert second["status"] == "unchanged", "nothing moved, so the status must say so"
+    assert second["desc_status"] == "unchanged", "the description did not move either"
     assert sorted(second["written_paths"]) == sorted(first["written_paths"]), (
         "an unchanged --out run must still write the whole entry, not an empty directory"
+    )
+    assert readme_relative in second["written_paths"], (
+        "the unchanged run's root still points at the readme, so it must write it too"
     )
     for relative in first["written_paths"]:
         assert (second_dir / relative).read_bytes() == (first_dir / relative).read_bytes()

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -2052,6 +2052,8 @@ An unchanged run normally opens no pull request either. The one exception is a `
 
 `--out` is unaffected by all of that: it writes the whole entry every run, unchanged included, so `announce --out dir` followed by a step that consumes `dir` never sees an empty directory. Only `status` reports that nothing moved.
 
+Every run also observes the package description published by [`ocx package describe`][cmd-package-describe]. When its artifact has moved since the last announce, the entry's description block is rebuilt — title, summary, keywords, and content-addressed copies of the README and logo — and the report's `desc_status` reads `updated`. An unmoved description costs one request and writes nothing. A description recorded in the index that the registry no longer serves stops the run rather than clearing it silently.
+
 Publishing tags for a package that has no entry in the index yet is out of scope for `announce` — a first-time claim goes through a manual pull request against the index repository.
 
 A tag that is not a version — the OCX-internal `__ocx` namespace, or a canonical `sha256.<hex>` tag from [`--canonical-tag`][cmd-package-push] — is dropped from the curated set rather than failing the run, and reported in the JSON report's `reserved_tags_dropped`. The one exception: `--tags-from-registry` filters a reserved tag out of its listing silently, before it reaches that report, since canonical tags are pushed by default and reporting one per published version would drown a real drop. A reserved tag already committed in the index root is still reported, from any mode. A curated set that resolves to nothing but reserved tags exits 64.
@@ -2090,6 +2092,7 @@ ocx package announce --package <NAMESPACE>/<NAME> (--tags <TAGS> | --tags-from-f
 | The namespace is unclaimed — no committed root exists for the package yet. Claiming one is a human-lane action, never something announce performs | 79 |
 | The forge rate-limited the run (429), or a concurrent announce kept winning the branch — retry | 75 |
 | The curated set resolved to nothing but reserved tags — nothing left to announce | 64 |
+| The description recorded in the index no longer exists on the registry — republish it, or ask for it to be cleared in the index | 65 |
 
 **JSON report**
 
@@ -2100,12 +2103,13 @@ ocx package announce --package <NAMESPACE>/<NAME> (--tags <TAGS> | --tags-from-f
   "pull_request_url": "https://github.com/ocx-sh/index/pull/42",
   "pull_request_number": 42,
   "fork": "forkuser/index",
+  "desc_status": "updated",
   "written_paths": [],
   "reserved_tags_dropped": []
 }
 ```
 
-`status` is `unchanged` or `updated`. `pull_request_url`/`pull_request_number`/`fork` are always `null` for `--out`; in `--fork` mode they are `null` only when the run made no pull request, so an unchanged run that ensured one still reports it. `written_paths` lists the files written under `--out` — the whole entry on every run, `unchanged` included — and stays empty in `--fork` mode. `reserved_tags_dropped` names the tags this run dropped for not being a version — always an array, empty rather than absent — except a reserved tag `--tags-from-registry` observed straight from the registry listing, which never enters it (see above).
+`status` and `desc_status` are each `unchanged` or `updated`; `desc_status` reports the package description separately from the tags. `pull_request_url`/`pull_request_number`/`fork` are always `null` for `--out`; in `--fork` mode they are `null` only when the run made no pull request, so an unchanged run that ensured one still reports it. `written_paths` lists the files written under `--out` — the whole entry on every run, `unchanged` included — and stays empty in `--fork` mode. `reserved_tags_dropped` names the tags this run dropped for not being a version — always an array, empty rather than absent — except a reserved tag `--tags-from-registry` observed straight from the registry listing, which never enters it (see above).
 
 ::: tip
 [`ocx package push --announce-file`][cmd-package-push] appends the tag it just pushed (and any cascade tags) to a file in the same comma/newline format `--tags-from-file` reads, so a publish pipeline can feed one straight into the other:
@@ -3545,6 +3549,7 @@ or a registry error) — the report then degrades to a local-state-only summary
 [patches-user-guide]: ../user-guide/patches.md
 
 <!-- commands (package-test options) -->
+[cmd-package-describe]: #package-describe
 [cmd-package-push]: #package-push
 [cmd-package-push-layout]: #package-push-layout
 [cmd-package-test]: #package-test


### PR DESCRIPTION
`ocx package announce` rebuilt the root's `tags` and carried every other field
over verbatim — so `desc` was never written. Every root the Rust tool has
produced carries `desc: null`, all five currently in `ocx-sh/index`, including
`bazelbuild/bazelisk`, whose registry *does* serve an `__ocx.desc` artifact
(44 tags on `ghcr.io/ocx-contrib/bazelbuild/bazelisk`, one of them `__ocx.desc`).
The Python reference publisher (`indexbot announce` → `core/desc.py`) observes it;
this closes the gap.

## Contract

- `desc.digest` is the `__ocx.desc` **tag** digest (floating-tag compare, D6),
  never a content hash. `desc.readme`/`desc.logo` are the opposite — CAS hashes
  over the exact fetched bytes. Index CI re-derives those two
  (`core/verify_claims.py`), so a wrong byte there is a red required check on
  every publisher's PR.
- Unmoved digest — both-absent included — leaves the committed `desc` untouched.
- CAS blobs ride along on every run that has a description, like the curated
  tags' objects already do: `--out` materializes the whole entry, so writing
  `desc.readme` only on runs where it moved would publish a dangling reference.
- Observation sits behind the same SSRF pre-flight as the tag work; a test
  asserts a forbidden host refuses with zero registry calls, listing included.

## One deliberate divergence from the Python reference

`desc.title` is typed `minLength: 1`, but the title annotation is genuinely
optional — `ocx package describe --readme` over a readme with no frontmatter
title pushes a manifest without one. `core/desc.py:101` defaults it to `""`,
which clears every PR check (nothing there tests title length) and then fails
`schema:validate:rendered` *after* merge, blocking the index deploy for every
package. Here an absent or empty annotation falls back to the root's `name` —
what the catalog renderer already shows for a package with no description.
`ocx-sh/index` needs the same fallback, or the two tools disagree on that field.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings` → 0
- `cargo nextest run -p ocx_lib -p ocx --release` → 3493 passed, 8 skipped
- `task verify --force` → 0 (1807 acceptance passed)
- Seven discriminating mutations, each gated on the mutated text being present
  before the run: union/replace of the desc slot, readme extension, keyword
  filtering, root field order, SSRF hoist, the empty-title fallback, and the
  early-return that dropped the blobs. Each reddened a named test and only that
  test; each was reverted.