### PR TITLE
feat(cli): --json is shorthand for --format json

### DIFF
--- a/.claude/rules/subsystem-cli.md
+++ b/.claude/rules/subsystem-cli.md
@@ -196,9 +196,11 @@ helpers in `conventions.rs` (`resolve_ci_arg`, `export_ci`).
   `--export-file` or stdout. No path channel: `PATH` and every path var are
   flattened (prepend package values to existing, join with `PATH_SEPARATOR`).
 
-## `ContextOptions.format` — `Option<Format>` (single format authority)
+## `ContextOptions.format` — flattened `options::Format` (single format authority)
 
-`ContextOptions.format` is `Option<options::Format>`. The single `Api::new` call site in `Context::try_init` applies `.unwrap_or(Format::Plain)`. This is the **only** place a format default is decided. **No subcommand declares its own `--format` or builds its own `Api`** — `ocx env` and `ocx package env` report through `context.api()` exactly like every other command (handshake §3 amended 2026-05-19: format is a context-only concern; the former env-specific `None → Json` divergence was removed).
+`ContextOptions.format` is a flattened `options::Format` group (`options/format.rs`) carrying `--format` plus its `--json` shorthand, resolved to `options::FormatMode` by `Format::mode()`. The single `Api::new` call site in `ContextOptions::build_api` calls it. That is the **only** place a format is decided; the two flags are private to the group, so nothing else can read them individually. **No subcommand declares its own `--format`/`--json` or builds its own `Api`** — `ocx env` and `ocx package env` report through `context.api()` exactly like every other command (handshake §3 amended 2026-05-19: format is a context-only concern; the former env-specific `None → Json` divergence was removed).
+
+`--json` and `--format` are `conflicts_with`, not last-wins: unlike the boolean toggles below they are two spellings of one value, so a combination that could disagree (`--format plain --json`) is exit 64 rather than a silent winner.
 
 ## Context Struct
 

--- a/crates/ocx_cli/src/api.rs
+++ b/crates/ocx_cli/src/api.rs
@@ -29,13 +29,13 @@ pub trait Printable: serde::Serialize {
 
 #[derive(Clone)]
 pub struct Api {
-    format: options::Format,
+    format: options::FormatMode,
     data: DataInterface,
     quiet: bool,
 }
 
 impl Api {
-    pub fn new(format: options::Format, data: DataInterface, quiet: bool) -> Self {
+    pub fn new(format: options::FormatMode, data: DataInterface, quiet: bool) -> Self {
         Self { format, data, quiet }
     }
 
@@ -51,14 +51,14 @@ impl Api {
             return Ok(());
         }
         match self.format {
-            options::Format::Json => item.print_json(&self.data)?,
-            options::Format::Plain => item.print_plain(&self.data),
+            options::FormatMode::Json => item.print_json(&self.data)?,
+            options::FormatMode::Plain => item.print_plain(&self.data),
         }
         Ok(())
     }
 
     pub fn is_json(&self) -> bool {
-        matches!(self.format, options::Format::Json)
+        matches!(self.format, options::FormatMode::Json)
     }
 }
 
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn report_skips_render_when_quiet() {
         let api = Api::new(
-            options::Format::Plain,
+            options::FormatMode::Plain,
             DataInterface::new(Printer::new(false, false)),
             true,
         );
@@ -119,7 +119,7 @@ mod tests {
     #[test]
     fn report_renders_plain_when_not_quiet() {
         let api = Api::new(
-            options::Format::Plain,
+            options::FormatMode::Plain,
             DataInterface::new(Printer::new(false, false)),
             false,
         );
@@ -132,7 +132,7 @@ mod tests {
     #[test]
     fn report_skips_json_when_quiet() {
         let api = Api::new(
-            options::Format::Json,
+            options::FormatMode::Json,
             DataInterface::new(Printer::new(false, false)),
             true,
         );

--- a/crates/ocx_cli/src/app/context_options.rs
+++ b/crates/ocx_cli/src/app/context_options.rs
@@ -83,12 +83,8 @@ pub struct ContextOptions {
     #[arg(long, conflicts_with = "remote", default_value_t = env::flag(env::keys::OCX_FROZEN, false))]
     pub frozen: bool,
 
-    /// Output format for stdout reports: `plain` (default) or `json`.
-    ///
-    /// Applies to every command; there is no per-command `--format`. The
-    /// `--shell[=NAME]` output of `env` / `package env` is unaffected.
-    #[arg(long, value_enum, value_name = "FORMAT")]
-    pub format: Option<options::Format>,
+    #[clap(flatten)]
+    pub format: options::Format,
 
     /// Suppress stdout report output (errors and progress on stderr remain).
     ///
@@ -150,7 +146,7 @@ impl ContextOptions {
     pub fn build_api(&self, color_config: ColorModeConfig) -> api::Api {
         let printer = Printer::new(color_config.stdout, color_config.stderr);
         let data = DataInterface::new(printer);
-        api::Api::new(self.format.unwrap_or(options::Format::Plain), data, self.quiet)
+        api::Api::new(self.format.mode(), data, self.quiet)
     }
 
     /// Builds the resolution-affecting policy snapshot forwarded to child ocx
@@ -187,5 +183,30 @@ impl ContextOptions {
             // (managed-config phase 4). The parser tier starts empty.
             managed_config_source: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_json(args: &[&str]) -> bool {
+        ContextOptions::try_parse_from(args)
+            .expect("args parse")
+            .build_api(ColorModeConfig {
+                stdout: false,
+                stderr: false,
+            })
+            .is_json()
+    }
+
+    /// The flattened `Format` group reaches the `Api` the context builds —
+    /// the wiring `options::format`'s own tests cannot see. Resolution
+    /// semantics are covered there.
+    #[test]
+    fn build_api_honors_the_flattened_format_group() {
+        assert!(!is_json(&["ocx"]), "default is plain");
+        assert!(is_json(&["ocx", "--json"]));
+        assert!(is_json(&["ocx", "--format", "json"]));
     }
 }

--- a/crates/ocx_cli/src/options.rs
+++ b/crates/ocx_cli/src/options.rs
@@ -20,7 +20,7 @@ pub use completion::Completion;
 pub use compression_level::CompressionLevel;
 pub use content_path::ContentPath;
 pub use env_override::EnvOverride;
-pub use format::Format;
+pub use format::{Format, FormatMode};
 pub use group_selection::GroupSelection;
 pub use identifier::Identifier;
 pub use platform::PlatformOption;

--- a/crates/ocx_cli/src/options/format.rs
+++ b/crates/ocx_cli/src/options/format.rs
@@ -3,9 +3,93 @@
 
 use clap::ValueEnum;
 
-#[derive(Clone, Copy, Debug, ValueEnum, Default)]
-pub enum Format {
+/// How stdout reports are rendered.
+///
+/// Flatten into a command with `#[clap(flatten)]` to add `--format` plus its
+/// `--json` shorthand. The two are `conflicts_with` rather than last-wins
+/// (unlike [`super::Pull`] / [`super::BinScan`]): they are not an on/off pair
+/// but two spellings of one value, so a combination that could disagree
+/// (`--format plain --json`) is a usage error instead of a silent winner.
+/// Resolve with [`Format::mode`] — never read the flags individually.
+#[derive(clap::Args, Clone, Debug, Default)]
+pub struct Format {
+    /// Output format for stdout reports: `plain` (default) or `json`.
+    ///
+    /// Applies to every command; there is no per-command `--format`. The
+    /// `--shell[=NAME]` output of `env` / `package env` is unaffected.
+    #[clap(long, value_enum, value_name = "FORMAT")]
+    format: Option<FormatMode>,
+
+    /// Shorthand for `--format json`.
+    ///
+    /// Conflicts with `--format`; pass one or the other.
+    #[clap(long, conflicts_with = "format")]
+    json: bool,
+}
+
+/// Resolved output format for stdout reports.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum FormatMode {
     Json,
     #[default]
     Plain,
+}
+
+impl Format {
+    /// Resolves the flags to a [`FormatMode`]. Neither flag yields `Plain`;
+    /// `--json` yields `Json`; `--format` yields whatever it names. The two
+    /// cannot both be present — clap rejects that at parse time.
+    pub fn mode(&self) -> FormatMode {
+        self.format
+            .or(self.json.then_some(FormatMode::Json))
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
+
+    use super::*;
+
+    #[derive(clap::Parser)]
+    struct Harness {
+        #[clap(flatten)]
+        format: Format,
+    }
+
+    fn mode(args: &[&str]) -> FormatMode {
+        let mut argv = vec!["harness"];
+        argv.extend_from_slice(args);
+        Harness::try_parse_from(argv).expect("parse").format.mode()
+    }
+
+    /// Neither flag → `Plain`.
+    #[test]
+    fn no_flags_yield_plain() {
+        assert_eq!(mode(&[]), FormatMode::Plain);
+    }
+
+    /// Both spellings of JSON resolve identically.
+    #[test]
+    fn json_flag_is_an_alias_for_format_json() {
+        assert_eq!(mode(&["--json"]), FormatMode::Json);
+        assert_eq!(mode(&["--format", "json"]), FormatMode::Json);
+    }
+
+    /// `--format plain` stays plain, and is not overridden by the default.
+    #[test]
+    fn explicit_plain_is_honored() {
+        assert_eq!(mode(&["--format", "plain"]), FormatMode::Plain);
+    }
+
+    /// The two spellings cannot disagree — clap rejects the combination.
+    #[test]
+    fn json_conflicts_with_format() {
+        for args in [["--json", "--format", "json"], ["--json", "--format", "plain"]] {
+            let mut argv = vec!["harness"];
+            argv.extend_from_slice(&args);
+            assert!(Harness::try_parse_from(argv).is_err(), "{args:?} must be rejected");
+        }
+    }
 }

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -30,6 +30,10 @@ Supported formats are:
 
 The available data depends on the command being executed.
 
+### `--json` {#arg-json}
+
+Shorthand for `--format json`. Conflicts with [`--format`](#arg-format) — pass one or the other, not both.
+
 ### `--offline` {#arg-offline}
 
 Disables all network access for this invocation. Tag→digest resolution must


### PR DESCRIPTION
Adds a root-level `--json` flag as an alias for `--format json`.

- Resolved in the single format-default site (`ContextOptions::build_api`) — no command sees a second spelling.
- `conflicts_with = "format"` so the two can never disagree (exit 64).
- Unit tests: default plain, both spellings yield JSON, conflict rejected.
- Documented in `reference/command-line.md` as `#arg-json`.

`task rust:verify` green (4146 passed).