### PR TITLE
ci: bump workflow-lint setup-ocx pin to 0.5.2 for lock_version 3

### DIFF
--- a/.github/workflows/verify-basic.yml
+++ b/.github/workflows/verify-basic.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup OCX
         uses: ./.github/actions/setup-ocx
         with:
-          version: '0.3.7'
+          version: '0.5.2'
       - name: Lint workflows
         # `ocx run` composes the project toolchain (actionlint + shellcheck +
         # go-task) from ocx.lock and runs the task hermetically — same gate as


### PR DESCRIPTION
The v0.5.2 release commit re-locked `ocx.lock` to `lock_version = 3`. The workflow-lint job bootstraps ocx **0.3.7**, which parses only lock v1 — exit 78 before actionlint runs ([failing run](https://github.com/ocx-sh/ocx/actions/runs/30741767601/job/91480343366)).

One-line pin bump `0.3.7` → `0.5.2` (release assets live). Verified locally: `ocx run -- task ci:actionlint` green with 0.5.x against the v3 lock.

Note: recurs on any future lock-format bump while the pin trails the lock writer — a floating pin in setup-ocx would fix the class; skipped as bigger change.