### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.licenserc.toml
+++ b/.licenserc.toml
@@ -1,6 +1,8 @@
-inlineHeader = """
+[header]
+text = """
 SPDX-License-Identifier: Apache-2.0
 Copyright 2026 The OCX Authors"""
 
+[files]
 includes = ["crates/**/*.rs"]
 excludes = ["external/**"]


### PR DESCRIPTION
## Summary

- migrate the HawkEye configuration and integration to v7
- install HawkEye from its latest release without pinning the tool version
- validate the migrated configuration with HawkEye v7 (479 files, 0 changes, 0 conflicts, 0 unsupported)