### PR TITLE
fix(describe): reject a logo whose bytes are not the format its extension names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [`ocx package describe --logo`](https://ocx.sh/docs/reference/command-line#package-describe) verifies the file's bytes are the image its extension claims, exiting 65 when they are not *(cli)*: only the extension was checked, so a Git LFS pointer left by a checkout without `lfs: true` — or an empty file, or an HTML error page — published as the logo, exited 0, and blanked the catalog entry a good logo had been pushed to.
 - `ocx patch test` can run a base package that declares entrypoints *(cli)*: the launcher `pkg-root` guard allow-listed only `ocx package test`'s scratch root, so re-entry from a generated launcher under `patch test`'s own scratch root was rejected with exit 64 before the command could run.
 
 ### Removed

--- a/crates/ocx_cli/src/command/package_describe.rs
+++ b/crates/ocx_cli/src/command/package_describe.rs
@@ -21,6 +21,10 @@ pub struct PackageDescribe {
     readme: Option<std::path::PathBuf>,
 
     /// Path to an optional logo image (PNG or SVG).
+    ///
+    /// The file's bytes must be the format its extension names. A file that is not
+    /// a real PNG or SVG fails the command without touching the published
+    /// description, so a broken checkout cannot blank a catalog logo.
     #[clap(long)]
     logo: Option<std::path::PathBuf>,
 
@@ -85,12 +89,7 @@ impl PackageDescribe {
         };
 
         let logo = match &self.logo {
-            Some(path) => {
-                let data = std::fs::read(path)
-                    .map_err(|e| anyhow::anyhow!("failed to read logo at {}: {e}", path.display()))?;
-                let media_type = package::description::logo_media_type(path)?;
-                Some(package::description::Logo { data, media_type })
-            }
+            Some(path) => Some(package::description::load_logo(path)?),
             None => existing
                 .as_ref()
                 .and_then(|d| d.logo.as_ref())

--- a/crates/ocx_lib/src/package/description.rs
+++ b/crates/ocx_lib/src/package/description.rs
@@ -23,12 +23,60 @@ pub struct Logo {
 }
 
 /// Returns the media type for a logo file based on its extension.
-pub fn logo_media_type(path: &Path) -> Result<&'static str> {
+fn logo_media_type(path: &Path) -> Result<&'static str> {
     match path.extension().and_then(|e| e.to_str()) {
         Some("png") => Ok(MEDIA_TYPE_PNG),
         Some("svg") => Ok(MEDIA_TYPE_SVG),
         other => Err(super::error::Error::UnsupportedLogoFormat(other.unwrap_or("<no extension>").to_string()).into()),
     }
+}
+
+/// The 8-byte PNG signature every PNG file starts with (PNG spec, clause 5.2).
+const PNG_SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+
+/// Reads a logo file and verifies its bytes are the format its extension claims.
+///
+/// The verification exists because an unchecked `--logo` silently overwrites a
+/// published logo with whatever is on disk — a Git LFS pointer left by a checkout
+/// without `lfs: true`, an empty file, an HTML error page — and the catalog then
+/// renders nothing. Failing here turns that into a loud publish failure.
+///
+/// # Errors
+///
+/// - [`Error::UnsupportedLogoFormat`](super::error::Error::UnsupportedLogoFormat)
+///   when the extension is neither `png` nor `svg`.
+/// - An I/O error carrying the path when the file cannot be read.
+/// - [`Error::InvalidLogoContent`](super::error::Error::InvalidLogoContent) when the
+///   bytes are not the claimed format.
+pub fn load_logo(path: &Path) -> Result<Logo> {
+    let media_type = logo_media_type(path)?;
+    let data = std::fs::read(path).map_err(|e| crate::error::file_error(path, e))?;
+    verify_logo_bytes(path, media_type, &data)?;
+    Ok(Logo { data, media_type })
+}
+
+/// Verifies logo bytes against the media type its extension claimed.
+///
+/// PNG is an exact signature check. SVG is UTF-8 text carrying an `<svg` element —
+/// a presence check, not a parse: it rejects every non-SVG payload seen in practice
+/// (LFS pointers, empty files, HTML, binaries) without owning an XML parser. A text
+/// file that merely mentions `<svg` passes; the fix for that is a real XML parse,
+/// which no failure so far justifies.
+fn verify_logo_bytes(path: &Path, media_type: &'static str, data: &[u8]) -> Result<()> {
+    let is_png = media_type == MEDIA_TYPE_PNG;
+    let valid = if is_png {
+        data.starts_with(&PNG_SIGNATURE)
+    } else {
+        std::str::from_utf8(data).is_ok_and(|text| text.contains("<svg"))
+    };
+    if valid {
+        return Ok(());
+    }
+    Err(super::error::Error::InvalidLogoContent {
+        path: path.to_path_buf(),
+        expected: if is_png { "PNG" } else { "SVG" },
+    }
+    .into())
 }
 
 /// YAML frontmatter extracted from a README.
@@ -123,6 +171,108 @@ pub fn parse_readme(raw: &str) -> ParsedReadme {
                 body: raw.to_string(),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod logo_tests {
+    use super::*;
+
+    /// What a checkout without `lfs: true` leaves at `assets/logo.png`. This exact
+    /// shape was published as a logo and blanked a live catalog entry.
+    const LFS_POINTER: &[u8] = b"version https://git-lfs.github.com/spec/v1\noid sha256:c95693dc\nsize 596109\n";
+
+    fn png() -> Vec<u8> {
+        let mut data = PNG_SIGNATURE.to_vec();
+        data.extend_from_slice(b"\x00\x00\x00\rIHDR");
+        data
+    }
+
+    fn verify(name: &str, data: &[u8]) -> Result<()> {
+        let path = Path::new(name);
+        verify_logo_bytes(path, logo_media_type(path)?, data)
+    }
+
+    /// `Logo` holds raw bytes and deliberately has no `Debug`, so `unwrap_err` is
+    /// unavailable here.
+    fn load_error(path: &str) -> String {
+        match load_logo(Path::new(path)) {
+            Ok(_) => panic!("expected '{path}' to be refused"),
+            Err(error) => error.to_string(),
+        }
+    }
+
+    #[test]
+    fn real_png_bytes_pass() {
+        assert!(verify("logo.png", &png()).is_ok());
+    }
+
+    #[test]
+    fn lfs_pointer_named_png_is_rejected() {
+        let error = verify("logo.png", LFS_POINTER).unwrap_err().to_string();
+        assert!(error.contains("is not a PNG image"), "{error}");
+    }
+
+    #[test]
+    fn lfs_pointer_named_svg_is_rejected() {
+        let error = verify("logo.svg", LFS_POINTER).unwrap_err().to_string();
+        assert!(error.contains("is not a SVG image"), "{error}");
+    }
+
+    #[test]
+    fn empty_file_is_rejected_for_both_formats() {
+        assert!(verify("logo.png", b"").is_err());
+        assert!(verify("logo.svg", b"").is_err());
+    }
+
+    #[test]
+    fn svg_passes_with_or_without_an_xml_declaration() {
+        assert!(verify("logo.svg", br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#).is_ok());
+        assert!(verify("logo.svg", b"<?xml version=\"1.0\"?>\n<svg viewBox=\"0 0 1 1\"></svg>").is_ok());
+    }
+
+    #[test]
+    fn html_error_page_named_svg_is_rejected() {
+        assert!(verify("logo.svg", b"<!DOCTYPE html><html><body>404</body></html>").is_err());
+    }
+
+    #[test]
+    fn png_bytes_named_svg_are_rejected() {
+        // Swapped extensions are caught in both directions.
+        assert!(verify("logo.svg", &png()).is_err());
+        assert!(verify("logo.png", br#"<svg xmlns="http://www.w3.org/2000/svg"/>"#).is_err());
+    }
+
+    #[test]
+    fn unsupported_extension_is_still_rejected_before_any_read() {
+        let error = load_error("logo.gif");
+        assert!(error.contains("unsupported logo format: gif"), "{error}");
+    }
+
+    #[test]
+    fn missing_file_reports_the_path() {
+        let error = load_error("no/such/logo.png");
+        assert!(error.contains("no/such/logo.png"), "{error}");
+    }
+
+    #[test]
+    fn load_logo_returns_the_bytes_and_media_type_it_verified() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logo.png");
+        std::fs::write(&path, png()).unwrap();
+
+        let logo = load_logo(&path).unwrap();
+        assert_eq!(logo.media_type, MEDIA_TYPE_PNG);
+        assert_eq!(logo.data, png());
+    }
+
+    #[test]
+    fn load_logo_refuses_a_file_whose_bytes_lie() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("logo.png");
+        std::fs::write(&path, LFS_POINTER).unwrap();
+
+        assert!(load_logo(&path).is_err());
     }
 }
 

--- a/crates/ocx_lib/src/package/error.rs
+++ b/crates/ocx_lib/src/package/error.rs
@@ -24,6 +24,10 @@ pub enum Error {
     #[error("unsupported logo format: {0}")]
     UnsupportedLogoFormat(String),
 
+    /// A logo file's bytes are not the image format its extension claims.
+    #[error("logo at {} is not a {expected} image", .path.display())]
+    InvalidLogoContent { path: PathBuf, expected: &'static str },
+
     /// A required path does not exist.
     #[error("required path does not exist: {}", .0.display())]
     RequiredPathMissing(PathBuf),
@@ -53,9 +57,11 @@ pub enum Error {
 impl ClassifyExitCode for Error {
     fn classify(&self) -> Option<ExitCode> {
         match self {
-            Self::VersionInvalid(_) | Self::UnsupportedLogoFormat(_) | Self::BuildMeta(_) | Self::EmptyPushSet => {
-                Some(ExitCode::DataError)
-            }
+            Self::VersionInvalid(_)
+            | Self::UnsupportedLogoFormat(_)
+            | Self::InvalidLogoContent { .. }
+            | Self::BuildMeta(_)
+            | Self::EmptyPushSet => Some(ExitCode::DataError),
             Self::RequiredPathMissing(_) => Some(ExitCode::NotFound),
             Self::EnvVarInterpolation { source, .. } => source.classify(),
             Self::EntrypointArgInterpolation { source, .. } => source.classify(),

--- a/test/tests/test_describe.py
+++ b/test/tests/test_describe.py
@@ -225,3 +225,52 @@ def test_describe_cli_flags_override_frontmatter(ocx: OcxRunner, unique_repo: st
 
     # Description was only in frontmatter (no CLI flag), so frontmatter value is used.
     assert annotations["org.opencontainers.image.description"] == "Frontmatter description"
+
+
+# A 1x1 transparent PNG.
+VALID_PNG = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06"
+    b"\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx"
+    b"\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+# What a checkout without `lfs: true` leaves behind at `assets/logo.png`.
+LFS_POINTER = b"version https://git-lfs.github.com/spec/v1\noid sha256:c95693dc\nsize 596109\n"
+
+
+def _sole_logo_digest(registry: str, repo: str) -> str:
+    """Digest of the one image layer on __ocx.desc, refusing an ambiguous manifest."""
+    manifest = fetch_manifest_from_registry(registry, repo, "__ocx.desc")
+    images = [l for l in manifest["layers"] if l["mediaType"].startswith("image/")]
+    assert len(images) == 1, f"expected exactly one image layer, got {images}"
+    return images[0]["digest"]
+
+
+def test_describe_refuses_a_logo_whose_bytes_are_not_an_image(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+):
+    """A file that is not really a PNG must fail loudly, leaving the published logo intact.
+
+    The regression: `--logo` validated only the extension, so an LFS pointer left by a
+    checkout without `lfs: true` published as the logo, exit 0, and blanked the catalog
+    entry that a good logo had been pushed to.
+    """
+    readme = tmp_path / "README.md"
+    readme.write_text("# Tool\n")
+    good = tmp_path / "logo.png"
+    good.write_bytes(VALID_PNG)
+
+    fq = f"{ocx.registry}/{unique_repo}"
+    ocx.plain("package", "describe", "--readme", str(readme), "--logo", str(good), fq)
+    published = _sole_logo_digest(ocx.registry, unique_repo)
+
+    pointer = tmp_path / "pointer.png"
+    pointer.write_bytes(LFS_POINTER)
+    result = ocx.plain("package", "describe", "--logo", str(pointer), fq, check=False)
+
+    assert result.returncode == 65, f"rc={result.returncode} stderr={result.stderr}"
+    assert "is not a PNG image" in result.stderr, result.stderr
+
+    # The good logo is still what the registry serves — nothing was overwritten.
+    assert _sole_logo_digest(ocx.registry, unique_repo) == published

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -2765,7 +2765,7 @@ ocx package describe [OPTIONS] <IDENTIFIER>
 **Options**
 
 - `--readme <PATH>`: Path to a README markdown file.
-- `--logo <PATH>`: Path to a logo image (PNG or SVG).
+- `--logo <PATH>`: Path to a logo image (PNG or SVG). The file's bytes must be the format its extension names; anything else exits 65 without touching the published description.
 - `--title <TITLE>`: Short display title for the package catalog.
 - `--description <TEXT>`: One-line summary.
 - `--keywords <LIST>`: Comma-separated search keywords.


### PR DESCRIPTION
Closes #166.

`--logo` checked the extension and nothing else. A Git LFS pointer left by a checkout without `lfs: true` published as the logo, exited 0, and blanked a live catalog entry — the good logo was uploaded, then effectively deleted.

`load_logo` now reads and verifies in one step, so the read path cannot be taken without the check:

- **PNG** — the 8-byte signature.
- **SVG** — UTF-8 text carrying an `<svg` element.

Mismatch raises `InvalidLogoContent` → **exit 65**, before anything is pushed. It catches both directions: PNG bytes named `.svg` fail too.

The SVG side is a presence check, not an XML parse. It rejects every non-SVG payload seen in practice (LFS pointers, empty files, HTML error pages, binaries) without owning a parser. A text file that merely mentions `<svg` passes — noted in the code, and no failure so far justifies more.

## Both outcomes demonstrated

Against a mutated verification (`starts_with(&PNG_SIGNATURE[..0])` / `from_utf8(..).is_ok()`), 6 unit tests and the acceptance test go red. The acceptance red reproduces the original bug verbatim:

```
E       assert 0 == 65
        ... INFO Pushed description for localhost:5000/t_26184753_...
```

Restored: 3578 Rust tests pass, `task rust:verify` exit 0, `test_describe.py` 9 passed.

The acceptance test guards the data loss itself, not just the exit code — it publishes a good logo, attempts the LFS pointer, then asserts the registry still serves the original digest.