### PR TITLE
fix: registry fault classification, transient push retry, package-first test resolution

### DIFF
--- a/crates/ocx_cli/src/command/launcher/exec.rs
+++ b/crates/ocx_cli/src/command/launcher/exec.rs
@@ -209,7 +209,11 @@ impl LauncherExec {
         // No PATHEXT manipulation: the Windows launcher is now a native
         // `<name>.exe` shim resolved via the default Windows PATHEXT.
 
-        let resolved = process_env.resolve_command(command);
+        // The shadow rule has to hold at this hop too: a package that declares
+        // entrypoints resolves THROUGH its generated launcher, so a plain
+        // `resolve_command` here would let a host copy win in the fresh
+        // `ocx launcher exec` process and defeat the check the parent made.
+        let resolved = process_env.resolve_test_command(command)?;
 
         let err = child_process::exec(&resolved, args, process_env);
         Err(anyhow::Error::from(err).context(format!("failed to run '{}'", resolved.display())))

--- a/crates/ocx_cli/src/command/package_test.rs
+++ b/crates/ocx_cli/src/command/package_test.rs
@@ -362,7 +362,7 @@ impl PackageTest {
             .split_first()
             .expect("clap required_unless_present=script guarantees a command in the non-script branch");
 
-        let resolved = process_env.resolve_command(command);
+        let resolved = process_env.resolve_test_command(command)?;
 
         // Print keep message before the child runs — last output ocx produces.
         if let Some(msg) = &keep_msg {

--- a/crates/ocx_cli/src/command/patch_test.rs
+++ b/crates/ocx_cli/src/command/patch_test.rs
@@ -242,7 +242,7 @@ async fn run_patch_test(args: &PatchTestArgs, context: crate::app::Context) -> a
         .await
     } else if !args.command.is_empty() {
         let (command, command_args) = args.command.split_first().expect("non-empty command checked above");
-        let resolved = process_env.resolve_command(command);
+        let resolved = process_env.resolve_test_command(command)?;
         let status = child_process::spawn_and_wait(&resolved, command_args, process_env)
             .await
             .map_err(|e| anyhow::Error::from(e).context(format!("failed to run '{}'", resolved.display())))?;

--- a/crates/ocx_lib/src/cli/classify.rs
+++ b/crates/ocx_lib/src/cli/classify.rs
@@ -82,7 +82,7 @@ fn try_classify(cause: &(dyn std::error::Error + 'static)) -> Option<ExitCode> {
     use crate::compression::error::Error as CompressionError;
     use crate::config::error::Error as ConfigError;
     use crate::config::managed::ManagedConfigError;
-    use crate::env::ForwardedEnvError;
+    use crate::env::{CommandResolutionError, ForwardedEnvError};
     use crate::file_structure::error::Error as FileStructureError;
     use crate::forge::ForgeError;
     use crate::managed_config::{
@@ -128,6 +128,7 @@ fn try_classify(cause: &(dyn std::error::Error + 'static)) -> Option<ExitCode> {
     try_downcast!(crate::Error);
     try_downcast!(ConfigError);
     try_downcast!(ForwardedEnvError);
+    try_downcast!(CommandResolutionError);
     try_downcast!(ClientError);
     try_downcast!(OciIndexError);
     try_downcast!(DigestError);
@@ -371,6 +372,19 @@ mod tests {
             "bad-input",
             crate::oci::identifier::error::IdentifierErrorKind::InvalidFormat,
         );
+        assert_eq!(classify(err), ExitCode::DataError);
+    }
+
+    #[test]
+    fn command_resolution_error_maps_to_data_error() {
+        // A package shipping a non-executable binary is malformed content →
+        // DataError (65), parity with BinScanError::DeclaredNotExecutable.
+        // Without the ladder rung this silently degrades to Failure (1).
+        let err = crate::env::CommandResolutionError::NotExecutable {
+            command: "shtool".into(),
+            path: PathBuf::from("/pkg/bin/shtool"),
+            mode: 0o644,
+        };
         assert_eq!(classify(err), ExitCode::DataError);
     }
 

--- a/crates/ocx_lib/src/cli/classify.rs
+++ b/crates/ocx_lib/src/cli/classify.rs
@@ -335,6 +335,16 @@ mod tests {
         assert_eq!(classify(err), ExitCode::Unavailable);
     }
 
+    /// The 75-vs-69 split: a transient registry fault exits 75, which is what
+    /// tells a wrapper the same command may succeed if it is run again. The
+    /// sibling test above keeps the 69 fall-through honest — both must hold, or
+    /// the distinction is decorative.
+    #[test]
+    fn client_registry_transient_maps_to_temp_fail() {
+        let err = ClientError::RegistryTransient(Box::new(std::io::Error::other("connect timed out")));
+        assert_eq!(classify(err), ExitCode::TempFail);
+    }
+
     #[test]
     fn client_io_maps_to_io_error() {
         // Plan taxonomy: ClientError::Io → IoError (74)

--- a/crates/ocx_lib/src/cli/exit_code.rs
+++ b/crates/ocx_lib/src/cli/exit_code.rs
@@ -30,14 +30,21 @@ pub enum ExitCode {
     DataError = 65,
     /// Required resource unavailable: network down, registry unreachable.
     /// Mirrors `EX_UNAVAILABLE` (69).
+    ///
+    /// Rerunning the same command will not change the outcome — that is what
+    /// separates this from [`ExitCode::TempFail`].
     Unavailable = 69,
     /// I/O error: filesystem permission denied, disk full, read/write failure.
     /// Mirrors `EX_IOERR` (74).
     IoError = 74,
-    /// Temporary failure that may succeed on retry: rate limit, transient network.
+    /// Temporary failure that may succeed on retry: rate limit, transient
+    /// network, registry connect failure or timeout.
     /// Mirrors `EX_TEMPFAIL` (75).
+    ///
+    /// The same command may succeed if it is run again — which is what makes
+    /// automated retry safe on 75 and unsafe on [`ExitCode::Unavailable`].
     TempFail = 75,
-    /// Insufficient permissions: registry 403, filesystem `EPERM`.
+    /// Insufficient permissions: filesystem `EPERM`.
     /// Mirrors `EX_NOPERM` (77).
     PermissionDenied = 77,
     /// Configuration error: bad `config.toml`, missing required field, parse failure.
@@ -46,7 +53,7 @@ pub enum ExitCode {
     /// Resource not found: package 404, explicit config path absent.
     /// OCX-specific; first slot above `EX_CONFIG`.
     NotFound = 79,
-    /// Authentication failure: registry 401, missing credentials.
+    /// Authentication failure: registry 401 or 403, missing credentials.
     /// OCX-specific.
     AuthError = 80,
     /// A deliberate local policy (offline, frozen, ...) refused a

--- a/crates/ocx_lib/src/env.rs
+++ b/crates/ocx_lib/src/env.rs
@@ -279,6 +279,16 @@ fn wide_to_upper(c: u16) -> u16 {
 #[derive(Clone)]
 pub struct Env {
     vars: HashMap<EnvKey, OsString>,
+    /// The `PATH` directories contributed by composed package entries, in the
+    /// same order they occupy in `PATH` — never the ambient inherited ones.
+    ///
+    /// This is what makes [`Env::resolve_test_command`] able to answer "does
+    /// the package under test ship this name?" separately from "is this name
+    /// on PATH at all". Populated only by [`Env::apply_entries`], and
+    /// deliberately never emitted by [`Env::iter`] / `IntoIterator`: it is
+    /// resolution bookkeeping, not an environment variable, and must not reach
+    /// a child process.
+    package_path: OsString,
 }
 
 impl Default for Env {
@@ -291,11 +301,15 @@ impl Env {
     pub fn new() -> Self {
         Self {
             vars: std::env::vars_os().map(|(k, v)| (EnvKey::new(k), v)).collect(),
+            package_path: OsString::new(),
         }
     }
 
     pub fn clean() -> Self {
-        Self { vars: HashMap::new() }
+        Self {
+            vars: HashMap::new(),
+            package_path: OsString::new(),
+        }
     }
 
     pub fn get(&self, key: &str) -> Option<&OsStr> {
@@ -475,11 +489,29 @@ impl Env {
     ///
     /// This is the bridge from [`entry::Entry`](crate::package::metadata::env::entry::Entry)
     /// (the canonical resolved env var) to the process environment used by `exec`.
+    ///
+    /// Every `PATH` directory a composed entry contributes is additionally
+    /// recorded in the private `package_path`, so [`Self::resolve_test_command`]
+    /// can tell a directory the package under test shipped from one the host
+    /// happened to have. Folding it in with the same
+    /// [`move_to_front`](crate::utility::path::move_to_front) used for the real
+    /// `PATH` keeps the two orders identical by construction.
     pub fn apply_entries(&mut self, entries: &[crate::package::metadata::env::entry::Entry]) {
         use crate::package::metadata::env::modifier::ModifierKind;
+        let path_key = EnvKey::new("PATH");
         for entry in entries {
             match entry.kind {
-                ModifierKind::Path => self.add_path(&entry.key, &entry.value),
+                ModifierKind::Path => {
+                    self.add_path(&entry.key, &entry.value);
+                    // Key equality under `EnvKey` (case-insensitive on Windows)
+                    // is what excludes the other path-shaped variables —
+                    // LD_LIBRARY_PATH, PKG_CONFIG_PATH, MANPATH — which
+                    // contribute no executables.
+                    if EnvKey::new(entry.key.as_str()) == path_key {
+                        self.package_path =
+                            utility::path::move_to_front(&self.package_path, OsStr::new(entry.value.as_str()));
+                    }
+                }
                 ModifierKind::Constant => self.set(&entry.key, &entry.value),
             }
         }
@@ -536,38 +568,13 @@ impl Env {
     /// method vs. delegating to `which_in` which reads `std::env::var_os`.
     #[cfg(windows)]
     fn resolve_command_windows(&self, command: &OsStr, cwd: &std::path::Path) -> Option<PathBuf> {
-        // Parse PATHEXT from our child env. Fall back to a sensible Windows
-        // default when absent so bare `foo` can still resolve `foo.exe`.
-        let pathext_str = self
-            .get("PATHEXT")
-            .and_then(|v| v.to_str())
-            .unwrap_or(".COM;.EXE;.BAT;.CMD")
-            .to_string();
-
-        let mut extensions: Vec<&str> = pathext_str
-            .split(';')
-            .map(|s| s.trim())
-            .filter(|s| !s.is_empty())
-            .collect();
-
-        // The OCX launcher shim is always `<name>.exe` post-`.cmd` cutover
-        // (adr_windows_exe_shim.md). A hardened or customized child PATHEXT may
-        // omit `.EXE` entirely (e.g. `PATHEXT=.BAT;.CMD`); the cutover removed
-        // the PATHEXT inject/warn safety net on the premise that `.EXE` is
-        // unconditionally resolvable, so guarantee it is probed here regardless
-        // of the child PATHEXT. Probe order still respects the user's listed
-        // extensions; `.exe` is appended only when absent (case-insensitive).
-        if !extensions.iter().any(|ext| ext.eq_ignore_ascii_case(".EXE")) {
-            extensions.push(".EXE");
-        }
-
         // For each extension, ask `which_in` if `command + ext` is found.
         // `which_in` on a name-with-extension will not try to append further
         // extensions — it just probes the PATH directories for that exact name.
         let path = self.get("PATH");
-        for ext in &extensions {
+        for ext in self.pathext() {
             let mut candidate = command.to_os_string();
-            candidate.push(ext);
+            candidate.push(&ext);
             if let Ok(found) = which::which_in(&candidate, path, cwd) {
                 return Some(found);
             }
@@ -577,6 +584,213 @@ impl Env {
         // that already carry an extension like `foo.exe`).
         which::which_in(command, path, cwd).ok()
     }
+
+    /// Windows-only: the executable extensions to probe, in order.
+    ///
+    /// Read from *this* env's PATHEXT, falling back to the Windows default when
+    /// absent so a bare `foo` can still resolve `foo.exe`.
+    ///
+    /// The OCX launcher shim is always `<name>.exe` post-`.cmd` cutover
+    /// (adr_windows_exe_shim.md). A hardened or customized child PATHEXT may
+    /// omit `.EXE` entirely (e.g. `PATHEXT=.BAT;.CMD`); the cutover removed the
+    /// PATHEXT inject/warn safety net on the premise that `.EXE` is
+    /// unconditionally resolvable, so it is guaranteed to be probed regardless
+    /// of the child PATHEXT. Probe order still respects the user's listed
+    /// extensions; `.EXE` is appended only when absent (case-insensitive).
+    #[cfg(windows)]
+    fn pathext(&self) -> Vec<String> {
+        let pathext_str = self
+            .get("PATHEXT")
+            .and_then(|v| v.to_str())
+            .unwrap_or(".COM;.EXE;.BAT;.CMD")
+            .to_string();
+
+        let mut extensions: Vec<String> = pathext_str
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+
+        if !extensions.iter().any(|ext| ext.eq_ignore_ascii_case(".EXE")) {
+            extensions.push(".EXE".to_string());
+        }
+        extensions
+    }
+
+    /// Resolve a command for `ocx * test` / launcher re-entry: never silently
+    /// skip a same-named file the package under test ships.
+    ///
+    /// [`Self::resolve_command`] answers "what would the OS run", which walks
+    /// the composed package directories straight on into the ambient PATH and
+    /// skips a non-executable file without a word. For a test command that is
+    /// the wrong question: a package shipping `tool` with the executable bit
+    /// missing would silently be tested against the *host's* `tool`, and pass.
+    ///
+    /// So the package's own copy is decided first, and only a name the package
+    /// does not ship at all is looked up on the host PATH:
+    ///
+    /// 1. Scan the package-contributed PATH directories, in PATH order; the
+    ///    first executable match wins.
+    /// 2. A match that is present but not executable is a hard error — never a
+    ///    fall-through to a host copy.
+    /// 3. A name the package does not ship resolves through
+    ///    [`Self::resolve_command`], with a warning naming the directories that
+    ///    were searched — unless the host lookup came up empty too, where
+    ///    [`Self::resolve_command`] has already warned about the same name.
+    ///
+    /// A path-bearing `command` (`./tool`, an absolute path, a Windows
+    /// drive-relative `C:tool`) names a file directly, so there is no
+    /// package-versus-host question to answer and it delegates unchanged.
+    ///
+    /// On Windows a candidate is reached only by matching a PATHEXT extension,
+    /// which *is* the platform's definition of executable — there is no exec
+    /// bit to fail, so [`CommandResolutionError::NotExecutable`] cannot occur.
+    ///
+    /// Synchronous, like [`Self::resolve_command`] (whose `which_in` stats the
+    /// same directories): a handful of local `stat` calls, once per invocation,
+    /// immediately before the process execs a child and stops doing anything
+    /// else. Not worth an async seam the sibling resolver does not have.
+    ///
+    /// # Errors
+    ///
+    /// [`CommandResolutionError::NotExecutable`] when the package under test
+    /// ships the name but the file cannot be executed.
+    pub fn resolve_test_command(&self, command: impl AsRef<OsStr>) -> Result<PathBuf, CommandResolutionError> {
+        let command = command.as_ref();
+        if command_is_path(command) {
+            return Ok(self.resolve_command(command));
+        }
+
+        // The bare name comes last, and only for a command that already
+        // carries a PATHEXT extension (`-- tool.exe`): without it the package
+        // scan misses a file the package plainly ships. An extensionless bare
+        // name is deliberately NOT a candidate — Windows cannot exec it, and
+        // `resolve_command_windows` would never return one either, so matching
+        // it here would trade a working host fallback for a doomed exec.
+        #[cfg(windows)]
+        let candidates: Vec<OsString> = {
+            let pathext = self.pathext();
+            let command_has_pathext_extension = std::path::Path::new(command)
+                .extension()
+                .and_then(std::ffi::OsStr::to_str)
+                .is_some_and(|extension| {
+                    pathext
+                        .iter()
+                        .any(|known| known.trim_start_matches('.').eq_ignore_ascii_case(extension))
+                });
+            pathext
+                .iter()
+                .map(|ext| {
+                    let mut candidate = command.to_os_string();
+                    candidate.push(ext);
+                    candidate
+                })
+                .chain(command_has_pathext_extension.then(|| command.to_os_string()))
+                .collect()
+        };
+        #[cfg(not(windows))]
+        let candidates: Vec<OsString> = vec![command.to_os_string()];
+
+        // The first present-but-not-executable hit, remembered across the whole
+        // scan so an executable match in a later directory still wins.
+        let mut blocked: Option<(PathBuf, u32)> = None;
+
+        for dir in std::env::split_paths(&self.package_path) {
+            if dir.as_os_str().is_empty() {
+                continue;
+            }
+            for name in &candidates {
+                let path = dir.join(name);
+                // `metadata` follows symlinks: a relative link inside the
+                // package to a real binary resolves, a dangling one is simply
+                // not a candidate.
+                let Ok(metadata) = std::fs::metadata(&path) else {
+                    continue;
+                };
+                if !metadata.is_file() {
+                    continue;
+                }
+                match executable_verdict(&metadata) {
+                    Ok(()) => return Ok(path),
+                    Err(mode) => blocked.get_or_insert((path, mode)),
+                };
+            }
+        }
+
+        if let Some((path, mode)) = blocked {
+            return Err(CommandResolutionError::NotExecutable {
+                command: command.to_string_lossy().into_owned(),
+                path,
+                mode,
+            });
+        }
+
+        // ponytail: warn, not error — strict upgrade = swap this arm for
+        // Err(OutsidePackage) when the owner flips decision #1 on #268.
+        let found = self.resolve_command(command);
+        // Only when the host lookup actually found something. `resolve_command`
+        // already warned on its way to returning the bare name unchanged, and a
+        // second line there would claim a resolution that did not happen.
+        // Directories go through `{:?}`, which quotes and escapes them: a value
+        // reaching here can carry a newline, and a raw one forges log lines
+        // (CWE-117).
+        if found.as_path() != std::path::Path::new(command) {
+            // `split_paths("")` yields one empty PathBuf; the scan skips those,
+            // so the message must too or a PATH-less package prints `[""]`.
+            let searched: Vec<PathBuf> = std::env::split_paths(&self.package_path)
+                .filter(|dir| !dir.as_os_str().is_empty())
+                .collect();
+            log::warn!(
+                "'{}' is not shipped by the composed packages; resolved to '{}' on the host PATH — expected it under one of: {:?}",
+                command.to_string_lossy(),
+                found.display(),
+                searched
+            );
+        }
+        Ok(found)
+    }
+}
+
+/// True when `command` names a file directly rather than a bare name to look
+/// up on PATH.
+///
+/// A bare name is *exactly one* [`Component::Normal`](std::path::Component) —
+/// anything else is path-bearing. The scan joins the name onto each package
+/// directory, and `Path::join` with a value carrying its own root or prefix
+/// discards the base, so a looser test lets the join stat outside every
+/// package directory and report the result as a copy the package ships. A
+/// separator test misses the Windows drive-relative form (`C:tool` has no
+/// separator, yet `join` keeps only the drive).
+fn command_is_path(command: &OsStr) -> bool {
+    let mut components = std::path::Path::new(command).components();
+    !matches!(
+        (components.next(), components.next()),
+        (Some(std::path::Component::Normal(_)), None)
+    )
+}
+
+/// `Ok(())` when the candidate can be executed, `Err(mode)` carrying its
+/// permission bits when it cannot.
+///
+/// Mirrors the three-bit POSIX test in
+/// [`crate::package::bin_scan`]'s `unix_is_executable`.
+// ponytail: duplicated 3-line POSIX bit test; sharing would invert env→package layering
+#[cfg(unix)]
+fn executable_verdict(metadata: &std::fs::Metadata) -> Result<(), u32> {
+    use std::os::unix::fs::PermissionsExt;
+    // The caller already filtered to `is_file()`, so this checks the bit only —
+    // a directory's `x` (traversable) can never reach here.
+    let mode = metadata.permissions().mode();
+    if mode & 0o111 != 0 { Ok(()) } else { Err(mode & 0o7777) }
+}
+
+/// Non-Unix hosts have no exec bit: a candidate is reached only by matching a
+/// PATHEXT extension, which is the platform's own executability rule, so every
+/// candidate that exists is executable.
+#[cfg(not(unix))]
+fn executable_verdict(_metadata: &std::fs::Metadata) -> Result<(), u32> {
+    Ok(())
 }
 
 impl IntoIterator for Env {
@@ -698,6 +912,39 @@ pub fn is_valid_env_key(key: &str) -> bool {
 pub fn is_reserved_ocx_key(key: &str) -> bool {
     let upper = key.to_ascii_uppercase();
     upper.starts_with("OCX_") || upper.starts_with("__OCX_")
+}
+
+/// Failure modes of [`Env::resolve_test_command`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum CommandResolutionError {
+    /// The package under test ships this name, but the file cannot be exec'd.
+    ///
+    /// Deliberately terminal: falling through to a same-named host binary
+    /// would run the test against something the package does not contain and
+    /// report a pass.
+    #[error(
+        "'{command}' is present in the package under test at '{}' but is not executable (mode {mode:04o}); \
+         re-create the package with the executable bit set - ocx does not fall through to a host copy on PATH",
+        path.display()
+    )]
+    NotExecutable {
+        /// The bare command name as invoked.
+        command: String,
+        /// Absolute path of the non-executable file inside the package.
+        path: PathBuf,
+        /// POSIX permission bits, masked to `0o7777`.
+        mode: u32,
+    },
+}
+
+impl crate::cli::ClassifyExitCode for CommandResolutionError {
+    fn classify(&self) -> Option<crate::cli::ExitCode> {
+        // Parity with `BinScanError::DeclaredNotExecutable`: the package's own
+        // content contradicts what it claims to ship — malformed input data,
+        // not a usage error and not a config fault.
+        Some(crate::cli::ExitCode::DataError)
+    }
 }
 
 /// Failure modes of decoding the forwarded [`keys::OCX_ENV`] payload.
@@ -2138,6 +2385,306 @@ mod tests {
             env.get(keys::OCX_PATCH_SNAPSHOT).is_none(),
             "patch_snapshot=None must remove any stale OCX_PATCH_SNAPSHOT from the child env"
         );
+    }
+
+    // ── `resolve_test_command` — the #268 shadow rule ──────────────────────
+
+    /// Builds a `PATH`-kind entry for `dir`, as the composer would.
+    fn path_entry(key: &str, dir: &std::path::Path) -> crate::package::metadata::env::entry::Entry {
+        crate::package::metadata::env::entry::Entry {
+            key: key.to_string(),
+            value: dir.to_str().unwrap().to_string(),
+            kind: crate::package::metadata::env::modifier::ModifierKind::Path,
+        }
+    }
+
+    /// Writes `name` into `dir` with the given mode, returning its path.
+    #[cfg(unix)]
+    fn write_binary(dir: &std::path::Path, name: &str, mode: u32) -> PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let path = dir.join(name);
+        std::fs::write(&path, b"#!/bin/sh\ntrue\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).unwrap();
+        path
+    }
+
+    /// macOS puts `TempDir` under the `/tmp` -> `/private/tmp` symlink, so a
+    /// raw tempdir path never equals a resolved one. Compare canonical forms.
+    fn same_file(left: &std::path::Path, right: &std::path::Path) -> bool {
+        match (dunce::canonicalize(left), dunce::canonicalize(right)) {
+            (Ok(l), Ok(r)) => l == r,
+            _ => left == right,
+        }
+    }
+
+    /// The #268 regression: a package that ships `tool` without the executable
+    /// bit must fail loudly, never fall through to the host's copy.
+    ///
+    /// The composition mirrors the real one — the package entry prepends onto
+    /// an inherited PATH — so `resolve_command`'s answer here is exactly what
+    /// `ocx package test` used to execute.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_test_command_errors_when_package_copy_not_executable() {
+        let package_dir = tempfile::tempdir().unwrap();
+        let ambient_dir = tempfile::tempdir().unwrap();
+        let shipped = write_binary(package_dir.path(), "tool", 0o644);
+        let decoy = write_binary(ambient_dir.path(), "tool", 0o755);
+
+        let mut env = Env::clean();
+        env.set("PATH", ambient_dir.path());
+        env.apply_entries(&[path_entry("PATH", package_dir.path())]);
+
+        // Anchor: the old resolver silently picked the host copy. If this ever
+        // stops holding, the test below no longer discriminates.
+        assert!(
+            same_file(&env.resolve_command("tool"), &decoy),
+            "precondition: resolve_command must still return the host decoy"
+        );
+
+        let error = env
+            .resolve_test_command("tool")
+            .expect_err("a non-executable package copy must not fall through to the host");
+        let message = error.to_string();
+        assert!(
+            message.contains(shipped.to_str().unwrap()),
+            "error must name the package path, got: {message}"
+        );
+        assert!(message.contains("0644"), "error must name the mode, got: {message}");
+        assert_eq!(
+            crate::cli::ClassifyExitCode::classify(&error),
+            Some(crate::cli::ExitCode::DataError)
+        );
+    }
+
+    /// Happy path is unchanged: an executable the package ships wins, and the
+    /// answer is the one `resolve_command` already gave.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_test_command_prefers_package_dir_over_ambient() {
+        let package_dir = tempfile::tempdir().unwrap();
+        let ambient_dir = tempfile::tempdir().unwrap();
+        let shipped = write_binary(package_dir.path(), "tool", 0o755);
+        write_binary(ambient_dir.path(), "tool", 0o755);
+
+        let mut env = Env::clean();
+        env.set("PATH", ambient_dir.path());
+        env.apply_entries(&[path_entry("PATH", package_dir.path())]);
+
+        let resolved = env.resolve_test_command("tool").unwrap();
+        assert!(
+            same_file(&resolved, &shipped),
+            "package copy must win; got {}",
+            resolved.display()
+        );
+        assert!(same_file(&resolved, &env.resolve_command("tool")));
+    }
+
+    /// A name the package does not ship still resolves on the host PATH — the
+    /// `sh` / `grep` case every test script relies on.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_test_command_falls_back_when_package_ships_nothing() {
+        let package_dir = tempfile::tempdir().unwrap();
+        let ambient_dir = tempfile::tempdir().unwrap();
+        write_binary(package_dir.path(), "other", 0o755);
+        let host_tool = write_binary(ambient_dir.path(), "tool", 0o755);
+
+        let mut env = Env::clean();
+        env.set("PATH", ambient_dir.path());
+        env.apply_entries(&[path_entry("PATH", package_dir.path())]);
+
+        let resolved = env.resolve_test_command("tool").unwrap();
+        assert!(
+            same_file(&resolved, &host_tool),
+            "an unshipped name must resolve on the host PATH; got {}",
+            resolved.display()
+        );
+    }
+
+    /// A dependency's `bin/` is a package directory too — the scan covers every
+    /// composed PATH entry, not just the root package's.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_test_command_searches_dependency_dirs() {
+        let root_dir = tempfile::tempdir().unwrap();
+        let dependency_dir = tempfile::tempdir().unwrap();
+        let shipped = write_binary(dependency_dir.path(), "tool", 0o755);
+
+        let mut env = Env::clean();
+        env.apply_entries(&[
+            path_entry("PATH", dependency_dir.path()),
+            path_entry("PATH", root_dir.path()),
+        ]);
+
+        let resolved = env.resolve_test_command("tool").unwrap();
+        assert!(
+            same_file(&resolved, &shipped),
+            "a dependency's bin dir must be searched; got {}",
+            resolved.display()
+        );
+    }
+
+    /// A blocked hit does not veto an executable copy a *later* package
+    /// directory ships. The scan remembers the block and keeps going; the
+    /// error is only reported when the whole scan turned up nothing runnable.
+    ///
+    /// This is the case that makes `blocked` a remembered `Option` rather than
+    /// an early return — a dependency shipping a stray 0644 `tool` must not
+    /// fail a package that ships a working one.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_test_command_later_executable_beats_an_earlier_blocked_copy() {
+        let first_dir = tempfile::tempdir().unwrap();
+        let second_dir = tempfile::tempdir().unwrap();
+        write_binary(first_dir.path(), "tool", 0o644);
+        let executable = write_binary(second_dir.path(), "tool", 0o755);
+
+        let mut env = Env::clean();
+        // `apply_entries` prepends each PATH value, so applying second then
+        // first leaves `first_dir` ahead of `second_dir` in the scan order.
+        env.apply_entries(&[
+            path_entry("PATH", second_dir.path()),
+            path_entry("PATH", first_dir.path()),
+        ]);
+
+        let resolved = env
+            .resolve_test_command("tool")
+            .expect("an executable copy in a later dir must win over an earlier blocked one");
+        assert!(
+            same_file(&resolved, &executable),
+            "expected the executable copy in the second dir; got {}",
+            resolved.display()
+        );
+    }
+
+    /// Two executable copies: scan order decides, and scan order is PATH
+    /// order — the same answer `resolve_command` gives.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_test_command_first_executable_in_path_order_wins() {
+        let first_dir = tempfile::tempdir().unwrap();
+        let second_dir = tempfile::tempdir().unwrap();
+        let first = write_binary(first_dir.path(), "tool", 0o755);
+        write_binary(second_dir.path(), "tool", 0o755);
+
+        let mut env = Env::clean();
+        env.apply_entries(&[
+            path_entry("PATH", second_dir.path()),
+            path_entry("PATH", first_dir.path()),
+        ]);
+
+        let resolved = env.resolve_test_command("tool").unwrap();
+        assert!(
+            same_file(&resolved, &first),
+            "the first package dir in PATH order must win; got {}",
+            resolved.display()
+        );
+        assert!(
+            same_file(&resolved, &env.resolve_command("tool")),
+            "package-scan order must agree with what the OS would run"
+        );
+    }
+
+    /// Only `PATH` contributes executables. A `LD_LIBRARY_PATH` entry pointing
+    /// at a directory that happens to hold a same-named non-executable file
+    /// must not turn a legitimate host lookup into an error.
+    #[cfg(unix)]
+    #[test]
+    fn apply_entries_records_only_path_dirs() {
+        let library_dir = tempfile::tempdir().unwrap();
+        let ambient_dir = tempfile::tempdir().unwrap();
+        write_binary(library_dir.path(), "tool", 0o644);
+        let host_tool = write_binary(ambient_dir.path(), "tool", 0o755);
+
+        let mut env = Env::clean();
+        env.set("PATH", ambient_dir.path());
+        env.apply_entries(&[path_entry("LD_LIBRARY_PATH", library_dir.path())]);
+
+        let resolved = env
+            .resolve_test_command("tool")
+            .expect("a LD_LIBRARY_PATH dir contributes no executables");
+        assert!(same_file(&resolved, &host_tool));
+    }
+
+    /// A path-bearing name addresses a file directly — no package-versus-host
+    /// question — so it must behave exactly as `resolve_command` does.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_test_command_delegates_path_bearing_names() {
+        let package_dir = tempfile::tempdir().unwrap();
+        let shipped = write_binary(package_dir.path(), "tool", 0o644);
+
+        let mut env = Env::clean();
+        env.apply_entries(&[path_entry("PATH", package_dir.path())]);
+
+        for name in [shipped.to_str().unwrap(), "./tool", "..", "a/b"] {
+            assert_eq!(
+                env.resolve_test_command(name).unwrap(),
+                env.resolve_command(name),
+                "path-bearing '{name}' must delegate unchanged"
+            );
+        }
+    }
+
+    /// Only a lone bare name may be joined onto a package directory.
+    ///
+    /// The package scan does `dir.join(command)`, and `join` with anything
+    /// carrying its own root or prefix *replaces* the base — so a name that is
+    /// not exactly one normal component would stat outside every package
+    /// directory and be reported as a copy the package ships (CWE-22 class).
+    /// `C:tool` is the Windows form that a separator test cannot see: it has
+    /// no separator at all, yet `join` keeps only the drive.
+    #[test]
+    fn command_is_path_admits_only_a_single_normal_component() {
+        for bare in ["tool", "tool.exe", "tool-1.2"] {
+            assert!(
+                !command_is_path(OsStr::new(bare)),
+                "'{bare}' is a lone bare name and must be package-scanned"
+            );
+        }
+        for bearing in ["..", "a/b", "./tool", "/abs/tool", ""] {
+            assert!(
+                command_is_path(OsStr::new(bearing)),
+                "'{bearing}' must delegate to resolve_command, never be joined onto a package dir"
+            );
+        }
+        #[cfg(windows)]
+        for bearing in ["C:tool", "C:\\tool", "\\\\server\\share\\tool"] {
+            assert!(
+                command_is_path(OsStr::new(bearing)),
+                "'{bearing}' carries a drive/prefix that would replace the package dir on join"
+            );
+        }
+    }
+
+    /// On Windows a package-shipped `<name>.exe` is found through the child
+    /// env's PATHEXT, and a name that already carries the extension resolves
+    /// through the bare-name candidate appended after them.
+    #[cfg(windows)]
+    #[test]
+    fn resolve_test_command_finds_package_exe_via_pathext() {
+        let package_dir = tempfile::tempdir().unwrap();
+        let shipped = package_dir.path().join("tool.exe");
+        std::fs::write(&shipped, b"MZ").unwrap();
+
+        let mut env = Env::clean();
+        env.set("PATHEXT", ".EXE;.CMD");
+        env.apply_entries(&[path_entry("PATH", package_dir.path())]);
+
+        // `tool` matches via the `.EXE` candidate; `tool.exe` only matches
+        // because the bare name is probed too — without it a `-- tool.exe`
+        // invocation would miss the package scan entirely and fall to the host.
+        for invoked in ["tool", "tool.exe"] {
+            let resolved = env
+                .resolve_test_command(invoked)
+                .unwrap_or_else(|e| panic!("'{invoked}' must resolve inside the package: {e}"));
+            assert_eq!(
+                resolved.file_name().unwrap().to_str().unwrap().to_ascii_lowercase(),
+                "tool.exe",
+                "'{invoked}' must resolve to the package's tool.exe"
+            );
+        }
     }
 
     /// `resolve_command` must find a well-known binary that exists on PATH.

--- a/crates/ocx_lib/src/oci/client/builder.rs
+++ b/crates/ocx_lib/src/oci/client/builder.rs
@@ -505,6 +505,7 @@ mod push_wire_tests {
     use super::*;
     use crate::oci::client::error::ClientError;
     use crate::oci::client::transport::{OciTransport as _, no_progress};
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _};
 
@@ -514,6 +515,42 @@ mod push_wire_tests {
         target: String,
         content_range: Option<String>,
         body_len: usize,
+    }
+
+    /// Injected chunk-`PATCH` failures: answer the next `remaining` of them
+    /// with `status` instead of `202`.
+    ///
+    /// The budget is shared across **connections**, not per-connection. A
+    /// restarted upload opens a fresh session and may well arrive on a fresh
+    /// socket, so a per-connection counter would fault every attempt equally —
+    /// the test could then never distinguish "retried and recovered" from
+    /// "never retried", which is the whole thing it exists to show.
+    #[derive(Clone)]
+    struct PatchFaults {
+        status: u16,
+        remaining: Arc<AtomicUsize>,
+    }
+
+    impl PatchFaults {
+        fn none() -> Self {
+            Self::new(0, 0)
+        }
+
+        fn new(status: u16, count: usize) -> Self {
+            Self {
+                status,
+                remaining: Arc::new(AtomicUsize::new(count)),
+            }
+        }
+
+        /// Spends one unit of budget, returning the status to answer with;
+        /// `None` once the budget is exhausted.
+        fn take(&self) -> Option<u16> {
+            self.remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |left| left.checked_sub(1))
+                .ok()
+                .map(|_| self.status)
+        }
     }
 
     /// Minimal HTTP/1.1 stub of an OCI blob-upload session.
@@ -532,6 +569,10 @@ mod push_wire_tests {
         /// `accepted_first_chunk` overrides the byte count reported for the first
         /// `PATCH`, simulating a registry that stored less than it was sent.
         async fn start(accepted_first_chunk: Option<usize>) -> Self {
+            Self::start_with(accepted_first_chunk, PatchFaults::none()).await
+        }
+
+        async fn start_with(accepted_first_chunk: Option<usize>, faults: PatchFaults) -> Self {
             let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
             let address = listener.local_addr().unwrap().to_string();
             let recorded = Arc::new(Mutex::new(Vec::new()));
@@ -540,8 +581,9 @@ mod push_wire_tests {
             tokio::spawn(async move {
                 while let Ok((socket, _)) = listener.accept().await {
                     let log = Arc::clone(&log);
+                    let faults = faults.clone();
                     tokio::spawn(async move {
-                        serve_connection(socket, log, accepted_first_chunk).await;
+                        serve_connection(socket, log, accepted_first_chunk, faults).await;
                     });
                 }
             });
@@ -553,12 +595,20 @@ mod push_wire_tests {
             self.recorded.lock().unwrap().clone()
         }
 
+        fn method(&self, method: &str) -> Vec<RecordedRequest> {
+            self.recorded().into_iter().filter(|r| r.method == method).collect()
+        }
+
+        fn posts(&self) -> Vec<RecordedRequest> {
+            self.method("POST")
+        }
+
         fn patches(&self) -> Vec<RecordedRequest> {
-            self.recorded().into_iter().filter(|r| r.method == "PATCH").collect()
+            self.method("PATCH")
         }
 
         fn puts(&self) -> Vec<RecordedRequest> {
-            self.recorded().into_iter().filter(|r| r.method == "PUT").collect()
+            self.method("PUT")
         }
     }
 
@@ -566,6 +616,7 @@ mod push_wire_tests {
         socket: tokio::net::TcpStream,
         recorded: Arc<Mutex<Vec<RecordedRequest>>>,
         accepted_first_chunk: Option<usize>,
+        faults: PatchFaults,
     ) {
         let (read_half, mut write_half) = socket.into_split();
         let mut reader = tokio::io::BufReader::new(read_half);
@@ -635,18 +686,23 @@ mod push_wire_tests {
                     "HTTP/1.1 202 Accepted\r\nLocation: /v2/test/blob/blobs/uploads/stub\r\nContent-Length: 0\r\n\r\n"
                         .to_string()
                 }
-                "PATCH" => {
-                    stored += body_len;
-                    patch_count += 1;
-                    let reported = match accepted_first_chunk {
-                        Some(accepted) if patch_count == 1 => accepted,
-                        _ => stored,
-                    };
-                    format!(
-                        "HTTP/1.1 202 Accepted\r\nLocation: /v2/test/blob/blobs/uploads/stub\r\nRange: 0-{}\r\nContent-Length: 0\r\n\r\n",
-                        reported.saturating_sub(1)
-                    )
-                }
+                // A faulted PATCH answers before the accounting: the bytes it
+                // carried were never stored, so `stored` must not advance.
+                "PATCH" => match faults.take() {
+                    Some(status) => format!("HTTP/1.1 {status} Injected Fault\r\nContent-Length: 0\r\n\r\n"),
+                    None => {
+                        stored += body_len;
+                        patch_count += 1;
+                        let reported = match accepted_first_chunk {
+                            Some(accepted) if patch_count == 1 => accepted,
+                            _ => stored,
+                        };
+                        format!(
+                            "HTTP/1.1 202 Accepted\r\nLocation: /v2/test/blob/blobs/uploads/stub\r\nRange: 0-{}\r\nContent-Length: 0\r\n\r\n",
+                            reported.saturating_sub(1)
+                        )
+                    }
+                },
                 "PUT" => format!("HTTP/1.1 201 Created\r\nLocation: {target}\r\nContent-Length: 0\r\n\r\n"),
                 // HEAD (blob_exists) and anything else: not present.
                 _ => "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n".to_string(),
@@ -857,6 +913,116 @@ mod push_wire_tests {
         assert_eq!(
             puts[0].body_len, total,
             "the committing PUT must carry the whole blob — a resuming fallback would commit bytes the registry never stored"
+        );
+    }
+
+    /// A 503 on a chunk `PATCH` must not lose the layer: the push restarts from
+    /// a fresh session and still commits the blob exactly once.
+    ///
+    /// The restart is whole-blob by design — a fresh `POST` abandons whatever
+    /// the failed session stored, which is why the recovery is safe without any
+    /// range reconciliation. The assertions pin that shape rather than just the
+    /// `Ok`: two `POST`s (a *new* session, not a resume on the old one), the two
+    /// surviving `PATCH`es tiling the blob exactly once, and one `PUT`.
+    #[tokio::test]
+    async fn transient_patch_failure_restarts_the_upload_and_commits_once() {
+        let stub = StubRegistry::start_with(None, PatchFaults::new(503, 1)).await;
+        let data: Vec<u8> = (0..PUSH_CHUNK_SIZE + 1024).map(|i| (i % 251) as u8).collect();
+        let total = data.len();
+
+        push_through_production_client(&stub, data)
+            .await
+            .expect("a 503 on one chunk must be retried, not surfaced as a failed push");
+
+        assert_eq!(
+            stub.posts().len(),
+            2,
+            "the retry must open a FRESH upload session, not resume the failed one; saw {:?}",
+            stub.posts()
+        );
+
+        let patches = stub.patches();
+        assert_eq!(
+            patches.len(),
+            3,
+            "one faulted PATCH plus the two of the successful attempt; saw {patches:?}"
+        );
+
+        let mut next_start = 0usize;
+        for patch in &patches[1..] {
+            let range = patch
+                .content_range
+                .as_deref()
+                .expect("every chunk PATCH must carry Content-Range");
+            let (start, end) = range.split_once('-').expect("Content-Range must be `start-end`");
+            let (start, end) = (start.parse::<usize>().unwrap(), end.parse::<usize>().unwrap());
+            assert_eq!(
+                start, next_start,
+                "the retried attempt's chunks must be contiguous, got {range} after {next_start}"
+            );
+            next_start = end + 1;
+        }
+        assert_eq!(
+            next_start, total,
+            "the retried attempt must cover the whole blob exactly once"
+        );
+
+        let puts = stub.puts();
+        assert_eq!(puts.len(), 1, "the blob must be committed exactly once, saw {puts:?}");
+    }
+
+    /// A registry that faults *every* chunk spends the whole budget and then
+    /// surfaces the fault as transient — the exit-75 contract, not a 69.
+    ///
+    /// Two things are pinned that the recovering sibling above cannot show:
+    /// the budget is bounded (exactly three `POST`s — one initial attempt plus
+    /// `PUSH_RETRY_ATTEMPTS` restarts, so a raised constant reds this), and
+    /// exhausting it does not downgrade the error. A caller that reruns on 75
+    /// is exactly right here: the registry never answered usefully.
+    #[tokio::test]
+    async fn exhausted_transient_retries_surface_as_transient() {
+        let stub = StubRegistry::start_with(None, PatchFaults::new(503, usize::MAX)).await;
+        let data: Vec<u8> = (0..1024).map(|i| (i % 251) as u8).collect();
+
+        let error = push_through_production_client(&stub, data)
+            .await
+            .expect_err("a registry that faults every chunk must not yield a successful push");
+
+        assert_eq!(
+            stub.posts().len(),
+            3,
+            "the budget is one initial attempt plus PUSH_RETRY_ATTEMPTS restarts; saw {:?}",
+            stub.posts()
+        );
+        assert!(
+            matches!(error, ClientError::RegistryTransient(_)),
+            "an exhausted transient retry must stay transient (exit 75), got {error:?}"
+        );
+    }
+
+    /// A 401 is not transient, so it must be surfaced on the first attempt.
+    ///
+    /// One `POST` is the discriminator: a retry-everything loop would open
+    /// three sessions before giving up, spending two extra round trips and two
+    /// backoff waits on an answer that will not change.
+    #[tokio::test]
+    async fn permanent_patch_failure_is_not_retried() {
+        let stub = StubRegistry::start_with(None, PatchFaults::new(401, usize::MAX)).await;
+        let data: Vec<u8> = (0..1024).map(|i| (i % 251) as u8).collect();
+
+        let error = push_through_production_client(&stub, data)
+            .await
+            .expect_err("a registry that rejects every chunk must not yield a successful push");
+
+        assert_eq!(
+            stub.posts().len(),
+            1,
+            "a credentials rejection must not be retried; saw {:?}",
+            stub.posts()
+        );
+        assert!(
+            matches!(error, ClientError::Authentication(_)),
+            "a 401 on a chunk PATCH must surface as Authentication (80), got {error:?}"
         );
     }
 }

--- a/crates/ocx_lib/src/oci/client/builder.rs
+++ b/crates/ocx_lib/src/oci/client/builder.rs
@@ -855,6 +855,7 @@ mod push_wire_tests {
 #[cfg(test)]
 mod read_timeout_tests {
     use super::*;
+    use crate::oci::client::error::ClientError;
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt as _, AsyncWriteExt as _};
 
@@ -979,6 +980,38 @@ mod read_timeout_tests {
         assert!(
             timed_out,
             "the stall must surface as a timeout somewhere in the source chain, got {error:?}"
+        );
+    }
+
+    /// The timeout must not only fire, it must land in the retryable bucket:
+    /// a registry that went quiet exits 75, not 69.
+    ///
+    /// This is the only way to exercise `registry_error`'s `is_timeout()` arm —
+    /// `reqwest::Error` has no public constructor, so a real stalled socket is
+    /// the sole source of one. `pull_blob` is the seam because it buffers the
+    /// body through the fork, which converts the stalled read into
+    /// `OciDistributionError::RequestError` before ocx maps it.
+    #[tokio::test]
+    async fn stalled_registry_read_timeout_classifies_as_transient() {
+        let address = start_stalling_registry().await;
+
+        let mut config = ClientBuilder::new().plain_http_registries(vec![address.clone()]).config;
+        config.read_timeout = Some(Duration::from_secs(2));
+        let transport = NativeTransport::new(oci::native::Client::new(config), auth::Auth::default());
+        let image: oci::native::Reference = format!("{address}/test/blob:latest").parse().unwrap();
+        let digest = crate::oci::Digest::Sha256("a".repeat(64));
+
+        let outcome = tokio::time::timeout(
+            Duration::from_secs(10),
+            crate::oci::client::transport::OciTransport::pull_blob(&transport, &image, &digest),
+        )
+        .await
+        .expect("a read timeout must end the stalled pull — timing out here means the client hung");
+
+        let error = outcome.expect_err("a body that never completes must not read as a successful pull");
+        assert!(
+            matches!(error, ClientError::RegistryTransient(_)),
+            "a stalled registry must classify as RegistryTransient (TempFail/75), got {error:?}"
         );
     }
 }

--- a/crates/ocx_lib/src/oci/client/builder.rs
+++ b/crates/ocx_lib/src/oci/client/builder.rs
@@ -70,6 +70,22 @@ pub(crate) const PUSH_CHUNK_SIZE: usize = MAX_UPLOAD_REQUEST_BYTES - 1024 * 1024
 /// correct taxonomy for a transport that went quiet.
 pub(crate) const REGISTRY_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 
+/// Bound on the connect phase of every registry request, mapped to
+/// [`reqwest::ClientBuilder::connect_timeout`].
+///
+/// The fork defaults this to `None`, which is unbounded: a host that accepts
+/// nothing and refuses nothing — a black-holing firewall, a load balancer with
+/// no backend — leaves the socket in SYN_SENT until the OS gives up, which on
+/// Linux is over two minutes and on some tunings far longer.
+/// [`REGISTRY_READ_TIMEOUT`] does not cover this, because a connect that never
+/// completes never dispatches a request for reqwest to time.
+///
+/// 30 s matches `INDEX_CONNECT_TIMEOUT` in `oci/index/ocx_index.rs`, the
+/// sibling bound on the index-document fetch: both are the connect phase
+/// against a registry-class endpoint, and one number is easier to reason about
+/// than two.
+pub(crate) const REGISTRY_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 pub struct ClientBuilder {
     auth: auth::Auth,
     config: oci::native::ClientConfig,
@@ -85,6 +101,7 @@ impl ClientBuilder {
             config: oci::native::ClientConfig {
                 push_chunk_size: PUSH_CHUNK_SIZE,
                 read_timeout: Some(REGISTRY_READ_TIMEOUT),
+                connect_timeout: Some(REGISTRY_CONNECT_TIMEOUT),
                 // CA roots are seeded by the fork's `ClientConfig::default()`
                 // (self-contained on hosts with no system trust store), inherited
                 // here via `..Default::default()`. Single source of truth: the fork.
@@ -943,6 +960,18 @@ mod read_timeout_tests {
             ClientBuilder::new().config.read_timeout,
             Some(REGISTRY_READ_TIMEOUT),
             "ClientBuilder::new() must set read_timeout — inheriting the fork's None means a stalled registry hangs the pull forever"
+        );
+    }
+
+    /// The connect phase needs its own bound: a host that neither accepts nor
+    /// refuses the SYN never dispatches a request, so the read timeout — which
+    /// reqwest arms at dispatch — never gets a chance to fire.
+    #[test]
+    fn production_client_config_carries_the_registry_connect_timeout() {
+        assert_eq!(
+            ClientBuilder::new().config.connect_timeout,
+            Some(REGISTRY_CONNECT_TIMEOUT),
+            "ClientBuilder::new() must set connect_timeout — inheriting the fork's None means a black-holed connect hangs until the OS gives up"
         );
     }
 

--- a/crates/ocx_lib/src/oci/client/error.rs
+++ b/crates/ocx_lib/src/oci/client/error.rs
@@ -86,6 +86,16 @@ pub enum ClientError {
     /// A registry operation failed.
     #[error("registry operation failed: {0}")]
     Registry(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// A registry operation failed for a reason that may not repeat: the
+    /// connect never completed, a request timed out, or the registry answered
+    /// 429 / 502 / 503 / 504.
+    ///
+    /// Split from [`ClientError::Registry`] because the two demand opposite
+    /// reactions from a caller: this one says "run the same command again",
+    /// [`ClientError::Registry`] says "the registry answered, and it will
+    /// answer the same way next time".
+    #[error("transient registry failure: {0}")]
+    RegistryTransient(#[source] Box<dyn std::error::Error + Send + Sync>),
     /// File I/O error with path context.
     #[error("I/O error for '{}': {source}", path.display())]
     Io {
@@ -194,10 +204,12 @@ impl ClassifyExitCode for ClientError {
             Self::Authentication(_) => ExitCode::AuthError,
             Self::ManifestNotFound(_) | Self::BlobNotFound(_) | Self::RepositoryNotFound(_) => ExitCode::NotFound,
             Self::Io { .. } => ExitCode::IoError,
-            // TODO: inspect inner source to refine (HTTP 429/503 → TempFail,
-            // 401/403 → AuthError, timeout → TempFail). For v1, treat every
-            // registry operation failure as Unavailable.
+            // The 75-vs-69 contract: 75 means the same command may succeed if
+            // it is run again, 69 means it will not. `Registry` is the second
+            // case — the registry answered, just not usefully — so a wrapper
+            // that retries on 75 leaves it alone.
             Self::Registry(_) => ExitCode::Unavailable,
+            Self::RegistryTransient(_) => ExitCode::TempFail,
             // An incomplete delivery is a transfer fault, not malformed data:
             // the same pull usually succeeds on retry, so it is TempFail rather
             // than DataError.

--- a/crates/ocx_lib/src/oci/client/native_transport.rs
+++ b/crates/ocx_lib/src/oci/client/native_transport.rs
@@ -53,65 +53,104 @@ impl NativeTransport {
         self.client
             .auth(image, &auth, operation)
             .await
-            .map_err(auth_or_availability_error)?;
+            .map_err(registry_error)?;
         Ok(())
     }
 }
 
-/// Classifies a failed auth ping. Only a registry that actually answered with a
-/// 401/403 (surfaced by `oci_client` as `AuthenticationFailure` /
-/// `UnauthorizedError`) is a genuine credentials failure
-/// ([`ClientError::Authentication`] → exit 80). Everything else is an
-/// availability problem ([`ClientError::Registry`] → exit 69):
-/// - connect / timeout (`RequestError`) — never reached the registry;
-/// - token-endpoint 5xx / 429 (`ServerError`, tagged in the patched
-///   `oci_client` `authenticate`) — the registry is unhealthy or rate-limiting;
-/// - an unparseable token body (`RegistryTokenDecodeError`).
-fn auth_or_availability_error(e: oci_client::errors::OciDistributionError) -> ClientError {
-    use oci_client::errors::OciDistributionError::{RegistryTokenDecodeError, RequestError, ServerError};
-    match &e {
-        RequestError(request) if request.is_connect() || request.is_timeout() => ClientError::Registry(Box::new(e)),
-        ServerError { .. } | RegistryTokenDecodeError(_) => ClientError::Registry(Box::new(e)),
-        _ => ClientError::Authentication(Box::new(e)),
-    }
-}
-
-fn registry_error(e: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> ClientError {
-    ClientError::Registry(e.into())
-}
-
-/// Maps OCI distribution errors to [`ClientError::ManifestNotFound`] when the
-/// registry indicates the manifest does not exist (404 / MANIFEST_UNKNOWN),
-/// and falls back to [`ClientError::Registry`] for everything else.
-fn manifest_not_found_or_registry_error(
-    e: oci_client::errors::OciDistributionError,
-    image: &oci::native::Reference,
-) -> ClientError {
-    use oci_client::errors::OciDistributionError::*;
+/// Classifies any failed registry operation onto the [`ClientError`] taxonomy.
+///
+/// Three buckets, and the split that matters is the last two:
+/// [`ClientError::RegistryTransient`] (exit 75) promises the same command may
+/// succeed if it is run again, [`ClientError::Registry`] (exit 69) promises it
+/// will not, and [`ClientError::Authentication`] (exit 80) says the credentials
+/// are the problem. A connect that never completed and a request that timed out
+/// belong in the first: nothing about the request was ever answered, least of
+/// all the credentials.
+///
+/// # Two shapes carry the same status code
+///
+/// A 429 or a 403 reaches this function as *either* an enveloped
+/// `RegistryError` or a bare `ServerError`, depending on which fork code path
+/// produced it. `validate_registry_response` parses the OCI error envelope out
+/// of any 4xx body, but the push path's `extract_location_header` turns every
+/// non-`202` answer into a `ServerError` without ever looking at the body — so
+/// a 401 rejecting a chunk `PATCH` arrives as `ServerError { code: 401 }`.
+/// Both shapes must be classified or half the wire surface falls to the
+/// catch-all.
+///
+/// # Why auth is checked before rate limiting on an envelope
+///
+/// An envelope may carry several codes. Auth wins because the costs are
+/// asymmetric under retry: retrying a denial spends the budget and can trip an
+/// account lockout, while reading a rate limit as an auth failure only misnames
+/// a wait the caller was going to take anyway.
+///
+/// # Why only 429 / 502 / 503 / 504 are transient
+///
+/// The set is deliberately issue-scoped, not "every 5xx". A 500 is a server
+/// bug — a rerun hits the same bug, so it stays 69. A 408 is rare from a
+/// registry, and the case it would cover is already transient by another
+/// route: reqwest surfaces a client-side timeout as `RequestError`, matched
+/// above.
+fn registry_error(e: oci_client::errors::OciDistributionError) -> ClientError {
+    use oci_client::errors::OciDistributionError::{
+        AuthenticationFailure, RegistryError, RequestError, ServerError, UnauthorizedError,
+    };
     use oci_client::errors::OciErrorCode;
     match &e {
-        ImageManifestNotFoundError(_) => ClientError::ManifestNotFound(image.to_string()),
+        RequestError(request) if request.is_timeout() || request.is_connect() => {
+            ClientError::RegistryTransient(Box::new(e))
+        }
+        AuthenticationFailure(_) | UnauthorizedError { .. } => ClientError::Authentication(Box::new(e)),
+        ServerError { code: 401 | 403, .. } => ClientError::Authentication(Box::new(e)),
+        ServerError {
+            code: 429 | 502 | 503 | 504,
+            ..
+        } => ClientError::RegistryTransient(Box::new(e)),
         RegistryError { envelope, .. } => {
-            let is_not_found = envelope.errors.iter().any(|err| {
-                matches!(
-                    err.code,
-                    OciErrorCode::ManifestUnknown | OciErrorCode::NotFound | OciErrorCode::NameUnknown
-                )
-            });
-            if is_not_found {
-                ClientError::ManifestNotFound(image.to_string())
+            let has = |wanted: OciErrorCode| envelope.errors.iter().any(|err| err.code == wanted);
+            if has(OciErrorCode::Unauthorized) || has(OciErrorCode::Denied) {
+                ClientError::Authentication(Box::new(e))
+            } else if has(OciErrorCode::Toomanyrequests) {
+                ClientError::RegistryTransient(Box::new(e))
             } else {
                 ClientError::Registry(Box::new(e))
             }
         }
-        ServerError { code: 404, .. } => ClientError::ManifestNotFound(image.to_string()),
         _ => ClientError::Registry(Box::new(e)),
+    }
+}
+
+/// Maps OCI distribution errors to [`ClientError::ManifestNotFound`] when the
+/// registry indicates the manifest does not exist (404 / MANIFEST_UNKNOWN),
+/// and defers to [`registry_error`] for everything else.
+fn manifest_not_found_or_registry_error(
+    e: oci_client::errors::OciDistributionError,
+    image: &oci::native::Reference,
+) -> ClientError {
+    use oci_client::errors::OciDistributionError::{ImageManifestNotFoundError, RegistryError, ServerError};
+    use oci_client::errors::OciErrorCode;
+    let is_not_found = match &e {
+        ImageManifestNotFoundError(_) | ServerError { code: 404, .. } => true,
+        RegistryError { envelope, .. } => envelope.errors.iter().any(|err| {
+            matches!(
+                err.code,
+                OciErrorCode::ManifestUnknown | OciErrorCode::NotFound | OciErrorCode::NameUnknown
+            )
+        }),
+        _ => false,
+    };
+    if is_not_found {
+        ClientError::ManifestNotFound(image.to_string())
+    } else {
+        registry_error(e)
     }
 }
 
 /// Maps OCI distribution errors to [`ClientError::RepositoryNotFound`] when the
 /// registry indicates the repository does not exist (404 / NAME_UNKNOWN),
-/// and falls back to [`ClientError::Registry`] for everything else.
+/// and defers to [`registry_error`] for everything else.
 ///
 /// Used by `list_tags` so callers can distinguish an authoritative
 /// "repository absent" (legitimately empty, e.g. before the first publish)
@@ -121,23 +160,20 @@ fn repository_not_found_or_registry_error(
     e: oci_client::errors::OciDistributionError,
     image: &oci::native::Reference,
 ) -> ClientError {
-    use oci_client::errors::OciDistributionError::*;
+    use oci_client::errors::OciDistributionError::{RegistryError, ServerError};
     use oci_client::errors::OciErrorCode;
-    let repository = format!("{}/{}", image.registry(), image.repository());
-    match &e {
-        RegistryError { envelope, .. } => {
-            let is_not_found = envelope
-                .errors
-                .iter()
-                .any(|err| matches!(err.code, OciErrorCode::NotFound | OciErrorCode::NameUnknown));
-            if is_not_found {
-                ClientError::RepositoryNotFound(repository)
-            } else {
-                ClientError::Registry(Box::new(e))
-            }
-        }
-        ServerError { code: 404, .. } => ClientError::RepositoryNotFound(repository),
-        _ => ClientError::Registry(Box::new(e)),
+    let is_not_found = match &e {
+        ServerError { code: 404, .. } => true,
+        RegistryError { envelope, .. } => envelope
+            .errors
+            .iter()
+            .any(|err| matches!(err.code, OciErrorCode::NotFound | OciErrorCode::NameUnknown)),
+        _ => false,
+    };
+    if is_not_found {
+        ClientError::RepositoryNotFound(format!("{}/{}", image.registry(), image.repository()))
+    } else {
+        registry_error(e)
     }
 }
 
@@ -503,29 +539,38 @@ mod tests {
     use futures::StreamExt;
     use std::sync::Mutex;
 
+    use oci_client::errors::{OciDistributionError, OciEnvelope, OciError, OciErrorCode};
+
+    fn reference() -> oci::native::Reference {
+        oci::native::Reference::try_from("registry.test/mirror/cmake:4.3.3").expect("valid reference")
+    }
+
+    fn envelope_error(code: OciErrorCode) -> OciDistributionError {
+        OciDistributionError::RegistryError {
+            envelope: OciEnvelope {
+                errors: vec![OciError {
+                    code,
+                    message: String::new(),
+                    detail: serde_json::Value::Null,
+                }],
+            },
+            url: "https://registry.test/v2/mirror/cmake/tags/list".to_string(),
+        }
+    }
+
+    fn server_error(code: u16) -> OciDistributionError {
+        OciDistributionError::ServerError {
+            code,
+            url: "https://registry.test/v2/mirror/cmake/tags/list".to_string(),
+            message: String::new(),
+        }
+    }
+
     /// Regression tests for issue #157 — `list_tags` errors must distinguish
     /// an authoritative "repository absent" from a transient registry failure
     /// so discover callers can stay fail-safe.
     mod repository_not_found_mapping {
         use super::*;
-        use oci_client::errors::{OciDistributionError, OciEnvelope, OciError, OciErrorCode};
-
-        fn reference() -> oci::native::Reference {
-            oci::native::Reference::try_from("registry.test/mirror/cmake:4.3.3").expect("valid reference")
-        }
-
-        fn envelope_error(code: OciErrorCode) -> OciDistributionError {
-            OciDistributionError::RegistryError {
-                envelope: OciEnvelope {
-                    errors: vec![OciError {
-                        code,
-                        message: String::new(),
-                        detail: serde_json::Value::Null,
-                    }],
-                },
-                url: "https://registry.test/v2/mirror/cmake/tags/list".to_string(),
-            }
-        }
 
         #[test]
         fn name_unknown_maps_to_repository_not_found() {
@@ -545,31 +590,21 @@ mod tests {
 
         #[test]
         fn server_404_maps_to_repository_not_found() {
-            let error = OciDistributionError::ServerError {
-                code: 404,
-                url: "https://registry.test/v2/mirror/cmake/tags/list".to_string(),
-                message: "not found".to_string(),
-            };
-            let mapped = repository_not_found_or_registry_error(error, &reference());
+            let mapped = repository_not_found_or_registry_error(server_error(404), &reference());
             assert!(matches!(mapped, ClientError::RepositoryNotFound(_)), "got {mapped:?}");
         }
 
         #[test]
-        fn server_5xx_stays_registry_error() {
-            let error = OciDistributionError::ServerError {
-                code: 503,
-                url: "https://registry.test/v2/mirror/cmake/tags/list".to_string(),
-                message: "service unavailable".to_string(),
-            };
-            let mapped = repository_not_found_or_registry_error(error, &reference());
-            assert!(matches!(mapped, ClientError::Registry(_)), "got {mapped:?}");
+        fn server_5xx_is_transient_registry_failure() {
+            let mapped = repository_not_found_or_registry_error(server_error(503), &reference());
+            assert!(matches!(mapped, ClientError::RegistryTransient(_)), "got {mapped:?}");
         }
 
         #[test]
-        fn rate_limit_envelope_stays_registry_error() {
+        fn rate_limit_envelope_is_transient_registry_failure() {
             let mapped =
                 repository_not_found_or_registry_error(envelope_error(OciErrorCode::Toomanyrequests), &reference());
-            assert!(matches!(mapped, ClientError::Registry(_)), "got {mapped:?}");
+            assert!(matches!(mapped, ClientError::RegistryTransient(_)), "got {mapped:?}");
         }
     }
 
@@ -578,51 +613,80 @@ mod tests {
     /// credentials failure — stays `Authentication` (exit 80).
     #[test]
     fn genuine_auth_rejection_stays_authentication() {
-        use oci_client::errors::OciDistributionError;
         let failure = OciDistributionError::AuthenticationFailure("bad token".to_string());
         assert!(
-            matches!(auth_or_availability_error(failure), ClientError::Authentication(_)),
+            matches!(registry_error(failure), ClientError::Authentication(_)),
             "AuthenticationFailure must classify as Authentication"
         );
         let unauthorized = OciDistributionError::UnauthorizedError {
             url: "https://registry.test/v2/".to_string(),
         };
         assert!(
-            matches!(auth_or_availability_error(unauthorized), ClientError::Authentication(_)),
+            matches!(registry_error(unauthorized), ClientError::Authentication(_)),
             "UnauthorizedError must classify as Authentication"
         );
     }
 
-    /// Bug 15: a token-endpoint 5xx / 429 (tagged `ServerError` in the patched
-    /// `authenticate`) or an unparseable token body is an availability failure —
-    /// `Registry` (69), not `Authentication` (80).
+    /// The push path never sees an enveloped 401/403: `extract_location_header`
+    /// turns every non-`202` into a bare `ServerError`, so a chunk `PATCH`
+    /// rejected for credentials arrives as `ServerError { code: 401 }`. Reading
+    /// only the envelope shape would classify it as a plain registry failure
+    /// and hand a 69 to a caller whose credentials are the actual problem.
     #[test]
-    fn token_service_unavailable_is_registry_not_authentication() {
-        use oci_client::errors::OciDistributionError;
-        for code in [503u16, 429] {
-            let server = OciDistributionError::ServerError {
-                code,
-                url: "https://registry.test/token".to_string(),
-                message: "down".to_string(),
-            };
+    fn server_401_and_403_are_authentication() {
+        for code in [401u16, 403] {
+            let mapped = registry_error(server_error(code));
             assert!(
-                matches!(auth_or_availability_error(server), ClientError::Registry(_)),
-                "token-service {code} must classify as Registry"
+                matches!(mapped, ClientError::Authentication(_)),
+                "a {code} answer must classify as Authentication, got {mapped:?}"
+            );
+        }
+    }
+
+    /// `DENIED` is the enveloped form of "your credentials do not cover this",
+    /// and the envelope check runs before the rate-limit one: under retry the
+    /// costs are asymmetric — retrying a denial burns the budget and can trip
+    /// an account lockout, while surfacing a rate limit as an auth failure only
+    /// misnames a wait.
+    #[test]
+    fn denied_envelope_is_authentication() {
+        let mapped = registry_error(envelope_error(OciErrorCode::Denied));
+        assert!(
+            matches!(mapped, ClientError::Authentication(_)),
+            "a DENIED envelope must classify as Authentication, got {mapped:?}"
+        );
+    }
+
+    /// Bug 15: a token-endpoint 5xx / 429 (tagged `ServerError` in the patched
+    /// `authenticate`) is never a credentials failure — it is transient
+    /// (`RegistryTransient` → 75). An unparseable token body is neither: it
+    /// falls to the catch-all `Registry` (69), which is what proves the
+    /// catch-all still exists after the classification table grew.
+    #[test]
+    fn token_service_faults_are_never_authentication() {
+        for code in [503u16, 429] {
+            let mapped = registry_error(server_error(code));
+            assert!(
+                matches!(mapped, ClientError::RegistryTransient(_)),
+                "token-service {code} must classify as RegistryTransient, got {mapped:?}"
             );
         }
         let decode = OciDistributionError::RegistryTokenDecodeError("bad json".to_string());
+        let mapped = registry_error(decode);
         assert!(
-            matches!(auth_or_availability_error(decode), ClientError::Registry(_)),
-            "an unparseable token body must classify as Registry"
+            matches!(mapped, ClientError::Registry(_)),
+            "an unparseable token body must fall through to Registry, got {mapped:?}"
         );
     }
 
     /// Bug 12 root cause: a connection-refused auth ping (the registry never
-    /// answered) must classify `Registry` (→ Unavailable, exit 69), NOT
-    /// `Authentication` (80). Port 1 on loopback is closed, so the connect fails
-    /// immediately and deterministically.
+    /// answered) must NOT classify as `Authentication` (80). It is transient
+    /// (`RegistryTransient` → 75): nothing about the credentials was ever
+    /// tested, and the same command may succeed once the host is reachable.
+    /// Port 1 on loopback is closed, so the connect fails immediately and
+    /// deterministically.
     #[tokio::test]
-    async fn connect_refused_auth_ping_is_registry_not_authentication() {
+    async fn connect_refused_auth_ping_is_transient_not_authentication() {
         let transport = NativeTransport::new(
             oci::native::Client::new(oci::native::ClientConfig::default()),
             crate::auth::Auth::new(),
@@ -630,8 +694,8 @@ mod tests {
         let reference = oci::native::Reference::try_from("127.0.0.1:1/ocx/probe:latest").expect("valid reference");
         let result = transport.authenticate(&reference, oci::RegistryOperation::Pull).await;
         assert!(
-            matches!(result, Err(ClientError::Registry(_))),
-            "a refused connection must be Registry (Unavailable/69), got {result:?}"
+            matches!(result, Err(ClientError::RegistryTransient(_))),
+            "a refused connection must be RegistryTransient (TempFail/75), got {result:?}"
         );
     }
 

--- a/crates/ocx_lib/src/oci/client/native_transport.rs
+++ b/crates/ocx_lib/src/oci/client/native_transport.rs
@@ -416,6 +416,27 @@ pub(super) fn map_fork_io_error_to_client_error(error: std::io::Error) -> super:
     })
 }
 
+/// Whole-blob push restarts allowed after a transient registry fault — three
+/// total attempts.
+///
+/// Each *request* is bounded by
+/// [`REGISTRY_READ_TIMEOUT`](super::builder::REGISTRY_READ_TIMEOUT) (120 s),
+/// not each attempt: a restart re-uploads the whole blob, so an attempt is as
+/// many bounded requests as the blob has chunks. The worst case before a push
+/// finally gives up is therefore three attempts, each of which may re-upload
+/// the whole blob and then stall for the full 120 s read deadline, plus the
+/// 1 s + 2 s backoff. That is the ceiling being bought; anything larger stops
+/// looking like resilience and starts looking like a hang.
+const PUSH_RETRY_ATTEMPTS: u8 = 2;
+
+/// Wait before the first restart, doubled per attempt (the house pattern from
+/// `project::resolve::retry_fetch`).
+///
+/// No jitter: two retries across at most four concurrent layers is not a
+/// thundering herd, and the spread jitter buys would be invisible against the
+/// per-request timeout.
+const PUSH_RETRY_INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
+
 impl NativeTransport {
     /// Checks blob existence, then uploads the blob via a streamed chunked push
     /// with fluent progress.
@@ -434,6 +455,29 @@ impl NativeTransport {
     /// cap the chunking exists to respect: falling back there would trade a
     /// diagnosable spec violation for the `416` this chunking was written to avoid.
     /// Above the cap the violation is propagated instead.
+    ///
+    /// # Restart on a transient fault
+    ///
+    /// A [`ClientError::RegistryTransient`] mid-upload restarts the whole blob,
+    /// up to [`PUSH_RETRY_ATTEMPTS`] times. Each attempt begins with a fresh
+    /// `POST`, which abandons whatever the failed session stored — a registry
+    /// discards an unreferenced upload session, so the restart needs no range
+    /// reconciliation to be safe. Progress rewinds with it, harmlessly: the bar
+    /// is driven by absolute `set_position`, so a restart moves it backwards
+    /// rather than double-counting.
+    ///
+    /// A `SpecViolationError` is *not* transient and keeps its existing
+    /// behaviour exactly — one monolithic fallback, itself never retried. The
+    /// registry disagreed with the client about what it stored; sending the
+    /// same bytes again does not resolve a disagreement.
+    ///
+    /// Deliberately skipped: re-checking `blob_exists` between attempts. It
+    /// would only pay off in the narrow case where the committing `PUT`
+    /// succeeded server-side and the response timed out. Add it when a log
+    /// shows that happening.
+    // ponytail: whole-blob restart. Per-chunk retry needs a fork change
+    // (buffer the chunk into Bytes for a replayable body) — do it when a
+    // re-sent layer measurably costs more than the fork PR.
     async fn do_push_blob(
         &self,
         image: &oci::native::Reference,
@@ -462,44 +506,56 @@ impl NativeTransport {
         }
 
         let total = data.len() as u64;
+        // `Bytes` clones are refcounted, so each attempt's fresh body — and the
+        // fallback's — costs a pointer, not a copy of the blob.
         let data = Bytes::from(data);
 
-        // Clone the blob for the fallback path (Bytes clone is cheap — refcounted).
-        let fallback_data = data.clone();
-
-        match self
-            .client
-            .push_blob_stream(
-                image,
-                progress_body_stream(data, Arc::clone(&on_progress)),
-                digest_str.as_str(),
-                Some(total as usize),
-            )
-            .await
-        {
-            Ok(url) => {
-                // The final frame already reported `total`; repeat so callers still
-                // see completion for a zero-length blob (which yields no frames).
-                on_progress(total);
-                Ok(url)
-            }
-            Err(error @ oci_client::errors::OciDistributionError::SpecViolationError(_)) => {
-                log::warn!("Registry spec violation during streamed chunked push: {}", error);
-                if total > MAX_UPLOAD_REQUEST_BYTES as u64 {
-                    log::warn!(
-                        "Not falling back to buffered push: it ends in a single {total}-byte request, \
-                         over the {MAX_UPLOAD_REQUEST_BYTES}-byte per-request cap, so the registry would \
-                         reject it too"
-                    );
-                    return Err(registry_error(error));
+        let mut attempt: u8 = 0;
+        let mut backoff = PUSH_RETRY_INITIAL_BACKOFF;
+        loop {
+            let body = progress_body_stream(data.clone(), Arc::clone(&on_progress));
+            match self
+                .client
+                .push_blob_stream(image, body, digest_str.as_str(), Some(total as usize))
+                .await
+            {
+                Ok(url) => {
+                    // The final frame already reported `total`; repeat so callers still
+                    // see completion for a zero-length blob (which yields no frames).
+                    on_progress(total);
+                    return Ok(url);
                 }
-                log::warn!("Falling back to buffered push (chunked-then-monolithic retry, no progress)");
-                self.client
-                    .push_blob(image, fallback_data, digest_str.as_str())
-                    .await
-                    .map_err(registry_error)
+                Err(error @ oci_client::errors::OciDistributionError::SpecViolationError(_)) => {
+                    log::warn!("Registry spec violation during streamed chunked push: {}", error);
+                    if total > MAX_UPLOAD_REQUEST_BYTES as u64 {
+                        log::warn!(
+                            "Not falling back to buffered push: it ends in a single {total}-byte request, \
+                             over the {MAX_UPLOAD_REQUEST_BYTES}-byte per-request cap, so the registry would \
+                             reject it too"
+                        );
+                        return Err(registry_error(error));
+                    }
+                    log::warn!("Falling back to buffered push (chunked-then-monolithic retry, no progress)");
+                    return self
+                        .client
+                        .push_blob(image, data.clone(), digest_str.as_str())
+                        .await
+                        .map_err(registry_error);
+                }
+                Err(e) => {
+                    let mapped = registry_error(e);
+                    if !matches!(mapped, ClientError::RegistryTransient(_)) || attempt >= PUSH_RETRY_ATTEMPTS {
+                        return Err(mapped);
+                    }
+                    attempt += 1;
+                    log::warn!(
+                        "Transient registry failure uploading blob {digest_str} ({mapped}); \
+                         restarting the upload in {backoff:?} (attempt {attempt} of {PUSH_RETRY_ATTEMPTS})"
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = backoff.saturating_mul(2);
+                }
             }
-            Err(e) => Err(registry_error(e)),
         }
     }
 }

--- a/crates/ocx_lib/src/package/bin_scan.rs
+++ b/crates/ocx_lib/src/package/bin_scan.rs
@@ -260,6 +260,9 @@ fn windows_claim_name(file_name: &str) -> Option<&str> {
     Some(&file_name[..file_name.len() - ext.len()])
 }
 
+// Deliberately duplicated by `env.rs`'s `executable_verdict` (which returns the
+// mode on failure so the resolver can name it) — sharing would invert the
+// env-on-package layering. Change the bit test here, change it there.
 #[cfg(unix)]
 fn unix_is_executable(metadata: &std::fs::Metadata) -> bool {
     use std::os::unix::fs::PermissionsExt;

--- a/crates/ocx_lib/src/project/error.rs
+++ b/crates/ocx_lib/src/project/error.rs
@@ -343,6 +343,10 @@ pub enum ProjectErrorKind {
 
     /// Resolution for a single tool exceeded the per-tool timeout. The
     /// underlying cause is absent (we only know the deadline fired).
+    ///
+    /// Classifies as [`ExitCode::TempFail`] (75): a deadline on a registry
+    /// interaction leaves the request unanswered rather than answered badly,
+    /// so a rerun can genuinely succeed.
     #[error("resolve timed out for '{identifier}'")]
     ResolveTimeout { identifier: Box<Identifier> },
 
@@ -496,9 +500,26 @@ impl ClassifyExitCode for Error {
                 ProjectErrorKind::Locked => ExitCode::TempFail,
                 ProjectErrorKind::TagNotFound { .. } => ExitCode::NotFound,
                 ProjectErrorKind::AuthFailure { .. } => ExitCode::AuthError,
-                ProjectErrorKind::RegistryUnreachable { .. } | ProjectErrorKind::ResolveTimeout { .. } => {
-                    ExitCode::Unavailable
-                }
+                // Exactly one cause may override the default, and it is the
+                // transient one: the announced contract for this variant is
+                // "75 when the resolver gives up on a transient fault".
+                // `project_err_from_client` boxes the `ClientError` verbatim
+                // for that downcast. Every other cause keeps 69 — deferring to
+                // a typed non-transient cause would let it re-code the
+                // lock-resolve interface (a `DigestMismatch` exhaustion
+                // reaching a caller as 65), and a cause that is not a
+                // `ClientError` at all has no classification to defer to.
+                ProjectErrorKind::RegistryUnreachable { source, .. } => source
+                    .downcast_ref::<crate::oci::client::error::ClientError>()
+                    .filter(|client| {
+                        matches!(client, crate::oci::client::error::ClientError::RegistryTransient(_))
+                    })
+                    .and_then(ClassifyExitCode::classify)
+                    .unwrap_or(ExitCode::Unavailable),
+                // A per-tool deadline on a registry interaction: nothing was
+                // answered, so a rerun can genuinely succeed. Same rule the
+                // transport applies to a request timeout one layer down.
+                ProjectErrorKind::ResolveTimeout { .. } => ExitCode::TempFail,
                 ProjectErrorKind::LockMissing => ExitCode::ConfigError,
                 // The lock was written by an unsupported version — the user
                 // must regenerate it, same remedy shape as a config mismatch.

--- a/crates/ocx_lib/src/project/resolve.rs
+++ b/crates/ocx_lib/src/project/resolve.rs
@@ -664,9 +664,11 @@ pub fn lookup_host_leaf<'a>(
     select_best(host, &candidates)
 }
 
-/// Run the retry chain: up to `retry_attempts` retries on
-/// [`ClientError::Registry`]; `Authentication`, `Ok(None)`, and any
-/// other terminal classification returns immediately.
+/// Run the retry chain: up to `retry_attempts` retries on any fault
+/// [`classify`] calls [`ClientFailure::Transient`] — [`ClientError::Registry`],
+/// [`ClientError::RegistryTransient`], [`ClientError::Io`] and
+/// [`ClientError::ShortBlobRead`]. `Authentication`, `Ok(None)`, and any other
+/// terminal classification returns immediately.
 async fn retry_fetch(
     index: &Index,
     identifier: Identifier,
@@ -740,9 +742,10 @@ async fn retry_fetch(
                     ClientFailure::Other => {
                         // No structured `ClientError` classification applied —
                         // treat as a registry-tier failure so the classification
-                        // table remains total. Exit code falls into Unavailable
-                        // (69), which is the safest default for "registry said
-                        // no, but we don't know why."
+                        // table remains total. The fault's own classification
+                        // decides only the transient case (75); everything else
+                        // defaults to Unavailable (69), the safest answer for
+                        // "registry said no, but we don't know why."
                         return Err(project_err_from_client(err, identifier, |id, src| {
                             ProjectErrorKind::RegistryUnreachable {
                                 identifier: Box::new(id),
@@ -1563,6 +1566,76 @@ mod tests {
         );
     }
 
+    /// Giving up on a *transient* fault after the retry budget is spent still
+    /// exits 75, not 69: the resolver ran out of patience, the registry did not
+    /// run out of the ability to answer. Paired with the sibling test above —
+    /// that one wraps `ClientError::Registry` and must stay at 69, so together
+    /// they prove `RegistryUnreachable` reads its own cause rather than
+    /// flattening every exhaustion to one code.
+    #[tokio::test]
+    async fn resolve_lock_retry_exhausted_on_transient_fault_classifies_as_temp_fail() {
+        let config = single_tool_config();
+        let script = (0..3)
+            .map(|_| Err(ClientError::RegistryTransient(Box::new(std::io::Error::other("connect timed out"))).into()))
+            .collect();
+        let mock = MockIndex::with_script(script);
+        let (index, counter) = index_from_mock(&mock);
+
+        let err = resolve_lock(&config, &index, &[], fast_options())
+            .await
+            .expect_err("retry exhaustion must surface as an error");
+
+        assert_eq!(
+            *counter.lock().unwrap(),
+            3,
+            "a transient fault must consume the same retry budget as any other; got {}",
+            *counter.lock().unwrap()
+        );
+
+        let code = <super::super::Error as crate::cli::ClassifyExitCode>::classify(&err);
+        assert_eq!(
+            code,
+            Some(crate::cli::ExitCode::TempFail),
+            "retry-exhausted transient fault must classify as TempFail (exit 75); got {code:?}"
+        );
+    }
+
+    /// The transient carve-out is exactly a carve-out: a typed but NOT
+    /// transient cause under `RegistryUnreachable` keeps 69.
+    ///
+    /// `RegistryUnreachable` is the lock-resolve interface's "the registry
+    /// would not answer" outcome, and 75 is announced for one case only — the
+    /// resolver giving up on a transient fault. Reading the exit code off the
+    /// innermost cause unconditionally would let a malformed manifest re-code
+    /// that outcome to 65, which no `case $?` around a resolve expects.
+    #[tokio::test]
+    async fn resolve_lock_non_transient_client_fault_stays_unavailable() {
+        let config = single_tool_config();
+        let script = vec![Err(
+            ClientError::InvalidManifest("no manifests array".to_string()).into()
+        )];
+        let mock = MockIndex::with_script(script);
+        let (index, counter) = index_from_mock(&mock);
+
+        let err = resolve_lock(&config, &index, &[], fast_options())
+            .await
+            .expect_err("a malformed manifest must surface as an error");
+
+        assert_eq!(
+            *counter.lock().unwrap(),
+            1,
+            "a data fault is not retryable; expected exactly 1 call, got {}",
+            *counter.lock().unwrap()
+        );
+
+        let code = <super::super::Error as crate::cli::ClassifyExitCode>::classify(&err);
+        assert_eq!(
+            code,
+            Some(crate::cli::ExitCode::Unavailable),
+            "a non-transient cause must keep Unavailable (exit 69), not adopt its own 65; got {code:?}"
+        );
+    }
+
     // ── 4. Auth failure — no retry ──────────────────────────────────────────
 
     /// Plan line 631: "auth failure: mock returns `Authentication` →
@@ -1635,16 +1708,18 @@ mod tests {
         );
     }
 
-    // ── 6. Timeout classifies as Unavailable ────────────────────────────────
+    // ── 6. Timeout classifies as TempFail ───────────────────────────────────
 
-    /// Plan line 633: "timeout: mock hangs past `per_tool_timeout` →
-    /// returns `Unavailable`-classified error."
+    /// A per-tool deadline firing on a registry interaction is the retryable
+    /// case: nothing was answered, so the same command may well succeed on a
+    /// rerun. Same rule the transport applies to a request timeout (75), one
+    /// layer up.
     ///
     /// Timeout path: per-call delay exceeds `per_tool_timeout`. The
     /// `tokio::time::timeout` wrapper around the retry chain must fire
-    /// and map to Unavailable classification (exit 69).
+    /// and map to TempFail classification (exit 75).
     #[tokio::test]
-    async fn resolve_lock_timeout_classifies_as_unavailable() {
+    async fn resolve_lock_timeout_classifies_as_temp_fail() {
         let config = single_tool_config();
         // Mock hangs 500ms per call; timeout is 50ms, so the first
         // attempt can never complete.
@@ -1676,8 +1751,8 @@ mod tests {
         let code = <super::super::Error as crate::cli::ClassifyExitCode>::classify(&err);
         assert_eq!(
             code,
-            Some(crate::cli::ExitCode::Unavailable),
-            "timeout must classify as Unavailable (exit 69); got {:?}",
+            Some(crate::cli::ExitCode::TempFail),
+            "timeout must classify as TempFail (exit 75); got {:?}",
             code
         );
     }

--- a/crates/ocx_lib/src/project/resolve.rs
+++ b/crates/ocx_lib/src/project/resolve.rs
@@ -823,9 +823,10 @@ fn classify(client: &ClientError) -> ClientFailure {
     match client {
         // Transient: registry-side failures, file I/O, and an incomplete blob
         // delivery are all retryable.
-        ClientError::Registry(_) | ClientError::Io { .. } | ClientError::ShortBlobRead { .. } => {
-            ClientFailure::Transient
-        }
+        ClientError::Registry(_)
+        | ClientError::RegistryTransient(_)
+        | ClientError::Io { .. }
+        | ClientError::ShortBlobRead { .. } => ClientFailure::Transient,
         // Terminal auth failure — no retry.
         ClientError::Authentication(_) => ClientFailure::Auth,
         // 404-equivalent — no retry.
@@ -890,6 +891,15 @@ mod classify_tests {
     #[test]
     fn registry_is_transient() {
         assert_transient(ClientError::Registry(Box::new(std::io::Error::other("net"))));
+    }
+
+    /// A connect failure, timeout, or 429/5xx is retryable by construction —
+    /// it is the variant that exists to say so.
+    #[test]
+    fn registry_transient_is_transient() {
+        assert_transient(ClientError::RegistryTransient(Box::new(std::io::Error::other(
+            "connect timed out",
+        ))));
     }
 
     #[test]

--- a/crates/ocx_lib/src/script/ocx_module.rs
+++ b/crates/ocx_lib/src/script/ocx_module.rs
@@ -336,16 +336,21 @@ fn program_is_path(program: &str) -> bool {
 /// `cwd` — NOT the process CWD — because the child runs with `current_dir(cwd)`
 /// applied; resolving it against the outer CWD would bind (and refuse-check)
 /// the wrong binary.
-fn resolve_program(base_env: &crate::env::Env, program: &str, cwd: &Path) -> std::path::PathBuf {
+///
+/// A bare name goes through
+/// [`Env::resolve_test_command`](crate::env::Env::resolve_test_command), so a
+/// name the package under test ships but cannot execute fails the script
+/// instead of silently running the host's copy.
+fn resolve_program(base_env: &crate::env::Env, program: &str, cwd: &Path) -> Result<std::path::PathBuf, String> {
     if program_is_path(program) {
         let raw = Path::new(program);
-        return if raw.is_absolute() {
+        return Ok(if raw.is_absolute() {
             raw.to_path_buf()
         } else {
             cwd.join(raw)
-        };
+        });
     }
-    base_env.resolve_command(program)
+    base_env.resolve_test_command(program).map_err(|e| e.to_string())
 }
 
 /// Returns true if `resolved` is (or resolves to) an `ocx` binary — refused in
@@ -456,6 +461,7 @@ fn ocx_members(globals: &mut GlobalsBuilder) {
         });
 
         let cwd_path = cwd_path.map_err(fail)?;
+        let resolved = resolved.map_err(fail)?;
 
         // Refuse re-entrant ocx (Fix#6).
         let reentrant = host::with(|s| is_ocx_binary(&s.env, &resolved));
@@ -751,12 +757,12 @@ mod tests {
         let env = crate::env::Env::clean();
         let cwd = Path::new("/sandbox/subdir");
         assert_eq!(
-            resolve_program(&env, "./tool", cwd),
+            resolve_program(&env, "./tool", cwd).unwrap(),
             cwd.join("tool"),
             "`./tool` must bind to <cwd>/tool"
         );
         assert_eq!(
-            resolve_program(&env, "bin/tool", cwd),
+            resolve_program(&env, "bin/tool", cwd).unwrap(),
             cwd.join("bin/tool"),
             "`bin/tool` must bind under the validated cwd"
         );
@@ -768,7 +774,7 @@ mod tests {
         let cwd = Path::new("/sandbox/subdir");
         let abs = if cfg!(windows) { r"C:\bin\tool" } else { "/usr/bin/tool" };
         assert_eq!(
-            resolve_program(&env, abs, cwd),
+            resolve_program(&env, abs, cwd).unwrap(),
             Path::new(abs),
             "an absolute program path must not be re-anchored on the cwd"
         );
@@ -783,7 +789,7 @@ mod tests {
         #[cfg(windows)]
         env.set("PATHEXT", ".EXE");
         let cwd = Path::new("/sandbox/subdir");
-        let resolved = resolve_program(&env, "definitely_missing_bin_xyz", cwd);
+        let resolved = resolve_program(&env, "definitely_missing_bin_xyz", cwd).unwrap();
         assert!(
             !resolved.starts_with(cwd),
             "a bare PATH name must not be anchored on the cwd, got {resolved:?}"

--- a/test/src/helpers.py
+++ b/test/src/helpers.py
@@ -442,6 +442,7 @@ def make_package_with_entrypoints(
     dependencies: list[dict] | None = None,
     env: list[dict] | None = None,
     extra_files: dict[str, str] | None = None,
+    bin_exec: dict[str, bool] | None = None,
 ) -> PackageInfo:
     """Publish a test package whose metadata declares ``entrypoints``.
 
@@ -473,6 +474,11 @@ def make_package_with_entrypoints(
         package's installed ``content/`` tree and reachable via
         ``${installPath}/<rel_path>`` at runtime.  Parent directories are
         created automatically.  Defaults to ``None`` (no extra files).
+    bin_exec:
+        Maps a binary name to whether it gets the executable bit (default:
+        every name in ``bins`` does).  A ``False`` entry builds the shadow-rule
+        fixture at the launcher hop: an entrypoint whose dispatch target the
+        package ships but cannot run.  POSIX only — Windows has no exec bit.
     """
     if isinstance(entrypoints, list):
         for n in entrypoints:
@@ -506,7 +512,8 @@ def make_package_with_entrypoints(
             script.write_text(f"@echo entry-point-{name} {marker} %*\n")
         else:
             script.write_text(f'#!/bin/sh\necho "entry-point-{name} {marker} $@"\n')
-            script.chmod(script.stat().st_mode | stat.S_IEXEC)
+            if (bin_exec or {}).get(name, True):
+                script.chmod(script.stat().st_mode | stat.S_IEXEC)
 
     if extra_files:
         for rel_path, content in extra_files.items():

--- a/test/tests/test_exit_codes.py
+++ b/test/tests/test_exit_codes.py
@@ -18,14 +18,12 @@ removed automatically the moment the product catches up:
   successfully parses and the install fails later as `NotFound` (79). Triggering
   `IdentifierError` at parse time requires either a stricter parser or a test
   fixture that can inject a pre-parsed `IdentifierError` through the CLI.
-- 69 (Unavailable): `ocx index update` logs errors per-package and exits 0;
-  `ocx install` against an unroutable host surfaces as `AuthError` (80) because
-  the transport interprets the connection failure as an auth failure. Neither
-  reliably produces `ClientError::Registry → Unavailable` via the CLI.
+- 69 (Unavailable): a registry that *answers*, just not usefully, is hard to
+  provoke from the CLI. An unroutable host never answers at all, so it is 75
+  (see below), not 69.
 
 Deferred codes (no reliable acceptance-test trigger available):
 - 74 (IoError): disk-full or read-failure not injectable from user tests.
-- 75 (TempFail): rate-limit or transient-network failure not reliably injectable.
 - 77 (PermissionDenied): filesystem EPERM not reliably injectable without root.
 """
 from __future__ import annotations
@@ -80,10 +78,16 @@ class TestExitCodes:
             f"got {result.returncode}\nstderr: {result.stderr.strip()}"
         )
 
-    def test_exit_code_69_unavailable_on_unroutable_registry(
+    def test_exit_code_75_tempfail_on_unroutable_registry(
         self, ocx: OcxRunner
     ) -> None:
-        """Unroutable registry → ClientError::Registry → exit 69 (EX_UNAVAILABLE)."""
+        """Unroutable registry → ClientError::RegistryTransient → exit 75.
+
+        The connect never completed, so nothing about the request was answered
+        and the same command may succeed once the host is reachable. That is
+        exactly what 75 (EX_TEMPFAIL) promises a retrying wrapper, and what 69
+        would deny it.
+        """
         # Port 1 is reserved and unroutable on standard systems.
         env = {**ocx.env, "OCX_DEFAULT_REGISTRY": "127.0.0.1:1"}
         result = subprocess.run(
@@ -92,7 +96,7 @@ class TestExitCodes:
             text=True,
             env=env,
         )
-        assert result.returncode == 69, (
-            f"expected exit 69 (Unavailable) for unroutable registry, "
+        assert result.returncode == 75, (
+            f"expected exit 75 (TempFail) for unroutable registry, "
             f"got {result.returncode}\nstderr: {result.stderr.strip()}"
         )

--- a/test/tests/test_launcher_exec.py
+++ b/test/tests/test_launcher_exec.py
@@ -16,8 +16,12 @@ Scenarios covered:
 
 from __future__ import annotations
 
+import os
+import stat
+import subprocess
 import sys
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
@@ -152,4 +156,70 @@ def test_launcher_exec_missing_metadata_json_exits_64(ocx: OcxRunner) -> None:
     )
     assert "metadata.json" in result.stderr, (
         f"error must mention 'metadata.json'; stderr={result.stderr.strip()!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shadow rule at the launcher hop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX executable bit has no Windows analogue")
+def test_launcher_hop_refuses_a_non_executable_dispatch_target(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """A package's own non-executable target must not be passed over here either.
+
+    A generated entrypoint re-enters `ocx launcher exec` as a *fresh* process,
+    so this hop makes its own resolution decision. Resolving it the way the OS
+    would means a package shipping a 0644 dispatch target silently runs the
+    host's same-named binary — #268, one process later, and invisible to the
+    `ocx package test` coverage because a different code path decides it.
+
+    The decoy is what makes this discriminating: it prints a marker no package
+    binary ever prints, so a green run that executed it is visible.
+    """
+    decoy_dir = tmp_path / "host-bin"
+    decoy_dir.mkdir()
+    decoy_marker = f"decoy-{uuid4().hex[:12]}"
+    decoy = decoy_dir / "hello"
+    decoy.write_text(f"#!/bin/sh\necho {decoy_marker}\n")
+    decoy.chmod(decoy.stat().st_mode | stat.S_IEXEC)
+
+    pkg = make_package_with_entrypoints(
+        ocx,
+        unique_repo,
+        tmp_path,
+        entrypoints=["hello"],
+        bins=["hello"],
+        bin_exec={"hello": False},
+    )
+    ocx.plain("package", "install", "--select", pkg.short)
+
+    launcher = _get_package_root(ocx, pkg.short) / "entrypoints" / "hello"
+    assert launcher.exists(), f"the generated launcher must exist: {launcher}"
+
+    launcher_env = dict(ocx.env)
+    # The decoy leads PATH; the ocx dir follows so the launcher can re-enter.
+    launcher_env["PATH"] = os.pathsep.join(
+        [str(decoy_dir), str(ocx.binary.parent), launcher_env.get("PATH", "")]
+    )
+    completed = subprocess.run(
+        [str(launcher)],
+        capture_output=True,
+        text=True,
+        env=launcher_env,
+        timeout=30,
+        check=False,
+    )
+
+    assert completed.returncode == 65, (
+        f"a non-executable dispatch target must exit 65 (DataError), got "
+        f"{completed.returncode}\nstdout: {completed.stdout}\nstderr: {completed.stderr}"
+    )
+    assert decoy_marker not in completed.stdout, (
+        f"the host decoy must never run; stdout:\n{completed.stdout}"
+    )
+    assert f"bin{os.sep}hello" in completed.stderr, (
+        f"stderr must name the package path of the offending file, got:\n{completed.stderr}"
     )

--- a/test/tests/test_managed_config.py
+++ b/test/tests/test_managed_config.py
@@ -384,10 +384,11 @@ def test_config_update_registry_down_leaves_snapshot_untouched(
     result = _run(ocx, "config", "update")
     # A hard connection-refused against `127.0.0.1:1` fails inside the OCI
     # client's `GET /v2/` auth ping at the transport (connect) layer -- the
-    # registry never answered, so it classifies as Unavailable (69), not a
-    # credentials failure (80).
-    assert result.returncode == 69, (
-        f"a connection-refused update classifies as Unavailable (69), got {result.returncode}: {result.stderr}"
+    # registry never answered, so it classifies as a transient fault (75), not
+    # a credentials failure (80). 75 rather than 69 because rerunning the same
+    # command once the host is reachable can succeed.
+    assert result.returncode == 75, (
+        f"a connection-refused update classifies as TempFail (75), got {result.returncode}: {result.stderr}"
     )
     assert snapshot_path.read_text() == before, (
         "a failed update must never partially overwrite the existing snapshot"

--- a/test/tests/test_package_test.py
+++ b/test/tests/test_package_test.py
@@ -55,6 +55,7 @@ def _make_test_package(
     env: list[dict] | None = None,
     dependencies: list[dict] | None = None,
     entrypoints: dict[str, dict] | None = None,
+    bin_exec: dict[str, bool] | None = None,
 ) -> tuple[Path, Path, PackageInfo]:
     """Create a local package layout (content dir + metadata file + bundle) for
     use with ``ocx package test``.
@@ -63,6 +64,10 @@ def _make_test_package(
     ``package_info`` is the pushed package record (needed for digest refs and
     dep descriptors). The bundle is also pushed to the registry so digest-layer
     tests can resolve layer blobs.
+
+    ``bin_exec`` maps a binary name to whether it gets the executable bit
+    (default: every name in ``bins`` does). A ``False`` entry builds the
+    shadow-rule fixture: a package that ships a name it cannot run.
     """
     plat = _PLATFORM
     marker = f"marker-{uuid4().hex[:12]}"
@@ -79,7 +84,8 @@ def _make_test_package(
             script.write_text(f"@echo {marker}\n")
         else:
             script.write_text(f"#!/bin/sh\necho {marker}\n")
-            script.chmod(script.stat().st_mode | stat.S_IEXEC)
+            if (bin_exec or {}).get(name, True):
+                script.chmod(script.stat().st_mode | stat.S_IEXEC)
 
     home_key = unique_repo.upper().replace("-", "_") + "_HOME"
     metadata_env = env or [
@@ -1270,4 +1276,101 @@ def test_env_flag_survives_generated_entrypoint_launcher(
         f"the override must survive the launcher re-entry — without forwarding "
         f"the launcher re-applies the package's own 'package-value' on top; "
         f"stdout:\n{result.stdout}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shadow rule (#268) — a package's own copy of a name is never skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="no POSIX executable bit on Windows")
+def test_nonexecutable_package_binary_fails_instead_of_using_host_copy(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """A package shipping a non-executable binary fails; the host copy never runs.
+
+    The bug (#268): command resolution walked the composed package PATH dirs
+    straight on into the ambient PATH, and skipped a non-executable file
+    without a word. A package whose `bin/shtool` lost its executable bit was
+    therefore tested against whatever `shtool` the host happened to have — and
+    reported a pass.
+
+    The decoy on PATH is what makes this discriminating: it prints a marker no
+    package binary ever prints, so a green run that executed it is visible.
+    """
+    decoy_dir = tmp_path / "host-bin"
+    decoy_dir.mkdir()
+    decoy_marker = f"decoy-{uuid4().hex[:12]}"
+    decoy = decoy_dir / "shtool"
+    decoy.write_text(f"#!/bin/sh\necho {decoy_marker}\n")
+    decoy.chmod(decoy.stat().st_mode | stat.S_IEXEC)
+
+    bundle, metadata_path, pkg_info = _make_test_package(
+        ocx,
+        unique_repo,
+        tmp_path,
+        bins=["shtool"],
+        bin_exec={"shtool": False},
+    )
+
+    result = ocx.plain(
+        "package", "test",
+        "-p", _PLATFORM,
+        "-m", str(metadata_path),
+        "-i", pkg_info.short,
+        str(bundle),
+        "--",
+        "shtool",
+        check=False,
+        env_overrides={"PATH": f"{decoy_dir}{os.pathsep}{ocx.env['PATH']}"},
+    )
+
+    assert result.returncode == 65, (
+        f"a non-executable package binary must exit 65 (DataError), got "
+        f"{result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert decoy_marker not in result.stdout, (
+        f"the host decoy must never run; stdout:\n{result.stdout}"
+    )
+    assert "not executable" in result.stderr, (
+        f"stderr must say the file is not executable, got:\n{result.stderr}"
+    )
+    # A path fragment, not the bare name: the command name alone appears in
+    # every one of these messages, so `"shtool" in stderr` would pass even if
+    # the error stopped naming the offending file at all.
+    assert f"bin{os.sep}shtool" in result.stderr, (
+        f"stderr must name the package path of the offending file, got:\n{result.stderr}"
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="uses the POSIX `sh` host tool")
+def test_host_tool_not_shipped_by_package_resolves_with_warning(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """A name the package does not ship still resolves on the host, with a warning.
+
+    The shadow rule only governs names the package under test actually ships.
+    `sh`, `grep` and friends must keep working — loudly, so a typo'd tool name
+    silently testing a host binary is visible in the log.
+    """
+    bundle, metadata_path, pkg_info = _make_test_package(ocx, unique_repo, tmp_path)
+
+    result = ocx.plain(
+        "package", "test",
+        "-p", _PLATFORM,
+        "-m", str(metadata_path),
+        "-i", pkg_info.short,
+        str(bundle),
+        "--",
+        "sh", "-c", "true",
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"an unshipped host tool must still run, got {result.returncode}\n"
+        f"stderr: {result.stderr}"
+    )
+    assert "not shipped by the composed packages" in result.stderr, (
+        f"resolving off the host PATH must warn, got:\n{result.stderr}"
     )

--- a/test/tests/test_package_test_script.py
+++ b/test/tests/test_package_test_script.py
@@ -1079,3 +1079,71 @@ def test_os_arch_cross_type_wall(
         f"cross-type wall: expected exit 0, got {result.returncode}\n"
         f"stderr: {result.stderr}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Shadow rule (#268) — ocx.run() never falls through to a host copy
+# ---------------------------------------------------------------------------
+
+
+def test_nonexecutable_package_binary_fails_script(
+    ocx: OcxRunner, unique_repo: str, tmp_path: Path
+) -> None:
+    """`ocx.run("shtool")` fails when the package ships shtool non-executable.
+
+    The literal #268 repro: with a same-named executable on the host PATH the
+    script used to run THAT and pass, so a package that lost its executable bit
+    shipped green. Script outcome is a failure → exit 1 (the existing contract;
+    the resolution error surfaces in the failure message, not as exit 65).
+    """
+    tag = "1.0.0"
+    decoy_dir = tmp_path / "host-bin"
+    decoy_dir.mkdir()
+    decoy = decoy_dir / "shtool"
+    decoy.write_text(_SHTOOL_SCRIPT)
+    decoy.chmod(0o755)
+
+    pkg = make_package(
+        ocx,
+        unique_repo,
+        tag,
+        tmp_path,
+        bins=["shtool"],
+        bin_scripts={"shtool": _SHTOOL_SCRIPT},
+        bin_exec={"shtool": False},
+        cascade=False,
+    )
+    bundle = tmp_path / f"bundle-{unique_repo}-{tag}.tar.xz"
+    metadata_path = resolved_metadata_path(bundle)
+
+    script = _write_script(
+        tmp_path,
+        "shadow.star",
+        'r = ocx.run("shtool", "--version")\nexpect.ok(r)\n',
+    )
+
+    env = {**ocx.env, "PATH": f"{decoy_dir}:{ocx.env['PATH']}"}
+    result = subprocess.run(
+        [
+            str(ocx.binary),
+            "package", "test",
+            "-p", _PLATFORM,
+            "-m", str(metadata_path),
+            "-i", pkg.short,
+            str(bundle),
+            "--script", str(script),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=120.0,
+    )
+
+    assert result.returncode == 1, (
+        f"a non-executable package binary must fail the script (exit 1), got "
+        f"{result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    combined = result.stdout + result.stderr
+    assert "not executable" in combined, (
+        f"the failure must say the shipped file is not executable, got:\n{combined}"
+    )

--- a/website/src/docs/authoring/testing.md
+++ b/website/src/docs/authoring/testing.md
@@ -34,6 +34,16 @@ OCX will:
 
 The child's exit code is forwarded unchanged. A failing test command (`exit 7`) gives you exit code 7.
 
+### What the command name resolves to {#basic-resolution}
+
+A bare command name is resolved against the package's own directories before the host `PATH`, and the package's copy of a name is never quietly passed over. The point of `package test` is to test what you are about to publish, so a name your package ships has to be the thing that runs.
+
+That matters most when the file is there but cannot be executed. A binary that lost its executable bit — a common casualty of `zip`, of a `COPY` in a build image, or of a checkout on a filesystem that drops the bit — fails with exit code 65, naming the path and its mode. It is not passed over in favour of a same-named host binary: doing so would test something the package does not contain, and report a pass for a package nobody can run.
+
+Names your package does not ship are unaffected: `sh`, `grep`, `curl` and the rest still resolve on the host `PATH`, with a warning on stderr naming the package directories that were searched. So a typo'd tool name is visible in the log rather than silently testing a host binary. A name carrying a path separator (`./tool`, an absolute path) addresses a file directly and skips this entirely.
+
+To catch a missing executable bit before you even get here, pass `--bin-scan` to [`ocx package create`][cmd-package-create]: it verifies the `binaries` claim against the content tree at authoring time.
+
 ## Identifier constraints {#identifier}
 
 The identifier must be in tag form — `repo:tag` or `registry/repo:tag`. An explicit `@digest` suffix is rejected with a usage error (exit 64), because the digest is computed locally from the layers you supply and would conflict with any pre-committed value.
@@ -231,6 +241,8 @@ The sandbox applies to the `ocx.*` host API only — file reads, writes, and pat
 
 Re-entrant `ocx` invocations are refused in v1. `ocx.run("ocx", ...)` exits with code 1 and a message explaining the limitation.
 
+`ocx.run` resolves a bare program name the same way the trailing-command form does — [against the package first][basic-resolution]. A name your package ships but cannot execute fails the script rather than running the host's copy of that tool, so a package with a 644 binary no longer passes its own smoke test. Names the package does not ship still resolve on the host `PATH`.
+
 ### Output format {#scripted-tests-output}
 
 Pass `--format json` to get a structured envelope alongside the exit code:
@@ -295,8 +307,12 @@ For `.star` syntax highlighting in VS Code, add the [vscode-bazel][vscode-bazel]
 <!-- commands -->
 [cmd-package-push]: ../reference/command-line.md#package-push
 [cmd-package-test]: ../reference/command-line.md#package-test
+[cmd-package-create]: ../reference/command-line.md#package-create
 [cmd-exec]: ../reference/command-line.md#package-exec
 [cmd-env]: ../reference/command-line.md#package-env
+
+<!-- internal -->
+[basic-resolution]: #basic-resolution
 
 <!-- authoring -->
 [authoring-building-pushing]: ./building-pushing.md

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -397,7 +397,7 @@ See [`--global`][global-flag] for the full root-flag reference.
 | 65 | `ocx.toml` drifted from `ocx.lock` before this add — run `ocx lock` to reconcile. |
 | 69 | Registry unreachable while resolving the new tag. |
 | 74 | I/O error reading or writing `ocx.toml` or `ocx.lock`. |
-| 75 | Another `ocx` process holds the project lock on `ocx.toml`. Retry with backoff. |
+| 75 | Another `ocx` process holds the project lock on `ocx.toml`, or a transient registry failure (connect failure, timeout, 429/502/503/504) survived the resolve retries. Retry with backoff. |
 | 78 | `ocx.lock` uses an unsupported version — V1 and V2 locks are rejected; regenerate with `ocx lock`. Also: `ocx.toml` schema invalid or TOML parse error, or a requested `--platform` is not shipped by a tool. |
 | 79 | Tag not found in the registry. |
 | 80 | Authentication failure against the registry. |
@@ -1400,6 +1400,7 @@ Pass `--global` **before** the subcommand: `ocx --global lock`. See [`--global`]
 | 65 | `--check` reported drift. |
 | 69 | Registry unreachable while resolving advisory tags. |
 | 74 | I/O error writing `ocx.lock`. |
+| 75 | Transient registry failure (connect failure, timeout, 429/502/503/504) survived the resolve retries — rerunning may succeed. |
 | 78 | Existing `ocx.lock` is malformed (parse error) or uses an unsupported version (V1/V2 are rejected; regenerate with `ocx lock`), `ocx.toml` schema-invalid, `--check` reported the lock is absent, or a requested `--platform` is not shipped by a tool. |
 | 79 | Tag unresolvable during resolution (package not found in registry after retries). |
 | 80 | Authentication failure against the registry. |
@@ -1608,6 +1609,7 @@ The composer prepends env entries in iteration order, so the **last group listed
 | 64 | `--` missing; empty argv; empty `-g` segment; no `ocx.toml` found; unknown `-g` group; unknown binding NAME; ambiguous NAME across groups with conflicting identifiers; `--global` combined with `--project`; a bare `--env FOO` with no `=`; an `--env` `TYPE` that names no modifier or is empty (`--env X:bogus=v`, `--env X:=v`); or `--env` sets an `OCX_*`/`__OCX_*` key. (OCX remaps clap's default exit 2 to 64.) |
 | 65 | `ocx.lock` is stale — run `ocx lock`. |
 | 69 | Registry unreachable during auto-install of a missing package. |
+| 75 | Transient registry failure during auto-install (connect failure, timeout, 429/502/503/504) — rerunning may succeed. |
 | 78 | `ocx.lock` absent — run `ocx lock`; or `ocx.toml` parse error — including a tool binding declared directly under `[group.<name>]` instead of `[group.<name>.tools]`, or an `[env]`/`[group.<name>.env]` entry with an `OCX_*`/`__OCX_*` key (e.g. `[group.all]` declared); or no leaf digest for the host platform at the locked version (no `"any"` fallback key in `[tool.platforms]`) — run `ocx update <tool>` to re-resolve. The host-leaf check fires only for tools actually composed: the named subset when `NAME` is given, or every tool in scope when it is omitted. |
 | 79 | Package not found in registry during auto-install. |
 | 80 | Authentication failure during auto-install. |

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -2627,6 +2627,18 @@ Malformed layout syntax at publish (`strip` not a `u8`, an unknown key, a duplic
 
 Materializes a package locally without a registry round-trip and runs a command or script in its composed env. Mirrors the argument shape of [`package push`][cmd-package-push]: identifier as `-i/--identifier`, then layers, then `--platform`. Either a trailing `-- CMD [ARGS...]` or a `--script PATH` is required; the two forms are mutually exclusive.
 
+::: warning Commands resolve against the package first
+A bare command name is looked up in the package's own directories before the host `PATH`, and the package's copy of a name is never skipped:
+
+- **The package ships an executable of that name** — it runs. This is the ordinary case.
+- **The package ships the name but the file is not executable** — the command fails with exit code 65, naming the path and its permission bits. It does *not* fall back to a same-named binary on the host, because that would test something the package does not contain and report a pass.
+- **The package does not ship the name at all** — it resolves on the host `PATH` as usual (`sh`, `grep`, and friends keep working), with a warning naming the directories that were searched.
+
+A name carrying a path separator (`./tool`, an absolute path) addresses a file directly and is unaffected.
+
+Catch a missing executable bit at publish time instead with [`ocx package create --bin-scan`][cmd-package-create].
+:::
+
 **Usage**
 
 ```shell
@@ -2684,6 +2696,10 @@ ocx package test -p linux/amd64 -m metadata.json -i mytool:1.0.1 \
 ::: tip Tempdir lifecycle
 Without `--keep` or `--output`, the temp directory is deleted on any exit — success or failure. Use `--keep` to opt in to preservation on failure. Re-run with `--keep` to inspect.
 :::
+
+**Exit codes — trailing-command branch**
+
+The child's own exit code propagates verbatim, so any value can appear. Two codes are produced by `ocx` itself before the child starts: 64 for a usage error, and 65 when the package ships the named command but the file is not executable (see the warning above).
 
 **Exit codes — `--script` branch**
 

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -283,14 +283,16 @@ The sysexits.h convention originates in BSD Unix and is documented at [man.freeb
 | 1 | Failure | — | Generic failure — only when no specific code applies | Inspect stderr |
 | 64 | UsageError | EX_USAGE | Bad CLI invocation: unknown flag, wrong argument count, invalid syntax | Check the command syntax |
 | 65 | DataError | EX_DATAERR | Input data malformed: bad identifier, invalid digest, corrupted manifest; also a platform feature mismatch — the package ships for the host os/arch but no candidate's `os.features` are a subset of the host's (e.g. glibc vs musl), see [`--platform`](#package-install); also an ambiguous selection — a dual-libc host matched two equally-specific candidates (see [libc differentiation][authoring-libc]) | Validate identifiers and file contents; for a feature mismatch or ambiguous selection, override with `--platform` |
-| 69 | Unavailable | EX_UNAVAILABLE | Required resource unavailable: network down, registry unreachable | Retry; check network and registry URL |
+| 69 | Unavailable | EX_UNAVAILABLE | The registry answered, but not usefully — and a rerun will not change that. Also a local resource that cannot be reached | Inspect stderr; fix the registry or the URL before retrying |
 | 74 | IoError | EX_IOERR | I/O error: filesystem permission denied, disk full, read/write failure | Check filesystem permissions and free space |
-| 75 | TempFail | EX_TEMPFAIL | Temporary failure that may succeed on retry: rate limit, transient network, or a layer blob that arrived short of its manifest-declared size | Retry with backoff |
-| 77 | PermissionDenied | EX_NOPERM | Insufficient permissions: registry 403, filesystem EPERM | Refresh credentials or adjust filesystem permissions |
+| 75 | TempFail | EX_TEMPFAIL | Temporary failure that may succeed on retry: registry connect failure or timeout, 429, 502, 503, 504, rate limit, transient network, or a layer blob that arrived short of its manifest-declared size | Retry with backoff |
+| 77 | PermissionDenied | EX_NOPERM | Insufficient permissions: filesystem EPERM | Adjust filesystem permissions |
 | 78 | ConfigError | EX_CONFIG | Configuration error: bad config file, missing required field, parse failure | Inspect the config file at the printed path |
 | 79 | NotFound | OCX | Resource not found: package 404, explicit config path absent | Pin a different version or correct the path |
-| 80 | AuthError | OCX | Authentication failure: registry 401, missing credentials | Refresh or set registry credentials |
+| 80 | AuthError | OCX | Authentication failure: registry 401 or 403, missing credentials | Refresh or set registry credentials |
 | 81 | PolicyBlocked | OCX | A deliberate local policy (`--offline` or `--frozen`) refused a network or resolution operation — not a fault. Includes an unpinned-tag resolve that the policy forbade | Loosen the flag, or populate the local index first (e.g. `ocx index update`) |
+
+**75 means the same command may succeed if run again; 69 does not.** That distinction is what makes automated retry safe: a wrapper loops on 75 and stops on 69, without parsing a single line of stderr. The per-command tables below still name 69 as "registry unreachable" — those rows exit 75 instead whenever the failure is transient (the connect never completed, the request timed out, or the registry answered 429/502/503/504).
 
 Scripts can `case $?` on these stable values:
 
@@ -299,8 +301,8 @@ ocx package install cmake:3.28
 case $? in
     0)  echo "installed" ;;
     64) echo "usage error; check flags" ;;
-    69) echo "registry unreachable; retry with backoff" ;;
-    75) echo "temporary failure; retry later" ;;
+    69) echo "registry answered badly; a rerun will not help" ;;
+    75) echo "transient failure; retry with backoff" ;;
     78) echo "bad config; inspect the config file" ;;
     79) echo "not found; pin a different version" ;;
     80) echo "auth failed; refresh credentials" ;;

--- a/website/src/docs/reference/script-host-api.md
+++ b/website/src/docs/reference/script-host-api.md
@@ -42,6 +42,8 @@ Every function below is a method (always written with parens). Returned values a
 
 The first positional argument is the program; the rest are argv. Splat a list with `ocx.run(*cmd)`. Calling with zero positional args fails the script.
 
+A bare program name resolves against the composed package directories before the host `PATH`, and never silently falls through to the host when the package under test ships a copy it cannot execute — that case fails the script instead. A name the package does not ship resolves on the host as usual.
+
 The keyword-only parameters:
 
 - `env` — dict overlaid on top of the composed env for this call only. Reserved keys (`PATH`, `OCX_HOME`, the `OCX_*` loader vars, and the `OCX_AUTH_*` credential family) are rejected.


### PR DESCRIPTION
Closes #266, closes #267, closes #268.

Five commits, one theme: registry faults and test resolution stop lying about what happened.

## #266 — classify registry failures (exit 75 / 80 / 69)

`ClientError::RegistryTransient` is produced at the single construction choke point (`native_transport::registry_error`), not by downcasting at classify time: connect failures and timeouts, HTTP 429/502/503/504, and `TOOMANYREQUESTS` envelopes exit **75** (`TempFail`); 401/403 in both wire shapes (`ServerError` and OCI envelope `UNAUTHORIZED`/`DENIED`) exit **80** (`AuthError`); everything else stays **69**. The contract, now in the docs and both rustdocs: **75 means the same command may succeed if run again; 69 does not.** The old `auth_or_availability_error` special case is subsumed and deleted.

The project-lock path delegates narrowly: `RegistryUnreachable` exits 75 only when the retained cause is transient; `ResolveTimeout` is 75 by #266's own rule (a deadline elapsed, a rerun can succeed). A typed non-transient cause (e.g. digest mismatch exhaustion) deliberately stays 69 — the announced contract is the transient case only.

## #267 — connect timeout + transient-only push retry

- `REGISTRY_CONNECT_TIMEOUT = 30 s` on the registry client (was unbounded; index client precedent).
- `do_push_blob` retries a failed upload up to 2 times (3 attempts, 1 s/2 s backoff), **only** when the mapped error is `RegistryTransient` — a 401 mid-chunk makes exactly one attempt. Each retry is a fresh upload session (fresh `POST`); the whole layer is already in RAM, so the restart is a refcounted `Bytes` clone. Chunk-granularity retry needs a fork change and is deferred (issue linked below); the `ponytail:` marker in code names the upgrade path.
- Timeout knob deliberately not added: chunking already bounds a single request at 3 MiB / 120 s, so upload progress is never judged by more than one chunk's deadline.

## #268 — the shadow rule for test command resolution

`Env::resolve_test_command` decides the package's own copy first, for `ocx package test`, `ocx patch test`, the Starlark `ocx.run()` host function, **and the launcher re-entry hop** (`ocx launcher exec` — without it, any entrypoint-declaring package defeats the check in the fresh process; this is why the commit is scoped `fix(cli)!`, it changes a production path):

1. First executable match in the package-composed PATH dirs wins (happy path unchanged).
2. Present but not executable → hard error naming path and mode, exit **65** — never a silent fall-through to the host's copy. This is the mirror-powershell false green, now red.
3. A name the package does not ship falls back to the host PATH with a warning naming the resolved path and the searched dirs (`{:?}`-formatted — log-injection safe). `-- sh -c '…'` keeps working.

Windows: candidates are PATHEXT-based; a bare name is a candidate only when it already carries a PATHEXT extension; `command_is_path` accepts exactly one normal path component (closes the drive-relative `C:tool` join escape).

## Review trail

3-round Claude panel (6 reviewers: spec, tests, quality, security, perf, docs — 26 findings fixed, incl. narrowing the lock-path delegation, the Windows bare-name gap, retry-exhaustion + launcher-hop + scan-order tests) + one-shot Codex terra cross-model gate (1 finding fixed: per-command 75 doc rows; 1 false positive dropped; 1 deferred to the fork issue). Every red observed before its green; mutation-checked where a red wasn't naturally reachable. `task --force verify` green (fmt, clippy -D warnings, build, 3700+ unit tests, 1865 acceptance tests against a live registry).

## Deferred (tracked as issues, linked after filing)

- Fork: per-chunk retry (re-send 3 MiB instead of the whole blob).
- Fork: `RegistryError` should carry the HTTP status — a 403/429 whose OCI envelope parses but carries an exotic code currently degrades to 69 (fail-safe: no retry, no credential re-send).
- Fork: credential forwarding on absolute `Location` redirects of the upload session (pre-existing, unchanged by this PR).
- `ClientError::Io` exhaustion on the lock path stays 69 (ambiguous local/socket faults; retry loop still retries them in-process).
- `patch test` acceptance twin for the 0644 case (unit-covered; CLI delta is one call site).
- Remaining per-command exit tables keep their generic 69 row; the canonical table carries the 75 contract and a global cross-reference (rows added where automation actually consumes them: add, lock, run).