### PR TITLE
ci(publish): publish releases to ghcr.io/ocx-sh/ocx/cli

### DIFF
--- a/.github/workflows/oci-publish.yml
+++ b/.github/workflows/oci-publish.yml
@@ -75,13 +75,13 @@ on:
           with. Absent (fork build, dev publish) means publish without announcing.
         required: false
 
-permissions:
-  contents: read
-  # GHCR push authenticates as GITHUB_TOKEN. A reusable workflow can only narrow
-  # the caller's grant, so this scope must be listed here AND granted by the
-  # caller — for release.yml that is `github-custom-job-permissions` in
-  # dist-workspace.toml, since the file itself is generated.
-  packages: write
+# No `permissions:` block on purpose. This workflow has two callers wanting
+# different scopes — the release path needs `packages: write` for the GHCR push,
+# the dev path pushes to dev.ocx.sh with its own registry credential and needs
+# nothing. A declaration here caps BOTH (a called workflow can only narrow its
+# caller's grant, never widen it), so a shared value would either strip the
+# release push's scope or hand the dev push one it has no use for. Each caller
+# declares what it needs instead.
 
 jobs:
   publish:

--- a/.github/workflows/oci-publish.yml
+++ b/.github/workflows/oci-publish.yml
@@ -15,14 +15,24 @@ on:
   workflow_call:
     inputs:
       registry:
-        description: Registry hostname (e.g. `dev.ocx.sh`, `ocx.sh`).
+        description: Registry hostname (e.g. `dev.ocx.sh`, `ghcr.io`).
         required: true
         type: string
       repo:
         description: First-party namespace within the registry (typically `ocx`).
           Default variant publishes to `<repo>/cli`; named variants to `<repo>/<variant>`.
+          This is the LOGICAL package path — the one the index entry is keyed by and
+          `package announce` names. The physical push target prepends `physical_namespace`.
         required: true
         type: string
+      physical_namespace:
+        description: Path segment prepended to `<repo>/<name>` for the push target only,
+          for a registry that namespaces by owner (`ghcr.io` → `ocx-sh`, giving
+          `ghcr.io/ocx-sh/ocx/cli` for the logical `ocx/cli`). Empty for a registry whose
+          root is already the namespace.
+        required: false
+        type: string
+        default: ""
       version_tag:
         description: Fully formed publish tag, including any pre-release and UTC
           build-metadata segments (e.g. `0.3.0-dev_20260514120000`). Callers are
@@ -48,6 +58,13 @@ on:
         required: false
         type: string
         default: bare
+      announce:
+        description: Publish the pushed tags into the index. Only the release publish
+          sets this — a dev tag does not exist on the repository the index root points at,
+          so announcing one would observe nothing.
+        required: false
+        type: boolean
+        default: false
     secrets:
       REGISTRY_USER:
         required: true
@@ -60,6 +77,11 @@ on:
 
 permissions:
   contents: read
+  # GHCR push authenticates as GITHUB_TOKEN. A reusable workflow can only narrow
+  # the caller's grant, so this scope must be listed here AND granted by the
+  # caller — for release.yml that is `github-custom-job-permissions` in
+  # dist-workspace.toml, since the file itself is generated.
+  packages: write
 
 jobs:
   publish:
@@ -146,6 +168,8 @@ jobs:
         env:
           REGISTRY: ${{ inputs.registry }}
           REPO: ${{ inputs.repo }}
+          PHYSICAL_NAMESPACE: ${{ inputs.physical_namespace }}
+          ANNOUNCE: ${{ inputs.announce }}
           VERSION_TAG: ${{ inputs.version_tag }}
           VARIANTS_JSON: ${{ inputs.variants }}
           TARGETS_JSON: ${{ inputs.targets }}
@@ -164,9 +188,17 @@ jobs:
 
           # W9: allowlist defense-in-depth — only permit known registries.
           case "$REGISTRY" in
-            dev.ocx.sh|ocx.sh) ;;
+            dev.ocx.sh|ghcr.io) ;;
             *) echo "::error::registry '$REGISTRY' not in allowlist"; exit 1 ;;
           esac
+
+          # Same validation for the physical namespace: it lands in the push
+          # identifier, so it must not be able to carry shell metacharacters.
+          if [[ -n "${PHYSICAL_NAMESPACE}" ]] && ! [[ "${PHYSICAL_NAMESPACE}" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+            echo "::error::physical_namespace '${PHYSICAL_NAMESPACE}' contains invalid characters"
+            exit 1
+          fi
+          physical_prefix="${PHYSICAL_NAMESPACE:+${PHYSICAL_NAMESPACE}/}"
 
           # Map secrets to the registry-specific env names ocx reads.
           # Hostname dots become underscores in OCX_AUTH_<host>_USER/TOKEN.
@@ -224,9 +256,11 @@ jobs:
             fi
             # The announce re-observes each curated tag on the physical
             # repository the index root points at, which is the PROD registry —
-            # a dev tag simply does not exist there.
-            if [[ "$REGISTRY" != "ocx.sh" ]]; then
-              echo "::notice::skipping index announce for ${repo_path}: ${REGISTRY} is not the registry ocx-sh/index points at"
+            # a dev tag simply does not exist there. The caller declares which
+            # publish that is; deriving it from the registry hostname went stale
+            # the moment the prod registry moved.
+            if [[ "$ANNOUNCE" != "true" ]]; then
+              echo "::notice::skipping index announce for ${repo_path}: this publish does not announce"
               return 0
             fi
             if [[ -z "${OCX_ANNOUNCE_TOKEN:-}" ]]; then
@@ -304,13 +338,17 @@ jobs:
                 -o "$ARCHIVE" \
                 -p "$platform"
 
-              identifier="${REGISTRY}/${repo_path}:${VERSION_TAG}"
+              identifier="${REGISTRY}/${physical_prefix}${repo_path}:${VERSION_TAG}"
               echo "==> Publishing ${identifier} (${platform})"
+              # `image.source` is what links the GHCR package to this repository
+              # and lets it inherit the repository's permissions; a registry
+              # derives nothing from the path, so it has to be stated.
               ocx package push \
                 --identifier "${identifier}" \
                 --platform "${platform}" \
                 --cascade \
                 --new \
+                --annotation "org.opencontainers.image.source=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
                 "${announce_flag[@]}" \
                 "$ARCHIVE"
 
@@ -332,8 +370,8 @@ jobs:
             # variant would need its own. None exists today — ocx-mirror
             # publishes ocx.sh/ocx/mirror from its own repository.
             if [[ -z "$variant" ]]; then
-              echo "==> Pushing catalog description for ${REGISTRY}/${repo_path}"
-              ocx package describe "${REGISTRY}/${repo_path}" \
+              echo "==> Pushing catalog description for ${REGISTRY}/${physical_prefix}${repo_path}"
+              ocx package describe "${REGISTRY}/${physical_prefix}${repo_path}" \
                 --readme packaging/ocx/CATALOG.md \
                 --logo assets/logo.svg
             fi

--- a/.github/workflows/post-release-oci-publish.yml
+++ b/.github/workflows/post-release-oci-publish.yml
@@ -14,6 +14,10 @@ on:
 
 permissions:
   contents: read
+  # Forwarded to oci-publish.yml for the GHCR push. Each link in the chain caps
+  # the next, so dropping this here would strip the scope release.yml grants
+  # (via `github-custom-job-permissions`) before the push job ever sees it.
+  packages: write
 
 jobs:
   compute-tag:

--- a/.github/workflows/post-release-oci-publish.yml
+++ b/.github/workflows/post-release-oci-publish.yml
@@ -39,8 +39,13 @@ jobs:
     needs: [compute-tag]
     uses: ./.github/workflows/oci-publish.yml
     with:
-      registry: ocx.sh
+      # Logical name stays `ocx.sh/ocx/cli` — that is what the index entry is
+      # keyed by and what users install. Only the physical home moved to GHCR,
+      # so `repo` (logical) and `physical_namespace` (push target) differ here.
+      registry: ghcr.io
       repo: ocx
+      physical_namespace: ocx-sh
+      announce: true
       version_tag: ${{ needs.compute-tag.outputs.version_tag }}
       # Prod registry carries the default ocx variant only. ocx-mirror
       # releases publish ocx.sh/ocx/mirror from its own repo:
@@ -50,6 +55,7 @@ jobs:
       environment: ocx.sh
       artifact_source: cargo-dist
     secrets:
-      REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
-      REGISTRY_TOKEN: ${{ secrets.REGISTRY_TOKEN }}
+      # GHCR takes the workflow's own token; no registry credential to provision.
+      REGISTRY_USER: ${{ github.actor }}
+      REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       OCX_ANNOUNCE_TOKEN: ${{ secrets.OCX_ANNOUNCE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,9 @@ jobs:
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
+    permissions:
+      "contents": "read"
+      "packages": "write"
 
   custom-deploy-website-release:
     needs:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -28,7 +28,7 @@ plan-jobs = ["./verify-version"]
 post-announce-jobs = ["./post-release-oci-publish", "./deploy-website-release", "./docker-publish"]
 # Extra permissions for custom jobs. The override REPLACES the defaults, so
 # every scope the called workflow needs must be listed.
-github-custom-job-permissions = { docker-publish = { contents = "read", packages = "write", id-token = "write", attestations = "write" } }
+github-custom-job-permissions = { docker-publish = { contents = "read", packages = "write", id-token = "write", attestations = "write" }, post-release-oci-publish = { contents = "read", packages = "write" } }
 # No `include` for LICENSE-THIRD-PARTY.md: dist's auto-include glob is a
 # prefix match on `LICENSE*`, so it already lands in every archive. Listing
 # it explicitly puts it in twice (verified with `dist plan`).


### PR DESCRIPTION
Follows [ocx-sh/index#132](https://github.com/ocx-sh/index/pull/132), which repointed the index entry at GHCR. The logical name `ocx.sh/ocx/cli` is unchanged, so nothing consumers write changes.

- **Logical vs physical split.** The push target and the index key stopped being the same string, so they stopped being one input: `repo` stays the logical `ocx` that `package announce` names, and the new `physical_namespace` is prepended for the push/describe identifiers only.
- **Announce gate.** It keyed on `REGISTRY == ocx.sh`, which silently stops announcing the moment the prod registry moves. Now an explicit `announce` input; `deploy-dev` leaves it false.
- **Credentials.** GHCR takes `GITHUB_TOKEN`, so no secret to provision. A reusable workflow can only narrow its caller's grant, so `packages: write` is declared in `oci-publish.yml` *and* granted via `github-custom-job-permissions` in `dist-workspace.toml` — `release.yml` is generated, regenerated here with `dist generate-ci`.
- **`image.source` annotation** links the GHCR package to this repository; the path implies nothing.
- **`ocx.sh` leaves the allowlist** — nothing publishes there any more, so a stale caller fails loudly.

Verified locally: `dist generate --check` clean, `actionlint` clean on all three workflows (and rc=1 on a known-bad fixture, so the pass means something). The real proof is the next release.