### PR TITLE
feat(oci)!: declare plain HTTP per registry; refuse unsafe destinations with exit 65

### DIFF
--- a/.agents/memory/hex.md
+++ b/.agents/memory/hex.md
@@ -280,3 +280,66 @@ research-axes:
     findings to `<path>`, append each as you confirm it, reply with just the path" and it
     delivered a full report immediately. Make the file the deliverable in the first brief, not the
     third.
+- **2026-08-23 `/hex-execute high` on the ocx#272 review set (branch
+  `fix/oci-cross-host-upload-auth-272`).** Rebased onto a `main` that had moved 9 commits, then
+  applied the `/hex-review` actionable set across three parallel work packages.
+  - **`worker-researcher` has no Write tool — THIRD run in a row I briefed it with a file
+    deliverable.** It routed around the gap by pasting the whole report into its reply, which
+    works but defeats the file-first rule that exists precisely because workers go idle holding
+    their output. Stop writing "write your findings to `<path>`" for this role: either brief it
+    to reply inline, or spawn `worker-explorer`/`general-purpose` when the deliverable must
+    land on disk. The orchestrator persists its output by hand.
+  - **The `Cargo.lock` inside `external/rust-oci-client` is gitignored.** A review finding read
+    it as a committed second lockfile pinning `reqwest 0.13.2` against the workspace's 0.13.4
+    and graded it High. It is a local artefact — but the real consequence survived the regrade:
+    every mutation proof ever run *inside* the fork executed against a dependency graph that is
+    not what ships. Any fork work package must `cargo update` and assert the resolved version
+    before producing evidence. Check whether a lockfile is tracked before grading a lockfile
+    finding.
+  - **`rtk` rewrites `cargo test` output into its own summary line.** `cargo test | grep
+    '^test result'` returns silently empty — a passing-looking gate that never ran. Same class
+    as the greps already logged above; the tell was an empty section where a number belonged.
+    Run the command unfiltered, or match `rtk`'s own `cargo test: N passed` line.
+  - **A mutation that fails to red is a lead, not a weakness — and reading the dependency
+    settled it.** A 307-shaped redirect test stayed green when the guard was removed. The cause
+    was in `tower-http`'s `follow_redirect`: the body is *moved* into the inner service and
+    `reqwest::Body::wrap_stream` is not cloneable, so a 307 is never followed at all. A 303
+    zeroes the body before the take and IS followed, so only that shape discriminates. The
+    worker root-caused it out of the vendored source rather than concluding the guard was fine.
+  - **Ask the research axis "does refusing this break anyone?" before shipping a hard refusal.**
+    A behaviour change (any 3xx on an upload `PUT`/`PATCH` is now fatal) looked like a
+    compatibility risk worth deferring to review. One sonnet researcher retired it instead, and
+    turned up the strongest evidence in the run: `distribution` computes the blob digest
+    server-side as bytes stream past, so a registry *structurally cannot* delegate an upload via
+    redirect; and oras-go shipped CVE-2026-50151 for this exact function shape. Prior art beat
+    a review round.
+  - **The cross-model gate earned its keep a FIFTH time, and this was its clearest win yet.** Seven
+    Claude reviewers — including a security pass that enumerated all 24 sites where a
+    registry-supplied URL reaches a request builder — produced two Blocks between them. Codex
+    then found two more that every one of them had missed:
+    - **A zero-padded port defeated the system lock.** The round had just fixed the *case* axis
+      of the same comparison and nobody asked what else two spellings of one authority could do.
+      `OCX_INSECURE_REGISTRIES=registry.corp:05000` misses a lock on `:5000` at every string
+      compare, and `url::parse_port` accumulates `port*10+digit`, so the socket lands on 5000
+      anyway. Lesson: when you normalise one axis of an identity comparison, enumerate the other
+      axes in the same sitting — case, port spelling, default-port elision, trailing dot.
+    - **The read-site audit marked the session-opening POST "clean" for the same reason the
+      implementer did**: its `Location` is vetted afterwards. Both true, both missing that the
+      *request itself* gets relocated before any `Location` exists. Two independent reviewers
+      agreeing is not corroboration when they share the premise. Codex proved it pre-existing
+      with a `git diff` against the fork base rather than asserting it.
+  - **A fix round can staledate its own reviewers.** Two agents fixed the same seam from opposite
+    sides in one round: the fork replaced `attempt.stop()` with `attempt.error(...)` while the ocx
+    side was documenting `attempt.stop()`. The resulting comment described neither tree. When
+    parallel work packages share a seam, re-read the other side before accepting a comment about
+    it — and sequence the gitlink bump before, not after, the dependent write-up.
+  - **"Not on either branch" does not mean "unlanded".** An auditor reported the hawkeye-7 work
+    lost because its commit was on neither branch; `main` had done the same migration
+    independently and the effect was live. The decisive test is whether the *effect* is present
+    (one `git show` plus one gate line), never commit ancestry alone.
+  - **The best worker output of the run refused the task as briefed.** Told to close a finding,
+    wp1-fork instead proved the defended branch unreachable and fixed the *comment* that claimed
+    otherwise; told to wire `ssrf_guard`, wp2-crates refused with the caller list that would break
+    (56 acceptance files on loopback, every air-gapped registry) and the subsystem rule already
+    documenting it as design. Brief for the outcome, and say that a reasoned refusal with evidence
+    is an acceptable answer — otherwise the agent implements the wrong thing well.

--- a/.claude/artifacts/adr_managed_config_tier.md
+++ b/.claude/artifacts/adr_managed_config_tier.md
@@ -331,6 +331,62 @@ The payload cap is unchanged. `MAX_MANAGED_CONFIG_BYTES` is 64 KiB and a
 trusted root measures ~2 KB (`test/sigstore/trusted_root.json`), leaving ~60 KiB
 of headroom — the raise the plan proposed was unnecessary and was not made.
 
+## Amendment (2026-08-23) — `[registries.<name>].insecure` makes the managed tier a transport authority
+
+Closes the gap `[registries.<name>].insecure` (`fix/oci-cross-host-upload-auth-272`) opened in
+Decision I's coverage claim. Where this conflicts with earlier text, this amendment governs.
+
+**What changed.** Decision I says every section outside `[managed]` "merge[s] normally; loosening
+structurally blocked by G." Decision G's enumeration (`[patches]`, `[managed]`, `RegistryDefaults`,
+`MirrorConfig`) never included `[registries.<name>]` — that table carries its own per-entry
+`system_locked`, not one of G's four whole-table locks, and a per-entry lock only fires for a name
+the system tier has already written. `insecure` (`crates/ocx_lib/src/config/registry.rs`) is the
+first field on that table where the *absence* of a system-tier entry is itself the loosening: a
+managed payload can declare `[registries."<any-host>"] insecure = true` for a host the system tier
+never named, and there is no entry yet for a lock to attach to. Decision I's clause held for every
+table G actually covers; it was never true for `[registries.<name>]`, and `insecure` is what turns
+that gap from theoretical into exploitable — managed-tier publish access now reaches index, mirror,
+and ordinary registry transport for any host, fleet-wide, on the next `ocx config update`.
+
+**Decision: keep the union; do not carve the managed tier out of `insecure`.**
+
+- *Considered and rejected* — deny `[registries.<name>].insecure` from the managed tier
+  specifically. `system_locked` is the only tier-restriction primitive this config tree has, and it
+  restricts a lower tier *against a value the higher tier already set*, never *a specific key
+  regardless of whether the higher tier said anything*. Building the latter is new config-system
+  surface for one field. It also costs the tier's own target user: an air-gapped fleet whose
+  registry is genuinely plain HTTP is exactly who `[managed]` exists to serve, and forcing that
+  fleet to provision `OCX_INSECURE_REGISTRIES` on every host to route around a restriction the tier
+  itself would impose defeats the point of centralizing the config.
+- *Chosen* — keep `insecure` in the union domain, and give the system tier a subtractive lever.
+  The property worth keeping is the one `insecure_hosts`'s own module doc already states: no
+  source can take a host back out of the set, so there is no four-way truth table
+  (unset/true/false × env-present/absent) for a reader to resolve. Widening that from zero
+  exceptions to exactly one — an explicit system-scope `insecure = false`, which also subtracts
+  from `OCX_INSECURE_REGISTRIES` — preserves order-independence (a lock means "this source is
+  final," not "last tier wins") while giving the platform engineer the only lever
+  `[registries.<name>]` needs: pre-declare the hosts that must never go plaintext.
+
+**Residual exposure — recorded, not softened.** The lever protects only a host the system tier
+thought to name. A managed-config publisher — compromised or malicious — can still self-authorize
+plaintext transport for any host the system tier has not already locked to `insecure = false`, and
+that authorization reaches index, mirror, and ordinary registry traffic identically
+(`crates/ocx_lib/src/config/insecure.rs`). This is a deliberate acceptance, not an oversight:
+`[managed]` is sold on fleet-wide policy distribution (`product-context.md` differentiator #11),
+and denying it this key outright would cost every legitimately-plaintext fleet the provisioning
+step this tier exists to remove. An operator who wants the hard guarantee enumerates the hosts and
+locks them at system scope; an operator who does not is trusting the managed-config registry the
+same way they already trust it for `[mirrors]`/`[patches]`/`[registry]`.
+
+**Scope note — the fetch client is a separate decision.** Whether a managed payload's own
+`insecure` entries may license plaintext for *fetching the next managed-config snapshot* is
+governed by the mirror-posture decision — `build_managed_config_client` in
+`crates/ocx_cli/src/app/context.rs`, cited in code as `adr_managed_config_tier.md`, "Mirror
+posture (AMENDED)" — and its C6 driver — the payload must never be able to redirect the tier
+that fetched it, one-hop. That invariant is unchanged by this amendment: the managed-config
+fetch client's transport allowance must still derive from the local-only view, never the
+merged view `insecure` now travels on for everything else.
+
 ## Links
 
 - Plan: `.claude/state/plans/plan_managed_config.md`

--- a/.claude/artifacts/research_cli_login_patterns.md
+++ b/.claude/artifacts/research_cli_login_patterns.md
@@ -155,6 +155,16 @@ or on not-logged-in no-op:
 
 ## Recommended `ocx login` UX Spec
 
+> **Superseded (2026-08-23, ocx#272).** The `--insecure` flag below was never shipped as a
+> per-invocation flag. Plain-HTTP eligibility is decided once, for the whole binary, through
+> `[registries.<name>].insecure` (config) unioned with `OCX_INSECURE_REGISTRIES` (env), resolved
+> through one shared predicate every registry-accessing command consults — `ocx login` included.
+> A hidden `--insecure` flag existed on `ocx login` as a no-op prior to `31f57854` and was removed
+> in that commit. See `website/src/docs/reference/configuration.md#keys-registries-insecure`.
+> The survey rows below (flag table, exit table, comparative table) are left as recorded — they
+> describe what the surveyed tools do and what was proposed at research time, not current OCX
+> behavior.
+
 ### Synopsis
 
 ```

--- a/.claude/rules/quality-security.md
+++ b/.claude/rules/quality-security.md
@@ -69,6 +69,7 @@ Recurring attack surfaces in OCX codebase. Use as STRIDE scoping checklist for a
 - Auth chain: `OCX_AUTH_<REGISTRY>_*` env vars → Docker credentials (`~/.docker/config.json`)
 - Credentials never logged or in error messages
 - `OCX_INSECURE_REGISTRIES` (HTTP-only) only for localhost/test registries
+- `[registries.<name>] insecure` config key — unions with `OCX_INSECURE_REGISTRIES`; only an explicit system-scope `insecure = false` subtracts from that union. Distributable via the `[managed]` tier: check `system_locked` enforcement and managed-tier propagation when auditing this surface
 
 ### Registry Communication
 - TLS verification for all registry connections (except insecure registries)

--- a/.claude/rules/subsystem-cli-commands.md
+++ b/.claude/rules/subsystem-cli-commands.md
@@ -179,7 +179,7 @@ All `ConfigGroup` variants are exempt from the required-snapshot gate; `config s
 
 | Command | Purpose | Key Flags |
 |---------|---------|-----------|
-| `login [REGISTRY]` | Authenticate to a registry (verifies credentials against the registry before storing; `--no-verify` opts out) | `-u/--username`, `--password-stdin`, `--verify`/`--no-verify`, `--insecure` |
+| `login [REGISTRY]` | Authenticate to a registry (verifies credentials against the registry before storing; `--no-verify` opts out) | `-u/--username`, `--password-stdin`, `--verify`/`--no-verify`, `--allow-insecure-store` |
 | `logout [REGISTRY]` | Remove stored credentials | — |
 | `clean` | GC unreferenced objects | `--dry-run`, `--force` |
 | `shell completion` | Generate shell completions | `--shell` |

--- a/crates/ocx_cli/src/api/data/config_test.rs
+++ b/crates/ocx_cli/src/api/data/config_test.rs
@@ -58,6 +58,16 @@ pub struct ConfigTestData {
     pub(crate) registries: Vec<String>,
     /// Effective `[mirrors."<host>"]` keys, sorted.
     pub(crate) mirrors: Vec<String>,
+    /// Hosts this machine would contact over plain HTTP once the candidate is
+    /// adopted, sorted — the candidate's own `[registries.<name>] insecure`
+    /// entries unioned with this machine's `OCX_INSECURE_REGISTRIES`, less
+    /// anything the system scope locked shut.
+    ///
+    /// The gate already computes this set to validate the payload's mirrors;
+    /// reporting it is what makes "did my entry take effect?" a one-command
+    /// question. A key that is not an exact `host[:port]` grants nothing and
+    /// simply will not appear here.
+    pub(crate) plain_http: Vec<String>,
     /// Effective `[patches]` tier, defaults applied.
     ///
     /// Same precedence every ocx invocation uses: the merged config tier when
@@ -85,6 +95,7 @@ impl ConfigTestData {
         preview: ManagedConfigPreview,
         patches: Option<ocx_lib::ResolvedPatchConfig>,
         managed: Option<&ocx_lib::ResolvedManagedConfig>,
+        plain_http: Vec<String>,
     ) -> Self {
         let effective = preview.effective;
         Self {
@@ -93,6 +104,7 @@ impl ConfigTestData {
             registry_default: effective.resolved_default_registry().map(str::to_owned),
             registries: sorted_keys(effective.registries.as_ref()),
             mirrors: sorted_keys(effective.mirrors.as_ref()),
+            plain_http: sorted(plain_http),
             patches: patches.map(|patches| PatchesView {
                 registry: patches.registry,
                 path_template: patches.path_template,
@@ -105,6 +117,12 @@ impl ConfigTestData {
             unknown_keys: preview.unknown_keys,
         }
     }
+}
+
+/// A report never inherits the order its input happened to arrive in.
+fn sorted(mut values: Vec<String>) -> Vec<String> {
+    values.sort_unstable();
+    values
 }
 
 /// Sorted keys of an optional config table — the order a `HashMap` yields is
@@ -139,6 +157,9 @@ impl Printable for ConfigTestData {
         for host in &self.mirrors {
             row("Mirrors".into(), host.clone());
         }
+        for host in &self.plain_http {
+            row("Plain HTTP".into(), host.clone());
+        }
         if let Some(patches) = &self.patches {
             row("Patch registry".into(), patches.registry.clone());
             row("Patch path".into(), patches.path_template.clone());
@@ -153,5 +174,83 @@ impl Printable for ConfigTestData {
         }
 
         printer.print_table(&["Field".into(), "Value".into()], &[fields, values]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn preview_of(payload: &str) -> ManagedConfigPreview {
+        ocx_lib::managed_config::preview_managed_config(
+            payload.as_bytes(),
+            ocx_lib::Config::default(),
+            &ocx_lib::Config::default(),
+        )
+        .expect("a well-formed candidate previews")
+    }
+
+    fn report(payload: &str, env_insecure: &[String]) -> ConfigTestData {
+        let preview = preview_of(payload);
+        let plain_http = ocx_lib::insecure_hosts(&preview.effective, env_insecure);
+        ConfigTestData::new(
+            std::path::Path::new("/tmp/candidate.toml"),
+            preview,
+            None,
+            None,
+            plain_http,
+        )
+    }
+
+    /// The candidate's OWN `[registries]` half must reach the plain-HTTP set —
+    /// that is the whole point of previewing a payload before a fleet adopts
+    /// it, and both existing acceptance cases drive the env half only.
+    ///
+    /// Asserted against the same payload minus the entry, with the environment
+    /// empty in both: without the pair, an inherited `OCX_INSECURE_REGISTRIES`
+    /// would make the green indistinguishable from the entry doing nothing.
+    #[test]
+    fn the_candidates_own_insecure_entry_reaches_the_reported_plain_http_set() {
+        let declared = report("[registries.\"mirror.corp:5000\"]\ninsecure = true\n", &[]);
+        assert_eq!(declared.plain_http, vec!["mirror.corp:5000".to_string()]);
+
+        let undeclared = report("[registries.\"mirror.corp:5000\"]\n", &[]);
+        assert!(
+            undeclared.plain_http.is_empty(),
+            "an entry that never states `insecure` licenses nothing"
+        );
+    }
+
+    /// A key that is not an exact `host[:port]` grants nothing at the transport,
+    /// and the report is where that becomes visible before it surfaces as an
+    /// opaque TLS error mid-install. Both rows list it verbatim — it IS a config
+    /// entry, and the set is exactly what the transport will compare against — so
+    /// the signal is seeing `private` where `private.corp:5000` was meant, not the
+    /// two rows disagreeing.
+    #[test]
+    fn a_wrongly_spelled_key_is_reported_verbatim_so_the_operator_can_see_it() {
+        let data = report("[registries.private]\ninsecure = true\n", &[]);
+
+        assert_eq!(data.registries, vec!["private".to_string()]);
+        assert_eq!(
+            data.plain_http,
+            vec!["private".to_string()],
+            "the set is the key verbatim — the report shows exactly what the transport will compare"
+        );
+    }
+
+    /// The machine's environment composes with the candidate, and the report
+    /// is sorted rather than inheriting the order the two sources arrived in.
+    #[test]
+    fn the_reported_set_unions_the_environment_and_is_sorted() {
+        let data = report(
+            "[registries.\"zeta.corp:5000\"]\ninsecure = true\n",
+            &["alpha.corp".to_string()],
+        );
+
+        assert_eq!(
+            data.plain_http,
+            vec!["alpha.corp".to_string(), "zeta.corp:5000".to_string()]
+        );
     }
 }

--- a/crates/ocx_cli/src/app/context.rs
+++ b/crates/ocx_cli/src/app/context.rs
@@ -85,6 +85,11 @@ pub struct Context {
     /// consumer (the required-gate below, `config update`, the refresh hook)
     /// agrees on the same value.
     managed_config_env_override: Option<String>,
+    /// Every host that may be contacted over plain HTTP: the union of
+    /// `[registries."<name>"].insecure` and `OCX_INSECURE_REGISTRIES`, resolved
+    /// once so the registry protocol, the mirror-role gate, the index base URL
+    /// and `ocx login`'s probe cannot disagree about a host.
+    insecure_hosts: Vec<String>,
     /// The on-disk managed-config snapshot, read once at `try_init` and
     /// **identity-gated** there (W2): `Some` only when it matches the
     /// effective source via the shared `snapshot_matches_source` predicate.
@@ -95,7 +100,8 @@ pub struct Context {
 /// The two `[managed]` tier gates `Context::try_init` needs, wrapped in a named
 /// struct so the two adjacent `bool`s can never be transposed at the call site.
 pub struct ManagedConfigGate {
-    /// Gates the `[managed]` tier's required-snapshot check (ADR Decision E,
+    /// Gates the `[managed]` tier's required-snapshot check
+    /// (`adr_managed_config_tier.md` Decision E,
     /// criterion 6): `true` for ordinary commands (fails closed with
     /// `SnapshotRequired`, exit 78, when `required = true` and no matching
     /// snapshot exists); `false` for `ocx config update` and the `self`/static
@@ -186,6 +192,19 @@ impl Context {
         // AND payload parse, as observed by the tier that did the folding.
         let managed_snapshot_state = loaded_config.managed_snapshot_state;
 
+        // Which hosts may be reached over plain HTTP, resolved ONCE: the union
+        // of the `[registries."<name>"].insecure` entries and the inherited
+        // `OCX_INSECURE_REGISTRIES`, less anything the system scope locked shut.
+        // Every gate below is handed this same set — the OCI client's protocol
+        // choice, the mirror-role gate, each index base URL, and `ocx login`'s
+        // probe — so one resolution answers for all of them.
+        //
+        // They compare it against their own resolved host string, and those
+        // strings are not all the same: see `insecure_hosts`' doc for the one
+        // name (Docker Hub) where they diverge, and why that divergence is
+        // closed in the safe direction.
+        let insecure_hosts = ocx_lib::insecure_hosts(&config, &env::insecure_registries());
+
         // Resolve the per-host mirror map once via the lib resolver
         // (`ocx_lib::resolve_mirror_map`): `[mirrors]` config merged with the
         // inherited `OCX_MIRRORS` env (env wins per-host key), every entry parsed
@@ -196,8 +215,8 @@ impl Context {
         // and a forwarded child re-parses + re-validates it the same way a
         // `[mirrors]` TOML entry would. The lib `thiserror` error is re-wrapped
         // into `anyhow` at this CLI boundary.
-        let resolved_mirrors = ocx_lib::resolve_mirror_map(&config, env::mirrors()?, &env::insecure_registries())
-            .map_err(anyhow::Error::new)?;
+        let resolved_mirrors =
+            ocx_lib::resolve_mirror_map(&config, env::mirrors()?, &insecure_hosts).map_err(anyhow::Error::new)?;
         let mirror_map = oci::MirrorMap::new(resolved_mirrors.registry.clone());
 
         let printer = Printer::new(color_config.stdout, color_config.stderr);
@@ -210,12 +229,14 @@ impl Context {
         // divergence).
         let api = options.build_api(color_config);
 
-        // Explicit builder (not `from_env_with_progress`) so the config-derived
+        // Explicit builder so the config-derived
         // `MirrorMap` is threaded in; `OCX_MIRRORS` env precedence is already
         // folded into `mirror_map` by `resolve_mirrors`. A plain-HTTP mirror
-        // requires its host in `OCX_INSECURE_REGISTRIES` (the mirror host is
-        // what gets contacted) — composition with the existing plain-HTTP set,
-        // no implicit scheme-driven opt-out (ADR F2).
+        // requires its host declared insecure (the mirror host is what gets
+        // contacted) — either `[registries."<host>"] insecure = true` or
+        // `OCX_INSECURE_REGISTRIES`, unioned; composition with the existing
+        // plain-HTTP set, no implicit scheme-driven opt-out
+        // (`adr_oci_registry_mirror.md`, Implementation Plan step 3 "Auth + insecure").
         //
         // `verify` reads the artifact + signature from the registry in every
         // mode (its `--offline` scopes to Sigstore trust services, not the
@@ -229,7 +250,7 @@ impl Context {
             (None, None)
         } else {
             let client = registry_client_cell
-                .get_or_init(|| build_registry_client(&mirror_map, &progress))
+                .get_or_init(|| build_registry_client(&mirror_map, &progress, &insecure_hosts))
                 .clone();
             (
                 Some(client.clone()),
@@ -279,7 +300,7 @@ impl Context {
             local_only_config.mirrors.as_ref(),
             &resolved_mirrors.index,
             &mirror_map,
-            &env::insecure_registries(),
+            &insecure_hosts,
             &progress,
         )?;
         let (mode, sources) = Self::chain_mode_and_sources(oci_index.as_ref(), &index_sources, online_mode);
@@ -382,22 +403,18 @@ impl Context {
         let managed_config_client = if options.offline || !needs_managed_config_client {
             None
         } else {
-            let local_resolved_mirrors =
-                ocx_lib::resolve_mirror_map(&local_only_config, env::mirrors()?, &env::insecure_registries())
-                    .map_err(anyhow::Error::new)?;
-            let local_mirror_map = oci::MirrorMap::new(local_resolved_mirrors.registry);
-            Some(
-                oci::ClientBuilder::new()
-                    .plain_http_registries(env::insecure_registries())
-                    .mirrors(local_mirror_map)
-                    .progress(progress.clone())
-                    .build(),
-            )
+            Some(build_managed_config_client(
+                &local_only_config,
+                env::mirrors()?,
+                &env::insecure_registries(),
+                &progress,
+            )?)
         };
 
-        // ADR Decision E: the `[managed]` target is resolved ONCE in the loader
-        // (from the local-only view — the payload can never redirect the tier
-        // that fetched it) and threaded here. Reuse it. The loader swallows a
+        // `adr_managed_config_tier.md` Decision A (identity-gated merge): the
+        // `[managed]` target is resolved ONCE in the loader, from the local-only
+        // view — the payload can never redirect the tier that fetched it — and
+        // threaded here. Reuse it. The loader swallows a
         // resolution ERROR for its best-effort fold, so a configured-but-
         // unresolvable seed re-resolves HERE only to surface the authoritative
         // typed error (malformed seed/env ref, bad interval → exit 78); the
@@ -474,7 +491,7 @@ impl Context {
             None
         } else {
             let client = registry_client_cell
-                .get_or_init(|| build_registry_client(&mirror_map, &progress))
+                .get_or_init(|| build_registry_client(&mirror_map, &progress, &insecure_hosts))
                 .clone();
             build_auto_verify(
                 operator_policies,
@@ -554,6 +571,7 @@ impl Context {
             config_overlay,
             local_mirrors: local_only_config.mirrors.clone(),
             managed_config_env_override,
+            insecure_hosts,
             managed_config_snapshot,
         })
     }
@@ -841,6 +859,14 @@ impl Context {
         self.config_trust.sigstore.as_ref()
     }
 
+    /// Hosts this invocation may contact over plain HTTP — the resolved union
+    /// of `[registries."<name>"].insecure` and `OCX_INSECURE_REGISTRIES`.
+    /// Commands that build their own registry connection take this rather than
+    /// re-deriving it, so every path agrees on the same set.
+    pub fn insecure_hosts(&self) -> &[String] {
+        &self.insecure_hosts
+    }
+
     pub fn file_structure(&self) -> &file_structure::FileStructure {
         &self.file_structure
     }
@@ -930,7 +956,7 @@ impl Context {
     /// trust-services network and require cached/supplied trust material.
     pub fn verify_client(&self) -> &oci::Client {
         self.registry_client_cell
-            .get_or_init(|| build_registry_client(&self.mirror_map, &self.progress))
+            .get_or_init(|| build_registry_client(&self.mirror_map, &self.progress, &self.insecure_hosts))
     }
 }
 
@@ -968,12 +994,48 @@ fn trusted_hosts_by_namespace(config: &ocx_lib::Config) -> std::collections::Has
 fn build_registry_client(
     mirror_map: &oci::MirrorMap,
     progress: &ocx_lib::cli::progress::ProgressManager,
+    insecure_hosts: &[String],
 ) -> oci::Client {
     oci::ClientBuilder::new()
-        .plain_http_registries(env::insecure_registries())
+        .plain_http_registries(insecure_hosts.to_vec())
         .mirrors(mirror_map.clone())
         .progress(progress.clone())
         .build()
+}
+
+/// Builds the client that FETCHES the managed-config payload.
+///
+/// Every input is the LOCAL-ONLY view or the raw environment — the merged
+/// config, and the process-wide `insecure_hosts` derived from it, are
+/// deliberately out of scope here rather than merely unused.
+/// `adr_managed_config_tier.md`, "Mirror posture (AMENDED)": the managed
+/// fetch's route derives from local tiers only, so the payload can never
+/// influence its own refresh route — and dropping TLS *is* a redirection on
+/// the transport axis. A managed snapshot declaring
+/// `[registries."<its own host>"] insecure = true` would otherwise downgrade
+/// the fetch of the NEXT snapshot to plaintext, which is exactly the
+/// self-authorization the mirror half of this client was already written to
+/// prevent.
+///
+/// # Errors
+///
+/// Propagates [`ocx_lib::MirrorConfigError`] when the
+/// local-only `[mirrors]` plus the forwarded `OCX_MIRRORS` do not resolve —
+/// including an `http://` mirror this view licenses nothing for.
+fn build_managed_config_client(
+    local_only_config: &ocx_lib::Config,
+    env_mirrors: Vec<(String, ocx_lib::MirrorConfig)>,
+    env_insecure_registries: &[String],
+    progress: &ocx_lib::cli::progress::ProgressManager,
+) -> anyhow::Result<oci::Client> {
+    let insecure_hosts = ocx_lib::insecure_hosts(local_only_config, env_insecure_registries);
+    let mirrors =
+        ocx_lib::resolve_mirror_map(local_only_config, env_mirrors, &insecure_hosts).map_err(anyhow::Error::new)?;
+    Ok(oci::ClientBuilder::new()
+        .plain_http_registries(insecure_hosts)
+        .mirrors(oci::MirrorMap::new(mirrors.registry))
+        .progress(progress.clone())
+        .build())
 }
 
 /// Build the shared policy-gated auto-verify inputs, or `None` when no operator
@@ -1939,6 +2001,53 @@ mod tests {
             mode,
             index::ChainMode::Offline,
             "offline (oci_index=None) must produce ChainMode::Offline even when frozen=true"
+        );
+    }
+
+    /// The managed-config FETCH client must not take its plain-HTTP allowance
+    /// from the payload it is about to fetch.
+    ///
+    /// Asserted as a pair, because a one-sided refusal would also hold if the
+    /// mirror gate were simply broken: the SAME mirror, the SAME env, refused
+    /// against the local-only view and allowed against the merged one. That is
+    /// what makes the refusal a property of *which config was consulted* — and
+    /// the merged view is exactly what the process-wide `insecure_hosts` is
+    /// built from, so it is the mistake this guards against, spelled out.
+    #[test]
+    fn the_managed_fetch_client_ignores_a_plain_http_allowance_the_payload_declared() {
+        let host = "mirror.corp:5000";
+        let mirrors = || {
+            vec![(
+                "ghcr.io".to_string(),
+                ocx_lib::MirrorConfig {
+                    registry: Some(format!("http://{host}")),
+                    ..Default::default()
+                },
+            )]
+        };
+        let with_allowance = |granted: bool| {
+            let entry = ocx_lib::RegistryConfig {
+                insecure: granted.then_some(true),
+                ..Default::default()
+            };
+            ocx_lib::Config {
+                registries: Some(std::collections::HashMap::from([(host.to_string(), entry)])),
+                ..Default::default()
+            }
+        };
+        let progress = ocx_lib::cli::progress::ProgressManager::disabled();
+
+        let refused = build_managed_config_client(&with_allowance(false), mirrors(), &[], &progress);
+        assert!(
+            refused.is_err(),
+            "the payload's own allowance is not in scope for the tier that fetches it"
+        );
+
+        let allowed = build_managed_config_client(&with_allowance(true), mirrors(), &[], &progress);
+        assert!(
+            allowed.is_ok(),
+            "the same mirror IS allowed once the view actually handed to the builder grants it: {:?}",
+            allowed.err()
         );
     }
 }

--- a/crates/ocx_cli/src/command/config_test.rs
+++ b/crates/ocx_cli/src/command/config_test.rs
@@ -34,11 +34,15 @@ impl ConfigTestArgs {
         // the effective merge — a payload that parses can still be one no
         // machine can start under (a plain-HTTP mirror, an empty patch
         // registry). Catching that here is the point of previewing.
-        ocx_lib::resolve_mirror_map(
-            &preview.effective,
-            ocx_lib::env::mirrors()?,
-            &ocx_lib::env::insecure_registries(),
-        )?;
+        // The plain-HTTP set comes from the CANDIDATE's own `[registries]`
+        // entries unioned with this machine's env — a payload that declares
+        // `insecure = true` for its own mirror host must pass its own gate.
+        let insecure_hosts = ocx_lib::insecure_hosts(&preview.effective, &ocx_lib::env::insecure_registries());
+        ocx_lib::resolve_mirror_map(&preview.effective, ocx_lib::env::mirrors()?, &insecure_hosts)?;
+        // Reported, not just consumed: a `[registries.<name>]` key that is not
+        // an exact `host[:port]` grants nothing and fails much later as an
+        // opaque TLS error, so the one command whose job is previewing a
+        // config has to answer "did my entry take effect?".
         // Same config-tier-then-env precedence `Context::try_init` uses, so the
         // report matches what the machine actually resolves.
         let patches = match ocx_lib::resolve_patch_config(&preview.effective)? {
@@ -49,9 +53,13 @@ impl ConfigTestArgs {
         // `[managed]` was already refused above.
         let managed = ocx_lib::resolve_managed_target(context.config(), context.managed_config_env_override())?;
 
-        context
-            .api()
-            .report(&ConfigTestData::new(&self.config, preview, patches, managed.as_ref()))?;
+        context.api().report(&ConfigTestData::new(
+            &self.config,
+            preview,
+            patches,
+            managed.as_ref(),
+            insecure_hosts,
+        ))?;
 
         Ok(ExitCode::SUCCESS)
     }

--- a/crates/ocx_cli/src/command/login.rs
+++ b/crates/ocx_cli/src/command/login.rs
@@ -29,14 +29,12 @@ pub struct Login {
     #[clap(long = "password-stdin")]
     password_stdin: bool,
 
-    /// Allow plain HTTP for the registry (overrides default HTTPS).
-    /// Reserved for the future `--verify` Ping path - currently no-op in v1.
-    #[clap(long = "insecure", hide = true)]
-    #[allow(dead_code)]
-    insecure: bool,
-
     /// Allow plaintext fallback to `~/.docker/config.json` `auths` when no native helper
     /// is configured. Default: refuse, exit `ConfigError(78)` with install hint.
+    ///
+    /// Governs credential STORAGE, not transport. It does not enable plain HTTP; to
+    /// reach a registry over HTTP, set `insecure = true` under `[registries."<host>"]`
+    /// or add the host to `OCX_INSECURE_REGISTRIES`.
     #[clap(long = "allow-insecure-store")]
     allow_insecure_store: bool,
 
@@ -147,8 +145,12 @@ impl Login {
         // `--no-verify` swaps in the no-op Ping to store without a round-trip.
         // Either way the security invariant ("Ping failure ⇒ no put") holds,
         // proven by `MockPing` unit tests in `auth/login.rs`.
+        // The probe must reach the registry over the same scheme every other
+        // command would, so it takes the resolved plain-HTTP set rather than
+        // deciding for itself.
+        let verifying_ping = OciClientPing::new(context.insecure_hosts().to_vec());
         let ping: &dyn RegistryPing = if self.verify.enabled() {
-            &OciClientPing
+            &verifying_ping
         } else {
             &NoopPing
         };
@@ -239,6 +241,46 @@ mod tests {
         );
     }
 
+    /// `--insecure` was removed: it was hidden, had no effect, and let one
+    /// command disagree with every other about a host's scheme. Nothing else
+    /// asserts the removal at either layer — the flag was deleted from
+    /// `login_clap_accepts_full_invocation` with no negative twin, so without
+    /// this a reintroduction is silent.
+    #[test]
+    fn login_clap_rejects_the_removed_insecure_flag() {
+        assert!(
+            Login::try_parse_from(["login", "--insecure", "ghcr.io"]).is_err(),
+            "--insecure was removed; it must be an unknown-argument usage error (exit 64)"
+        );
+    }
+
+    /// The confusable that survives. `--allow-insecure-store` is what clap's
+    /// edit distance suggests when `--insecure` is rejected, and following that
+    /// tip weakens credential storage without granting plain HTTP — so its help
+    /// has to say what it is not.
+    #[test]
+    fn allow_insecure_store_help_disclaims_transport() {
+        let cmd = Login::command();
+        let arg = cmd
+            .get_arguments()
+            .find(|a| a.get_id() == "allow_insecure_store")
+            .expect("allow_insecure_store arg present");
+        let help = arg
+            .get_long_help()
+            .or_else(|| arg.get_help())
+            .expect("the flag must carry help")
+            .to_string();
+
+        assert!(
+            help.contains("not transport"),
+            "the help must disclaim transport, since clap suggests this flag for the removed --insecure: {help}"
+        );
+        assert!(
+            help.contains("OCX_INSECURE_REGISTRIES"),
+            "the help must point at what DOES enable plain HTTP: {help}"
+        );
+    }
+
     #[test]
     fn login_clap_accepts_minimal_invocation() {
         Login::try_parse_from(["login", "ghcr.io"]).expect("bare positional must parse");
@@ -251,7 +293,6 @@ mod tests {
             "-u",
             "user",
             "--password-stdin",
-            "--insecure",
             "--allow-insecure-store",
             "--no-verify",
             "ghcr.io",

--- a/crates/ocx_cli/src/command/package_announce.rs
+++ b/crates/ocx_cli/src/command/package_announce.rs
@@ -253,7 +253,7 @@ impl PackageAnnounce {
 /// runs. Mirrors and reuses the same mirror-map / plain-HTTP resolution the
 /// CLI's own remote client goes through.
 fn announce_client(context: &crate::app::Context, trusted_hosts: Vec<String>) -> anyhow::Result<oci::Client> {
-    let insecure_hosts = ocx_lib::env::insecure_registries();
+    let insecure_hosts = context.insecure_hosts().to_vec();
     let resolved_mirrors = ocx_lib::resolve_mirror_map(context.config(), ocx_lib::env::mirrors()?, &insecure_hosts)?;
     let mirrors = oci::MirrorMap::new(resolved_mirrors.registry);
     Ok(oci::ClientBuilder::new()

--- a/crates/ocx_lib/src/auth/error.rs
+++ b/crates/ocx_lib/src/auth/error.rs
@@ -34,6 +34,25 @@ pub enum AuthError {
     /// Registry returned 401 for the supplied credentials during login-time verification.
     #[error("registry '{registry}' rejected credentials")]
     LoginRejected { registry: String },
+    /// The login-time probe never completed, so the credential was never judged.
+    ///
+    /// Split from [`Self::LoginRejected`] because a TLS handshake against a
+    /// plain-HTTP registry, a DNS failure and a genuine 401 demand three
+    /// different actions. Reporting all three as "rejected credentials" at
+    /// exit 80 routes a CI script into the refresh-credentials branch, whose
+    /// retry then fails identically forever — and tells a human to rotate a
+    /// secret that never left the machine.
+    ///
+    /// The exit code is delegated to the wrapped
+    /// [`ClientError`](crate::oci::client::error::ClientError), so the probe
+    /// classifies the same way the rest of the binary classifies the same wire
+    /// failure.
+    #[error("could not verify credentials against registry '{registry}'")]
+    ProbeFailed {
+        registry: String,
+        #[source]
+        source: Box<crate::oci::client::error::ClientError>,
+    },
 }
 
 impl ClassifyExitCode for AuthError {
@@ -51,6 +70,10 @@ impl ClassifyExitCode for AuthError {
             },
             Self::NoCredentialStoreAvailable => ExitCode::ConfigError,
             Self::LoginRejected { .. } => ExitCode::AuthError,
+            // Provenance only: the probe adds context, the wire failure keeps
+            // its own code. Anything else would put a second taxonomy for the
+            // same failures beside the one every other command uses.
+            Self::ProbeFailed { source, .. } => return source.classify(),
         })
     }
 }
@@ -125,6 +148,42 @@ mod tests {
             registry: "ghcr.io".into(),
         };
         assert_eq!(ec(e), Some(ExitCode::AuthError));
+    }
+
+    /// A probe that never completed must NOT read as 80. Asserting two
+    /// different wrapped failures is what pins the delegation — a single case
+    /// passes just as well against a hardcoded constant — and asserting
+    /// `!= AuthError` is what pins the split from `LoginRejected`, which is the
+    /// bug: exit 80 routes a CI script into "refresh credentials", and the
+    /// retry with a fresh credential fails identically forever.
+    #[test]
+    fn a_failed_probe_delegates_its_exit_code_and_never_reads_as_rejected_credentials() {
+        use crate::oci::client::error::ClientError;
+
+        let probe = |source: ClientError| AuthError::ProbeFailed {
+            registry: "localhost:5000".into(),
+            source: Box::new(source),
+        };
+
+        assert_eq!(
+            ec(probe(ClientError::RegistryTransient(Box::new(std::io::Error::other(
+                "connect refused"
+            ))))),
+            Some(ExitCode::TempFail),
+        );
+        assert_eq!(
+            ec(probe(ClientError::UnsafeDestination(Box::new(std::io::Error::other(
+                "plaintext realm"
+            ))))),
+            Some(ExitCode::DataError),
+        );
+        assert_ne!(
+            ec(probe(ClientError::RegistryTransient(Box::new(std::io::Error::other(
+                "connect refused"
+            ))))),
+            Some(ExitCode::AuthError),
+            "the credential was never judged, so this must not classify as an auth failure"
+        );
     }
 
     #[test]

--- a/crates/ocx_lib/src/auth/login.rs
+++ b/crates/ocx_lib/src/auth/login.rs
@@ -21,30 +21,80 @@ use crate::oci;
 #[async_trait::async_trait]
 pub trait RegistryPing: Send + Sync {
     /// Probe the registry with `cred` applied. Returns `Ok(())` on a
-    /// successful authenticated response (2xx) and `Err` for any failure
-    /// (401, 403, network error, DNS failure, etc.) so the caller can map
-    /// to `AuthError::LoginRejected`.
+    /// successful authenticated response (2xx).
+    ///
+    /// The two failure shapes are kept apart on purpose:
+    /// [`AuthError::LoginRejected`] means the registry judged the credential
+    /// and said no, [`AuthError::ProbeFailed`] means it was never judged
+    /// because the request did not complete. Collapsing them tells a CI
+    /// wrapper to rotate a credential that was never sent, and the retry with
+    /// a fresh one fails identically, forever.
     async fn ping(&self, registry: &str, cred: &Credential) -> Result<(), AuthError>;
 }
 
 /// Adapter that talks to a real OCI registry via the patched `oci-client`
 /// crate. Constructs a fresh client per call so cached auth state does not
 /// pollute the probe.
-pub struct OciClientPing;
+///
+/// Carries the caller's plain-HTTP host set rather than reading the
+/// environment itself: `ocx login` must reach the registry over exactly the
+/// scheme the rest of the binary would, and that answer is the union of
+/// `[registries.<name>].insecure` and `OCX_INSECURE_REGISTRIES`
+/// ([`crate::insecure_hosts`]) — a set a library adapter cannot assemble on
+/// its own.
+pub struct OciClientPing {
+    insecure_hosts: Vec<String>,
+}
+
+impl OciClientPing {
+    /// Probes registries over HTTPS, except the hosts named here.
+    pub fn new(insecure_hosts: Vec<String>) -> Self {
+        Self { insecure_hosts }
+    }
+
+    /// The scheme this probe will use for `registry`.
+    ///
+    /// Membership is byte-exact, the same comparison
+    /// [`crate::insecure_hosts`] documents and the transport makes, so an
+    /// unlisted, differently-cased or differently-ported name falls to
+    /// [`ClientProtocol::Https`] — the probe fails closed.
+    ///
+    /// The subject is the *canonicalized* registry, because [`login`]
+    /// canonicalizes before calling [`RegistryPing::ping`]. For `host[:port]`
+    /// names canonicalization is the identity, so this agrees with every other
+    /// gate. Docker Hub is the exception and deliberately unreachable: it
+    /// canonicalizes to `https://index.docker.io/v1/`, which no allowance
+    /// spelling matches.
+    ///
+    /// # Never the blanket [`ClientProtocol::Http`]
+    ///
+    /// Returning `Http` for a listed host would pick the right scheme for the
+    /// probe and destroy the transport's auth-realm guard on the way. `Http`
+    /// ignores its argument (`ClientProtocol::scheme_for`), so *every* host
+    /// reads as plaintext-eligible — and `require_secure_realm` accepts a
+    /// plaintext realm on any host that is plaintext-eligible. A registry
+    /// declared insecure could then name
+    /// `realm="http://collector.example/token"` and this probe would send the
+    /// raw Basic password there in the clear (CWE-319/CWE-522). `ocx login` is
+    /// the one command in the binary holding a password, so it is the worst
+    /// place to widen that set.
+    ///
+    /// `HttpsExcept` picks the identical scheme for the probe — `"http"` for
+    /// exactly the declared hosts, `"https"` for everything else — while
+    /// leaving the realm guard scoped to the hosts the operator actually named.
+    fn protocol_for(&self, _registry: &str) -> oci_client::client::ClientProtocol {
+        oci_client::client::ClientProtocol::HttpsExcept(self.insecure_hosts.clone())
+    }
+}
 
 #[async_trait::async_trait]
 impl RegistryPing for OciClientPing {
     async fn ping(&self, registry: &str, cred: &Credential) -> Result<(), AuthError> {
         use oci_client::Reference;
-        use oci_client::client::{Client as RawClient, ClientConfig, ClientProtocol};
+        use oci_client::client::{Client as RawClient, ClientConfig};
 
-        let protocol = if is_insecure(registry) {
-            ClientProtocol::Http
-        } else {
-            ClientProtocol::Https
-        };
         let raw = RawClient::new(ClientConfig {
-            protocol,
+            protocol: self.protocol_for(registry),
             // Same per-read idle bound as the main client: a registry that
             // accepts the connection and then goes quiet must not hang `ocx
             // login` forever.
@@ -57,30 +107,29 @@ impl RegistryPing for OciClientPing {
         let reference = Reference::with_tag(registry.to_string(), "library/_".into(), "latest".into());
         raw.auth(&reference, &auth, oci::RegistryOperation::Pull)
             .await
-            .map_err(|_| AuthError::LoginRejected {
-                registry: registry.to_string(),
-            })?;
+            .map_err(|source| probe_error(registry, source))?;
         Ok(())
     }
 }
 
-fn is_insecure(registry: &str) -> bool {
-    // Heuristic: respect OCX_INSECURE_REGISTRIES env var.
-    // Note: `ocx login --insecure` is currently hidden / no-op in v1.
-    // Callers that need HTTP must export `OCX_INSECURE_REGISTRIES` directly.
-    // When the future `--verify` flag wires real registry Ping, the flag will
-    // propagate through `apply_ocx_config` to this env var.
-    // `crate::env::var` is used instead of `std::env::var` for test-injectability
-    // via the env-lock mechanism used across this crate's unit tests.
-    if let Some(list) = crate::env::var("OCX_INSECURE_REGISTRIES") {
-        for entry in list.split(',') {
-            let entry = entry.trim();
-            if !entry.is_empty() && entry == registry {
-                return true;
-            }
-        }
+/// Splits a failed probe into "the registry said no" and "the registry never
+/// answered", reusing the transport's own taxonomy rather than a second one.
+///
+/// [`oci::client::native_transport::registry_error`] is the single place that
+/// classifies an `OciDistributionError`, and it is where the plain-HTTP
+/// remediation is attached to a failed HTTPS connect — so routing through it
+/// is what makes `ocx login` against a plaintext registry say what to do
+/// instead of blaming the password.
+fn probe_error(registry: &str, source: oci_client::errors::OciDistributionError) -> AuthError {
+    match oci::client::native_transport::registry_error(source) {
+        crate::oci::client::error::ClientError::Authentication(_) => AuthError::LoginRejected {
+            registry: registry.to_string(),
+        },
+        other => AuthError::ProbeFailed {
+            registry: registry.to_string(),
+            source: Box::new(other),
+        },
     }
-    false
 }
 
 fn to_registry_auth(cred: &Credential) -> oci_client::secrets::RegistryAuth {
@@ -99,7 +148,9 @@ fn to_registry_auth(cred: &Credential) -> oci_client::secrets::RegistryAuth {
 /// 1. Canonicalize `registry` via `auth::registry_url::canonicalize_registry`.
 /// 2. `GET /v2/` with the credential applied — `Ping`.
 /// 3. On Ping success, `store.put(canonical, &cred)`.
-/// 4. On Ping failure, return `AuthError::LoginRejected { registry }` WITHOUT calling `put`.
+/// 4. On Ping failure, return the `Ping`'s error — `AuthError::LoginRejected`
+///    when the registry judged the credential, `AuthError::ProbeFailed` when it
+///    never did — WITHOUT calling `put`.
 ///
 /// Bad credentials never reach the store. Single most load-bearing security invariant.
 pub async fn login(
@@ -260,5 +311,116 @@ mod tests {
             &["ghcr.io".to_string()],
             "ping must see the canonical registry, not the raw scheme/version form",
         );
+    }
+
+    // ─── `OciClientPing`'s protocol choice ───
+
+    fn ping_allowing(hosts: &[&str]) -> OciClientPing {
+        OciClientPing::new(hosts.iter().map(|host| (*host).to_string()).collect())
+    }
+
+    /// Mirrors what `ClientProtocol::scheme_for` does with the value this gate
+    /// returns. Spelled out here rather than called, because `scheme_for` is
+    /// private to the fork — so the assertion states the transport rule instead
+    /// of borrowing it, and reds if this gate ever returns a variant that
+    /// resolves differently.
+    fn is_http(ping: &OciClientPing, registry: &str) -> bool {
+        use oci_client::client::ClientProtocol;
+        match ping.protocol_for(registry) {
+            ClientProtocol::Http => true,
+            ClientProtocol::Https => false,
+            ClientProtocol::HttpsExcept(hosts) => hosts.iter().any(|host| host == registry),
+        }
+    }
+
+    /// The blanket [`ClientProtocol::Http`] must never be what this gate
+    /// returns: it ignores its argument, so every host on earth reads as
+    /// plaintext-eligible and the transport's auth-realm guard degenerates to
+    /// "accept anything" — sending `ocx login`'s raw Basic password to whatever
+    /// host a declared-insecure registry names in its `WWW-Authenticate` realm.
+    /// Asserted on the variant, not the scheme, because the scheme is identical
+    /// either way and only the variant carries the defect.
+    #[test]
+    fn the_probe_never_widens_plaintext_eligibility_beyond_the_declared_hosts() {
+        let ping = ping_allowing(&["registry.corp:5000"]);
+
+        for registry in ["registry.corp:5000", "ghcr.io"] {
+            match ping.protocol_for(registry) {
+                oci_client::client::ClientProtocol::HttpsExcept(hosts) => assert_eq!(
+                    hosts,
+                    vec!["registry.corp:5000".to_string()],
+                    "plaintext eligibility must be exactly the declared set — an undeclared \
+                     third host is the realm the password would be sent to",
+                ),
+                other => panic!(
+                    "probing {registry} must not widen plaintext eligibility beyond the \
+                     declared hosts; got {other:?}",
+                ),
+            }
+        }
+    }
+
+    /// The one decision the login gate makes, asserted directly: the six gates
+    /// the commit says share a predicate include this one, and before this test
+    /// nothing at any layer observed it (every acceptance `ocx login` passes
+    /// `--no-verify`, so the `RegistryPing` branch is never taken).
+    #[test]
+    fn a_listed_host_probes_over_http_and_an_unlisted_one_over_https() {
+        let ping = ping_allowing(&["registry.corp:5000"]);
+
+        assert!(
+            is_http(&ping, "registry.corp:5000"),
+            "a listed host must probe over HTTP"
+        );
+        assert!(
+            !is_http(&ping, "ghcr.io"),
+            "an unlisted host must probe over HTTPS — the probe fails closed"
+        );
+    }
+
+    /// Byte-exact, the same rule `insecure_hosts` documents: a near miss is a
+    /// miss, in both directions, and case is not folded. Without this the probe
+    /// could diverge from the transport on exactly the spellings an operator
+    /// gets wrong.
+    #[test]
+    fn a_near_miss_of_the_allowed_name_probes_over_https() {
+        assert!(
+            !is_http(&ping_allowing(&["registry.corp"]), "registry.corp:5000"),
+            "a bare-host allowance must not cover the same host on a port"
+        );
+        assert!(
+            !is_http(&ping_allowing(&["registry.corp:5000"]), "registry.corp"),
+            "a ported allowance must not cover the bare host"
+        );
+        assert!(
+            !is_http(&ping_allowing(&["Registry.Corp:5000"]), "registry.corp:5000"),
+            "the comparison is byte-exact, so case matters"
+        );
+    }
+
+    /// Docker Hub is the one name where this gate's subject differs from the
+    /// transport's, and the divergence is closed in the safe direction: neither
+    /// host name an operator would write reaches the canonicalized subject
+    /// `login()` actually passes in, so no plaintext probe of Docker Hub can be
+    /// granted by accident.
+    ///
+    /// Recorded as a decision, not a gap. Docker Hub is not served over plain
+    /// HTTP, and the alternative — normalizing the login subject back to a host
+    /// — would make `ocx login` the one gate that rewrites a name before
+    /// comparing it.
+    #[test]
+    fn a_docker_hub_host_name_cannot_license_a_plaintext_probe() {
+        let subject = canonicalize_registry("docker.io");
+        assert_eq!(
+            subject, "https://index.docker.io/v1/",
+            "the canonical form login passes in"
+        );
+
+        for spelling in ["docker.io", "index.docker.io"] {
+            assert!(
+                !is_http(&ping_allowing(&[spelling]), &subject),
+                "`{spelling}` must not license a plaintext probe of the canonicalized `{subject}`"
+            );
+        }
     }
 }

--- a/crates/ocx_lib/src/cli/classify.rs
+++ b/crates/ocx_lib/src/cli/classify.rs
@@ -391,6 +391,25 @@ mod tests {
         assert_eq!(classify(err), ExitCode::TempFail);
     }
 
+    /// A destination the transport refused is terminal, and the two codes it
+    /// must NOT be are asserted with it: 69 would tell a retry wrapper to
+    /// re-issue the push against the same hostile `Location` until its budget
+    /// runs out, and 75 would tell it the same and promise success.
+    ///
+    /// `UnfollowedRedirect` shares the code and the argument: a rerun walks the
+    /// same chain to the same answer, whether it ended in a refusal, the hop
+    /// limit, or a `Location` no client could act on.
+    #[test]
+    fn a_refused_destination_and_an_unfollowed_redirect_map_to_65_and_are_not_retryable() {
+        let refusal = || ClientError::UnsafeDestination(Box::new(std::io::Error::other("cross-host session URL")));
+        let redirect = || ClientError::UnfollowedRedirect(Box::new(std::io::Error::other("https -> http hop")));
+        for build in [&refusal as &dyn Fn() -> ClientError, &redirect] {
+            assert_eq!(classify(build()), ExitCode::DataError);
+            assert_ne!(classify(build()), ExitCode::Unavailable);
+            assert_ne!(classify(build()), ExitCode::TempFail);
+        }
+    }
+
     #[test]
     fn client_io_maps_to_io_error() {
         // Plan taxonomy: ClientError::Io → IoError (74)

--- a/crates/ocx_lib/src/config.rs
+++ b/crates/ocx_lib/src/config.rs
@@ -2,6 +2,7 @@
 // Copyright 2026 The OCX Authors
 
 pub mod error;
+pub mod insecure;
 pub mod loader;
 pub mod managed;
 pub mod mirror;
@@ -49,9 +50,8 @@ pub struct Config {
     ///
     /// Every key is an identifier prefix, always — `[registry] default`
     /// never dereferences through this table (§6 ratified simplification).
-    /// Future extensions (per-registry insecure flag, location rewrite,
-    /// timeout, auth) drop into the same entry struct without breaking
-    /// existing configs.
+    /// Future extensions (location rewrite, timeout, auth) drop into the same
+    /// entry struct without breaking existing configs.
     pub registries: Option<HashMap<String, RegistryConfig>>,
 
     /// Per-traffic-host mirrors (`[mirrors."<host>"]`).
@@ -374,7 +374,7 @@ mod tests {
              timeout = 30\n\
              [registries.\"corp.example.com\"]\n\
              index = \"https://index.corp.example.com\"\n\
-             insecure = true\n\
+             location = \"corp.example.com/rewritten\"\n\
              [mirrors.\"ghcr.io\"]\n\
              registry = \"https://mirror.corp/ghcr\"\n\
              attest = \"https://mirror.corp/attest\"\n\
@@ -716,6 +716,20 @@ mod tests {
                     ..Default::default()
                 });
                 system.system_locked && system.index.as_deref() == Some("https://system-index.corp")
+            }),
+            // The same entry's security-relevant field: a lower tier must not be
+            // able to declare a system-locked registry reachable over plain HTTP.
+            ("[registries.<name>] insecure", || {
+                let mut system = RegistryConfig {
+                    insecure: Some(false),
+                    ..Default::default()
+                };
+                system.lock_as_system();
+                system.merge(RegistryConfig {
+                    insecure: Some(true),
+                    ..Default::default()
+                });
+                system.system_locked && system.insecure == Some(false)
             }),
             ("[mirrors.\"<host>\"]", || {
                 let mut system = MirrorConfig {

--- a/crates/ocx_lib/src/config/insecure.rs
+++ b/crates/ocx_lib/src/config/insecure.rs
@@ -1,0 +1,478 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 The OCX Authors
+
+//! The one answer to "may this registry be contacted over plain HTTP?".
+//!
+//! Two sources declare it — an `insecure = true` entry under
+//! `[registries."<name>"]`, and the `OCX_INSECURE_REGISTRIES` env list — and
+//! they are a **union** in the permissive direction: a host named by either is
+//! plaintext-eligible, so "config says secure, env says insecure" is not a
+//! conflict anyone has to resolve and the answer never depends on which source
+//! was consulted last.
+//!
+//! There is exactly one subtraction, and only the system scope can make it —
+//! see [`insecure_hosts`]. The union is computed once and handed to every gate
+//! that needs it (the OCI client's protocol choice, the mirror-role gate, the
+//! index base URL, and `ocx login`'s ping), because a host that is insecure for
+//! one of them and secure for another is a bug, not a feature.
+
+use crate::config::Config;
+
+/// The deduped union of config-declared and env-declared plain-HTTP hosts,
+/// less any host the system scope has explicitly locked shut.
+///
+/// # The one subtraction
+///
+/// A `[registries."<name>"]` entry resolved from the SYSTEM scope
+/// (`/etc/ocx/config.toml`, so `system_locked`) that *states* `insecure = false`
+/// removes that name from the result — `OCX_INSECURE_REGISTRIES` included.
+/// `Some(false)` is a decision; `None` is silence and subtracts nothing, which
+/// is exactly the distinction the `Option<bool>` already carries. Without this,
+/// the per-entry lock [`RegistryConfig::merge`](crate::config::RegistryConfig::merge)
+/// enforces against lower config tiers would be defeated by one env var, and
+/// the platform engineer hardening a fleet would have no lever at all.
+///
+/// Everything else is additive: a *non*-system tier saying `insecure = false`
+/// revokes nothing.
+///
+/// # What "matched exactly" means, and against what
+///
+/// Names are compared with plain string equality, `host[:port]` together,
+/// because that is what the transport does: `oci_client`'s
+/// `ClientProtocol::HttpsExcept` tests the resolved registry string for
+/// membership. An entry for `registry.corp` therefore does not cover
+/// `registry.corp:5001`, and case matters.
+///
+/// The *subject* of that comparison is each gate's own resolved host string,
+/// and they are not all the same string. The transport and the mirror gate
+/// both compare `Reference::resolve_registry()`; the index gate compares the
+/// index base URL's host; `ocx login` compares
+/// [`canonicalize_registry`](crate::auth::registry_url::canonicalize_registry)'s
+/// output. For `host[:port]` names all four agree. Docker Hub is the one name
+/// they do not: `docker.io` resolves to `index.docker.io` for the transport and
+/// to `https://index.docker.io/v1/` for login, so no spelling of it can be
+/// granted a plaintext allowance here. That is deliberate — Docker Hub is not
+/// served over plain HTTP — and pinned by the `protocol_for` tests in
+/// [`crate::auth::login`].
+///
+/// # Spelling: exact to grant, normalised to revoke
+///
+/// The two directions want opposite normalisation, so they get it.
+///
+/// **Granting stays byte-exact**, case included, because that is the comparison
+/// the transport makes and being stricter than the transport fails *closed*: a
+/// mis-cased `[registries."Registry.Corp"]` grants nothing, which is the safe
+/// outcome. Pinned by `host_and_port_are_one_opaque_name`.
+///
+/// **Revoking normalises**, because being stricter there fails *open*. Two axes,
+/// both of which let a differently-spelled name reach the same socket:
+///
+/// - **ASCII case.** Hostnames are case-insensitive (RFC 4343) and DNS resolves
+///   every spelling to the same address, so an exact-match revoke lets
+///   `OCX_INSECURE_REGISTRIES=Registry.Corp:5000` — or a lower-tier
+///   `[registries."Registry.Corp:5000"]`, a different map key that therefore
+///   never meets the locked entry in
+///   [`RegistryConfig::merge`](crate::config::RegistryConfig::merge) — walk past
+///   a lock on `registry.corp:5000`.
+/// - **Port spelling.** `url` parses a port numerically before dialling, so
+///   `http://registry.corp:05000/` opens TCP 5000. An exact-match revoke lets
+///   `OCX_INSECURE_REGISTRIES=registry.corp:05000` take the session plaintext to
+///   the port the operator locked shut, by adding one character.
+///
+/// Either bypass is CWE-319/CWE-522. [`same_registry_name`] is the one place
+/// both normalisations live.
+///
+/// The asymmetry is not a wart: the strict side is the one where strictness is
+/// safe, and both sides are the *conservative* reading of an ambiguous name.
+///
+/// # Known residual: default-port elision
+///
+/// A lock on `registry.corp` does not reach a declaration of `registry.corp:80`,
+/// nor the reverse. Closing it needs the scheme's default port, and this one
+/// list gates four consumers across both schemes — so any constant filled in
+/// here would be wrong for some of them. Left open deliberately rather than
+/// guessed.
+pub fn insecure_hosts(config: &Config, env: &[String]) -> Vec<String> {
+    let mut hosts: Vec<String> = config
+        .registries
+        .iter()
+        .flatten()
+        .filter(|(name, registry)| registry.insecure.unwrap_or(false) && !system_locked_shut(config, name))
+        .map(|(name, _)| name.clone())
+        .collect();
+
+    for host in env {
+        if system_locked_shut(config, host) || hosts.contains(host) {
+            continue;
+        }
+        hosts.push(host.clone());
+    }
+    hosts
+}
+
+/// Whether `host` carries a plain-HTTP allowance.
+///
+/// The granting comparison, in one place. Byte-exact on `host[:port]`, matching
+/// `oci_client::ClientProtocol::HttpsExcept` — the fork makes the same test on
+/// the same set and cannot share this function across the crate boundary, so
+/// the two must not drift. Every ocx-side gate (mirror role, index base URL,
+/// `ocx login`'s probe) calls this rather than writing the `iter().any(..)` out
+/// again, so the invariant [`insecure_hosts`] documents has one place to be true.
+pub fn allows_plain_http(hosts: &[String], host: &str) -> bool {
+    hosts.iter().any(|allowed| allowed == host)
+}
+
+/// Whether the system scope declared this name plaintext-forbidden.
+///
+/// Both halves of the entry are required: an unlocked `insecure = false` is an
+/// ordinary lower-tier default and revokes nothing, and a locked entry that
+/// never states `insecure` has said nothing about transport.
+///
+/// The name comparison folds ASCII case — see [`insecure_hosts`] for why this
+/// one direction does. A linear scan rather than a `HashMap` lookup for the
+/// same reason; the map is keyed on the TOML name verbatim, and this runs once
+/// per process over a handful of entries.
+fn system_locked_shut(config: &Config, host: &str) -> bool {
+    config
+        .registries
+        .iter()
+        .flatten()
+        .any(|(name, entry)| entry.system_locked && entry.insecure == Some(false) && same_registry_name(name, host))
+}
+
+/// Whether two `host[:port]` names denote the same socket, for the revoking
+/// side only.
+///
+/// ASCII case folded (hostnames are case-insensitive) and a numeric port
+/// re-rendered from its parsed value, because `url` canonicalizes the port
+/// before the socket is opened: `http://registry.corp:05000/` dials TCP 5000,
+/// so a lock on `registry.corp:5000` must reach the `:05000` spelling too.
+/// Pinned by `a_zero_padded_port_is_the_same_socket_as_the_bare_one`.
+///
+/// A port that is not a `u16` — non-numeric, or out of range — is **not**
+/// normalised: the whole name falls back to the case-folded string, so it
+/// matches its own spelling and nothing else. Silently treating it as portless
+/// would make `registry.corp:99999` revoke `registry.corp`, i.e. one unparseable
+/// name subtracting a different host.
+///
+/// Deliberately no default-port fill. The elision axis (`registry.corp` versus
+/// `registry.corp:443`, or `:80`) is a known residual: the right default is the
+/// scheme's, and this predicate feeds four gates on two schemes, so any constant
+/// here is wrong for some of them. Over-subtracting fails closed, but guessing
+/// which port an operator meant is not something a comparison can do.
+fn same_registry_name(left: &str, right: &str) -> bool {
+    fn normalize(name: &str) -> String {
+        match name.rsplit_once(':') {
+            Some((host, port)) => port.parse::<u16>().map_or_else(
+                |_| name.to_ascii_lowercase(),
+                |port| format!("{}:{port}", host.to_ascii_lowercase()),
+            ),
+            None => name.to_ascii_lowercase(),
+        }
+    }
+    normalize(left) == normalize(right)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::RegistryConfig;
+    use std::collections::HashMap;
+
+    fn config_with(entries: &[(&str, Option<bool>)]) -> Config {
+        let registries = entries
+            .iter()
+            .map(|(name, insecure)| {
+                (
+                    (*name).to_string(),
+                    RegistryConfig {
+                        insecure: *insecure,
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect::<HashMap<_, _>>();
+        Config {
+            registries: Some(registries),
+            ..Default::default()
+        }
+    }
+
+    /// One `[registries.<name>]` entry as the SYSTEM scope would leave it:
+    /// `lock_as_system` is what the loader calls on every entry of
+    /// `/etc/ocx/config.toml`, so the flag is set the same way here.
+    fn system_config_with(name: &str, insecure: Option<bool>) -> Config {
+        let mut entry = RegistryConfig {
+            insecure,
+            ..Default::default()
+        };
+        entry.lock_as_system();
+        Config {
+            registries: Some(HashMap::from([(name.to_string(), entry)])),
+            ..Default::default()
+        }
+    }
+
+    /// A system lock plus a lower tier's entry under a DIFFERENT map key — the
+    /// shape `RegistryConfig::merge` never sees, because the two names never
+    /// collide in the `HashMap` and so the locked entry's early return never runs.
+    fn system_locked_plus_lower_tier(locked: &str, lower: &str, lower_insecure: bool) -> Config {
+        let mut locked_entry = RegistryConfig {
+            insecure: Some(false),
+            ..Default::default()
+        };
+        locked_entry.lock_as_system();
+        Config {
+            registries: Some(HashMap::from([
+                (locked.to_string(), locked_entry),
+                (
+                    lower.to_string(),
+                    RegistryConfig {
+                        insecure: Some(lower_insecure),
+                        ..Default::default()
+                    },
+                ),
+            ])),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn only_entries_declaring_true_are_insecure() {
+        let config = config_with(&[
+            ("plain.corp:5000", Some(true)),
+            ("secure.corp", Some(false)),
+            ("unstated.corp", None),
+        ]);
+
+        let hosts = insecure_hosts(&config, &[]);
+
+        assert_eq!(hosts, vec!["plain.corp:5000".to_string()]);
+    }
+
+    #[test]
+    fn config_and_env_union_without_duplicates() {
+        let config = config_with(&[("plain.corp:5000", Some(true))]);
+        let env = vec!["plain.corp:5000".to_string(), "localhost:5001".to_string()];
+
+        let hosts = insecure_hosts(&config, &env);
+
+        assert_eq!(hosts, vec!["plain.corp:5000".to_string(), "localhost:5001".to_string()]);
+    }
+
+    /// An ORDINARY tier saying `insecure = false` revokes nothing: the union is
+    /// additive everywhere the system scope has not spoken, so the answer never
+    /// depends on which source was consulted last.
+    #[test]
+    fn an_unlocked_false_cannot_revoke_an_env_declared_host() {
+        let config = config_with(&[("plain.corp:5000", Some(false))]);
+        let env = vec!["plain.corp:5000".to_string()];
+
+        assert_eq!(insecure_hosts(&config, &env), vec!["plain.corp:5000".to_string()]);
+    }
+
+    /// The one subtraction. A system-scope entry that *states* `insecure = false`
+    /// is the platform engineer's lever, and it has to bind the environment or it
+    /// is not a lever at all — `RegistryConfig::merge`'s per-entry lock already
+    /// stops every lower CONFIG tier, and the env var is the only way left in.
+    ///
+    /// Asserted as a pair with the unlocked case above: dropping the
+    /// `system_locked` half of the predicate leaves this one red, dropping the
+    /// `Some(false)` half leaves the `None` case below red.
+    #[test]
+    fn a_system_locked_false_subtracts_the_host_from_the_environment() {
+        let config = system_config_with("locked.corp:5000", Some(false));
+        let env = vec!["locked.corp:5000".to_string()];
+
+        assert!(
+            insecure_hosts(&config, &env).is_empty(),
+            "a system-locked `insecure = false` must forbid plaintext for that host, env included"
+        );
+    }
+
+    /// Silence is not a decision: a locked entry that never states `insecure`
+    /// has said nothing about transport, so it subtracts nothing.
+    #[test]
+    fn a_system_locked_entry_that_never_states_insecure_subtracts_nothing() {
+        let config = system_config_with("locked.corp:5000", None);
+        let env = vec!["locked.corp:5000".to_string()];
+
+        assert_eq!(
+            insecure_hosts(&config, &env),
+            vec!["locked.corp:5000".to_string()],
+            "`None` is silence, not a refusal — only an explicit `false` locks a host shut"
+        );
+    }
+
+    /// The revoke direction folds ASCII case, because exactness there fails
+    /// OPEN: hostnames are case-insensitive and DNS lands every spelling on the
+    /// same socket, so a byte-exact revoke lets one changed letter in an
+    /// environment variable walk past the only lever the design gives a
+    /// platform engineer (CWE-319/CWE-522).
+    ///
+    /// Paired with `mixed_case_grants_nothing_even_when_a_lock_would_fold_to_it`
+    /// below: this asserts the fold happens on the revoking side, that one
+    /// asserts it does NOT happen on the granting side. Either alone would also
+    /// pass with the fold applied everywhere, which is the wrong fix.
+    #[test]
+    fn a_system_lock_revokes_a_differently_cased_environment_entry() {
+        let config = system_config_with("registry.corp:5000", Some(false));
+
+        for spelling in ["Registry.Corp:5000", "REGISTRY.CORP:5000", "registry.CORP:5000"] {
+            assert!(
+                insecure_hosts(&config, &[spelling.to_string()]).is_empty(),
+                "`{spelling}` must not slip past a lowercase system lock — DNS reaches the same host"
+            );
+        }
+    }
+
+    /// The same fold on the other half of the union. A lower tier's
+    /// `[registries."Registry.Corp:5000"] insecure = true` is a DIFFERENT
+    /// `HashMap` key from the system tier's lowercase entry, so
+    /// `RegistryConfig::merge` never folds the two together and its per-entry
+    /// `system_locked` early return never runs — the subtraction is the only
+    /// thing standing between that entry and a plaintext session.
+    #[test]
+    fn a_system_lock_revokes_a_differently_cased_config_entry_from_a_lower_tier() {
+        let config = system_locked_plus_lower_tier("registry.corp:5000", "Registry.Corp:5000", true);
+
+        assert!(
+            insecure_hosts(&config, &[]).is_empty(),
+            "a lower tier must not re-grant a locked host by re-spelling its case"
+        );
+    }
+
+    /// The premise the port half of [`same_registry_name`] rests on, asserted
+    /// rather than assumed: `url` parses the port numerically and re-renders it,
+    /// so a zero-padded spelling is not a different endpoint that merely looks
+    /// alike — it is a different SPELLING of the same socket, and the whole
+    /// bypass below follows from that. If this ever stops holding, the
+    /// normalisation is over-subtraction and should be revisited, not kept.
+    #[test]
+    fn a_zero_padded_port_is_the_same_socket_as_the_bare_one() {
+        let padded = reqwest::Url::parse("http://registry.corp:05000/v2/").expect("valid url");
+
+        assert_eq!(padded.port(), Some(5000), "url must parse the port numerically");
+        assert_eq!(
+            padded.as_str(),
+            "http://registry.corp:5000/v2/",
+            "url must re-render the canonical port, which is what the socket then uses"
+        );
+    }
+
+    /// The bypass: a system lock on `registry.corp:5000`, and an unprivileged
+    /// `OCX_INSECURE_REGISTRIES=registry.corp:05000`. Nothing between the env
+    /// var and the socket re-spells the port — `split_registry_repository` takes
+    /// the first path segment verbatim, and the granting comparison is
+    /// byte-exact by design — so before the port normalisation the host was
+    /// granted plaintext and `url` then dialled the very port the operator
+    /// locked shut, at the cost of one character (CWE-319).
+    #[test]
+    fn a_system_lock_revokes_a_zero_padded_environment_port() {
+        let config = system_config_with("registry.corp:5000", Some(false));
+
+        for spelling in ["registry.corp:05000", "registry.corp:0005000", "Registry.Corp:05000"] {
+            assert!(
+                insecure_hosts(&config, &[spelling.to_string()]).is_empty(),
+                "`{spelling}` reaches TCP 5000, so it must not slip past a lock on `registry.corp:5000`"
+            );
+        }
+    }
+
+    /// A port no `u16` accepts is not silently treated as portless — that would
+    /// let one unparseable name subtract a DIFFERENT host. It falls back to the
+    /// case-folded whole string: it matches its own spelling, and nothing else.
+    #[test]
+    fn an_unparseable_port_matches_only_its_own_spelling() {
+        let locked_bare = system_config_with("registry.corp", Some(false));
+        for spelling in ["registry.corp:99999", "registry.corp:abc", "registry.corp:5000"] {
+            assert_eq!(
+                insecure_hosts(&locked_bare, &[spelling.to_string()]),
+                vec![spelling.to_string()],
+                "a lock on the bare host must not reach `{spelling}` — it names a port, the lock does not"
+            );
+        }
+
+        let locked_junk = system_config_with("registry.corp:abc", Some(false));
+        assert!(
+            insecure_hosts(&locked_junk, &["registry.corp:ABC".to_string()]).is_empty(),
+            "case folding still applies to a name whose port cannot be normalised"
+        );
+        assert_eq!(
+            insecure_hosts(&locked_junk, &["registry.corp".to_string()]),
+            vec!["registry.corp".to_string()],
+            "an unparseable port must not collapse to the bare host and revoke it"
+        );
+    }
+
+    /// Granting stays byte-exact even where a revoke would have folded, so the
+    /// asymmetry is real rather than a fold that leaked into both directions.
+    /// Being stricter than the transport here fails CLOSED — the entry licenses
+    /// nothing, and nothing is the safe answer.
+    #[test]
+    fn mixed_case_grants_nothing_even_when_a_lock_would_fold_to_it() {
+        let config = config_with(&[("Registry.Corp:5000", Some(true))]);
+
+        assert_eq!(
+            insecure_hosts(&config, &[]),
+            vec!["Registry.Corp:5000".to_string()],
+            "the set carries the key verbatim; the gate below is what refuses it"
+        );
+        assert!(
+            !crate::allows_plain_http(&insecure_hosts(&config, &[]), "registry.corp:5000"),
+            "a mis-cased entry must not license the lowercase name the transport will ask about"
+        );
+    }
+
+    /// Matching is exact, asserted where the exactness is *consumed*: a bare
+    /// host does not license the same host on a port, and case is not folded.
+    /// The predicate's own return value cannot show this — a set built from a
+    /// disjoint literal never contains the literal it was not built from — so
+    /// the assertion has to run through a gate.
+    #[test]
+    fn host_and_port_are_one_opaque_name() {
+        let bare = insecure_hosts(&config_with(&[("registry.corp", Some(true))]), &[]);
+        let ported = insecure_hosts(&config_with(&[("registry.corp:5001", Some(true))]), &[]);
+        let mixed_case = insecure_hosts(&config_with(&[("Registry.Corp:5001", Some(true))]), &[]);
+
+        let gate = |hosts: &[String]| {
+            crate::config::mirror::resolve_mirror_map(
+                &Config::default(),
+                vec![(
+                    "up.example".to_string(),
+                    crate::config::MirrorConfig {
+                        registry: Some("http://registry.corp:5001".to_string()),
+                        ..Default::default()
+                    },
+                )],
+                hosts,
+            )
+        };
+
+        assert!(
+            matches!(
+                gate(&bare),
+                Err(crate::config::mirror::MirrorConfigError::PlainHttpMirrorNotAllowed { .. })
+            ),
+            "an entry for the bare host must not license the same host on a port"
+        );
+        assert!(
+            matches!(
+                gate(&mixed_case),
+                Err(crate::config::mirror::MirrorConfigError::PlainHttpMirrorNotAllowed { .. })
+            ),
+            "the comparison is byte-exact — a differently-cased name licenses nothing"
+        );
+        assert!(gate(&ported).is_ok(), "the exact `host:port` name must license it");
+    }
+
+    #[test]
+    fn no_registries_table_is_just_the_environment() {
+        let config = Config::default();
+
+        assert_eq!(
+            insecure_hosts(&config, &["localhost:5000".to_string()]),
+            vec!["localhost:5000".to_string()]
+        );
+    }
+}

--- a/crates/ocx_lib/src/config/mirror.rs
+++ b/crates/ocx_lib/src/config/mirror.rs
@@ -244,13 +244,15 @@ pub enum MirrorConfigError {
         /// Human-readable type name of the offending value (e.g. `"integer"`).
         found: String,
     },
-    /// A mirror endpoint uses plain HTTP but its host is not listed in
+    /// A mirror endpoint uses plain HTTP but its host is in neither half of the
+    /// insecure-host union — `[registries."<host>"] insecure` and
     /// `OCX_INSECURE_REGISTRIES`. Replace semantics forbid silently downgrading
     /// to HTTP, so this fails loud at resolve time with an actionable hint
-    /// (CWE-319) rather than as an opaque TLS error mid-transport.
+    /// (CWE-319) rather than as an opaque TLS error mid-transport. Both
+    /// spellings are named because either one fixes it.
     #[error(
-        "mirror for '{upstream}' uses http:// but mirror host '{mirror_host}' is not in \
-         OCX_INSECURE_REGISTRIES; add it to allow plain-HTTP transport"
+        "mirror for '{upstream}' uses http:// but mirror host '{mirror_host}' is not allowed plain HTTP; \
+         set insecure = true under [registries.\"{mirror_host}\"] or add the host to OCX_INSECURE_REGISTRIES"
     )]
     PlainHttpMirrorNotAllowed {
         /// The upstream host key whose mirror uses plain HTTP.
@@ -514,7 +516,7 @@ pub struct ResolvedMirrors {
 /// entry, splitting the result by traffic role.
 ///
 /// This is the single Config→mirror-map transform shared by the CLI
-/// (`Context::try_init`) and the OCI client (`ClientBuilder::from_env*`). It
+/// (`Context::try_init`) and `ocx config test`'s preview of a candidate. It
 /// owns the one-way-door precedence rule and the plain-HTTP security gate so
 /// they cannot drift between layers:
 ///
@@ -527,7 +529,7 @@ pub struct ResolvedMirrors {
 ///   no-op mirror silently egresses to the blocked upstream host); an entry
 ///   with no role at all is [`MirrorConfigError::EmptyEntry`].
 /// - **Plain-HTTP gate (CWE-319)** — an `http://` mirror whose host is not in
-///   `insecure_hosts` is a hard error naming `OCX_INSECURE_REGISTRIES`, so the
+///   `insecure_hosts` is a hard error naming both ways to allow it, so the
 ///   failure surfaces loud at resolve time rather than as an opaque TLS error
 ///   mid-transport.
 /// - **Role-only filtering** — an index-only entry never appears in
@@ -594,7 +596,7 @@ fn resolve_mirror_role(
         upstream: upstream.to_string(),
         source: Box::new(source),
     })?;
-    if parsed.protocol == "http" && !insecure_hosts.contains(&parsed.host) {
+    if parsed.protocol == "http" && !crate::allows_plain_http(insecure_hosts, &parsed.host) {
         return Err(MirrorConfigError::PlainHttpMirrorNotAllowed {
             upstream: upstream.to_string(),
             mirror_host: parsed.host,
@@ -606,6 +608,26 @@ fn resolve_mirror_role(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The refusal has to name the config key, quoted with its port, or the
+    /// operator is told only half the fix. Asserting the rendered text is the
+    /// only thing that pins it — every variant-shape test passed against the
+    /// old env-var-only wording too.
+    #[test]
+    fn the_plain_http_mirror_refusal_names_both_ways_to_allow_it() {
+        let rendered = MirrorConfigError::PlainHttpMirrorNotAllowed {
+            upstream: "ghcr.io".to_string(),
+            mirror_host: "mirror.corp:5000".to_string(),
+        }
+        .to_string();
+
+        assert!(rendered.contains("mirror.corp:5000"), "{rendered}");
+        assert!(
+            rendered.contains("set insecure = true under [registries.\"mirror.corp:5000\"]"),
+            "the exact TOML key, port included, pre-empts the whole wrong-spelling failure class: {rendered}"
+        );
+        assert!(rendered.contains("OCX_INSECURE_REGISTRIES"), "{rendered}");
+    }
 
     #[test]
     fn mirror_config_merge_none_in_higher_does_not_clobber_lower_url() {

--- a/crates/ocx_lib/src/config/registry.rs
+++ b/crates/ocx_lib/src/config/registry.rs
@@ -8,8 +8,8 @@
 //! resolution protocol for this namespace. Every `[registries.<name>]` key is
 //! an identifier prefix, always — `[registry] default` takes a literal prefix
 //! only, never a hostname alias (§6 ratified simplification). Future
-//! per-registry fields (`insecure`, `location` rewrite, `timeout`, auth) land
-//! here too, without forcing migration of existing configs.
+//! per-registry fields (`location` rewrite, `timeout`, auth) land here too,
+//! without forcing migration of existing configs.
 
 use serde::Deserialize;
 
@@ -43,6 +43,40 @@ pub struct RegistryConfig {
     /// per-entry and managed-tier distributable, so `system_locked` applies —
     /// there is no CLI flag to widen a locked trust set.
     pub trusted_hosts: Option<Vec<String>>,
+
+    /// Contact this registry over plain HTTP instead of HTTPS.
+    ///
+    /// The per-registry spelling of what `OCX_INSECURE_REGISTRIES` says as a
+    /// flat list; the two are a **union** in the permissive direction —
+    /// declaring a host in either source adds it, so there is no "config says
+    /// secure, env says insecure" conflict to resolve. One source can subtract:
+    /// a SYSTEM-scope entry stating `insecure = false` locks that host shut
+    /// against the env list too. See
+    /// [`insecure_hosts`](crate::insecure_hosts) for the resolution rule.
+    ///
+    /// Matching is exact on the registry name as written, `host[:port]`
+    /// together: an entry for `registry.corp` does not cover
+    /// `registry.corp:5001`. The name must be the one references actually
+    /// carry, because that is the string the transport compares against.
+    ///
+    /// # What it reaches, stated in full
+    ///
+    /// Dropping TLS is a security decision, so the entry is managed-tier
+    /// distributable and `system_locked` applies.
+    ///
+    /// Beyond the registry's own traffic it reaches exactly one thing: which
+    /// **authentication realm** that registry may name. The transport accepts a
+    /// realm only when it is `https`, or shares the registry's own authority, or
+    /// sits on a host that itself carries a plain-HTTP allowance. So a cleartext
+    /// credential can only ever go somewhere the operator already declared
+    /// plaintext — an `insecure` entry for one host never licenses cleartext to a
+    /// host nobody named, for a realm or for registry traffic (CWE-319/CWE-522).
+    ///
+    /// The operator-visible consequence: a plain-HTTP registry whose **token
+    /// service sits on a different host or port** needs that host declared plain
+    /// HTTP too, or the probe is refused. Declaring the registry alone is enough
+    /// only when the realm is on the registry's own authority.
+    pub insecure: Option<bool>,
 
     /// Runtime provenance marker: this entry was declared at the SYSTEM config
     /// scope (`/etc/ocx/config.toml`), so it is NON-OVERRIDABLE by any lower
@@ -111,6 +145,9 @@ impl RegistryConfig {
         }
         if other.trusted_hosts.is_some() {
             self.trusted_hosts = other.trusted_hosts;
+        }
+        if other.insecure.is_some() {
+            self.insecure = other.insecure;
         }
     }
 }
@@ -339,6 +376,51 @@ mod tests {
             system.trusted_hosts.as_deref(),
             Some(["10.0.0.0/8".to_string()].as_slice()),
             "a locked entry's trust set must not be widened by a lower tier"
+        );
+    }
+
+    // ── `insecure` plain-HTTP opt-in ─────────────────────────────────────────
+
+    /// `insecure = true` parses into the field; an entry that never states it
+    /// stays `None`, which is what distinguishes "not stated" from an explicit
+    /// `false` during the merge.
+    #[test]
+    fn registries_table_parses_insecure_field() {
+        let config: crate::config::Config =
+            toml::from_str("[registries.\"registry.corp:5000\"]\ninsecure = true\n[registries.ghcr]\n").unwrap();
+        let registries = config.registries.expect("registries table must be present");
+        assert_eq!(
+            registries
+                .get("registry.corp:5000")
+                .expect("the declaring entry must exist")
+                .insecure,
+            Some(true)
+        );
+        assert_eq!(
+            registries.get("ghcr").expect("ghcr entry must exist").insecure,
+            None,
+            "an entry that never states `insecure` must stay unstated, not default to false"
+        );
+    }
+
+    /// A typo of `insecure` is ignored — and, security-relevant, must not turn
+    /// plain HTTP on. Ignoring fails safe; absorbing would drop TLS on a typo.
+    #[test]
+    fn registries_table_ignores_typo_of_insecure_field() {
+        let config: crate::config::Config = toml::from_str("[registries.\"registry.corp\"]\ninsecre = true\n")
+            .expect("a typo'd field must parse as an ignored unknown key");
+        let registries = config.registries.as_ref().expect("registries table must be present");
+        let entry = registries.get("registry.corp").expect("entry must exist");
+        assert!(
+            entry.insecure.is_none(),
+            "a typo'd key must not deserialize as `insecure`"
+        );
+        // The parse outcome is one call short of the security property. The
+        // licensing decision is `insecure_hosts`'s `unwrap_or(false)`, so assert
+        // it there or the test's own message is a claim it never checked.
+        assert!(
+            crate::insecure_hosts(&config, &[]).is_empty(),
+            "a typo'd key must never license plaintext transport"
         );
     }
 

--- a/crates/ocx_lib/src/lib.rs
+++ b/crates/ocx_lib/src/lib.rs
@@ -9,6 +9,7 @@ mod media_type;
 /// `config` module path. Used by `ocx_cli`'s `ProjectContextError::Config`
 /// variant.
 pub use config::error::Error as ConfigError;
+pub use config::insecure::{allows_plain_http, insecure_hosts};
 pub use config::loader::{ConfigInputs, ConfigLoader};
 pub use config::managed::{
     ManagedConfig, ManagedConfigError, ManagedSnapshotState, RefreshPolicy, ResolvedManagedConfig,

--- a/crates/ocx_lib/src/oci/client.rs
+++ b/crates/ocx_lib/src/oci/client.rs
@@ -319,6 +319,8 @@ impl Client {
             error,
             ClientError::Registry(_)
                 | ClientError::RegistryTransient(_)
+                | ClientError::UnsafeDestination(_)
+                | ClientError::UnfollowedRedirect(_)
                 | ClientError::Authentication(_)
                 | ClientError::NotAManifest(_)
                 | ClientError::UnexpectedManifestType

--- a/crates/ocx_lib/src/oci/client/builder.rs
+++ b/crates/ocx_lib/src/oci/client/builder.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2026 The OCX Authors
 
-use crate::config::mirror::MirrorConfigError;
 use crate::{auth, oci};
 
 use super::Client;
@@ -113,58 +112,6 @@ impl ClientBuilder {
         }
     }
 
-    /// Creates a client configured from standard environment variables.
-    ///
-    /// Reads `OCX_INSECURE_REGISTRIES` to configure plain-HTTP registries and
-    /// `OCX_MIRRORS` to configure per-host registry mirrors. Progress rendering
-    /// is disabled; the CLI uses
-    /// [`from_env_with_progress`](Self::from_env_with_progress) to inject
-    /// its shared [`ProgressManager`](crate::cli::progress::ProgressManager).
-    ///
-    /// `from_env*` is the seam through which a forwarded `OCX_MIRRORS` reaches a
-    /// child `ocx`. Audit of call sites (2026-06-02): `from_env` is called only
-    /// by `crates/ocx_mirror/src/command/sync.rs::sync` (the mirror tool's
-    /// publisher client); `from_env_with_progress` is called only by
-    /// `crates/ocx_cli/src/app/context.rs::Context::try_init`. The CLI also
-    /// passes a `Config`-derived `MirrorMap` through the explicit
-    /// [`mirrors`](Self::mirrors) builder; reading `env::mirrors()` here makes
-    /// the same map available on the `from_env*` path so a forwarded
-    /// `OCX_MIRRORS` reaches a child even when it has no parsed `Config`.
-    ///
-    /// # Errors
-    ///
-    /// Returns the [`MirrorConfigError`] from [`resolve_mirror_map`] when the
-    /// forwarded `OCX_MIRRORS` is malformed, carries a non-string value, or
-    /// names an `http://` mirror whose host is not in `OCX_INSECURE_REGISTRIES`.
-    /// A failure aborts client construction rather than degrading to an identity
-    /// map — a silent degrade would route reads to the firewall-blocked origin,
-    /// the exact anti-goal replace semantics exist to prevent.
-    ///
-    /// [`resolve_mirror_map`]: crate::config::mirror::resolve_mirror_map
-    pub fn from_env() -> Result<Client, MirrorConfigError> {
-        Ok(ClientBuilder::new()
-            .plain_http_registries(crate::env::insecure_registries())
-            .mirrors(mirrors_from_env()?)
-            .build())
-    }
-
-    /// Like [`from_env`](Self::from_env) but renders transfer progress
-    /// through the supplied shared manager.
-    ///
-    /// # Errors
-    ///
-    /// Same as [`from_env`](Self::from_env): propagates the [`MirrorConfigError`]
-    /// from a malformed or insecure forwarded `OCX_MIRRORS`.
-    pub fn from_env_with_progress(
-        progress: crate::cli::progress::ProgressManager,
-    ) -> Result<Client, MirrorConfigError> {
-        Ok(ClientBuilder::new()
-            .plain_http_registries(crate::env::insecure_registries())
-            .mirrors(mirrors_from_env()?)
-            .progress(progress)
-            .build())
-    }
-
     /// Sets the shared progress manager used for download/upload bars.
     pub fn progress(mut self, progress: crate::cli::progress::ProgressManager) -> Self {
         self.progress = progress;
@@ -260,37 +207,6 @@ impl ClientBuilder {
     }
 }
 
-/// Builds a [`MirrorMap`] from the forwarded `OCX_MIRRORS` env var.
-///
-/// Delegates to the single lib resolver
-/// [`crate::config::mirror::resolve_mirror_map`] with an empty [`Config`] (the
-/// `from_env*` path has no parsed config — the mirror map comes entirely from
-/// the inherited `OCX_MIRRORS`) and the inherited
-/// [`crate::env::insecure_registries`]. Using the same resolver as
-/// `Context::try_init` means there is ONE Config→mirror-map transform with one
-/// precedence rule and one plain-HTTP gate, not two with divergent handling.
-///
-/// # Errors
-///
-/// A resolution failure here (a malformed or non-string forwarded env, or an
-/// http mirror whose host the parent did not also forward into
-/// `OCX_INSECURE_REGISTRIES`) is a HARD error: it aborts client construction on
-/// the child the same way the parent (`Context::try_init`) aborts. Degrading to
-/// an empty identity map would route reads to the firewall-blocked origin — the
-/// exact anti-goal replace semantics exist to prevent. A well-formed forwarded
-/// `OCX_MIRRORS` reaches the child unchanged.
-///
-/// [`Config`]: crate::config::Config
-fn mirrors_from_env() -> Result<MirrorMap, MirrorConfigError> {
-    let resolved = crate::config::mirror::resolve_mirror_map(
-        &crate::config::Config::default(),
-        crate::env::mirrors()?,
-        &crate::env::insecure_registries(),
-    )?;
-    // Registry role only — an index-only mirror must never rewrite OCI traffic.
-    Ok(MirrorMap::new(resolved.registry))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -334,57 +250,6 @@ mod tests {
         // proves they are valid DER. A wrong encoding tag (PEM over DER bytes)
         // would fail conversion and trip the very `Client::new` panic under test.
         let _client = builder.build();
-    }
-
-    // ── Step 3.1 specification tests ─────────────────────────────────────────
-
-    /// `from_env_with_progress` with `OCX_MIRRORS` set produces a `Client`
-    /// whose `mirrors` map is non-empty.
-    ///
-    /// This forces the `from_env*` wiring — not just the explicit-builder path.
-    /// Traces: plan Testing Strategy — "`from_env_with_progress` with
-    /// `OCX_MIRRORS` set → built `Client.mirrors` is non-empty"; ADR review
-    /// A5a/F4.
-    #[test]
-    fn from_env_with_progress_reads_ocx_mirrors_env() {
-        // Use the test env-lock so we do not mutate std::env and so the test
-        // serialises with other env-touching tests (no flaky parallel env race).
-        let env = crate::test::env::lock();
-        // A valid single-entry JSON object for OCX_MIRRORS.
-        env.set(
-            crate::env::keys::OCX_MIRRORS,
-            r#"{"ghcr.io":"https://mirror.corp/ghcr-remote"}"#,
-        );
-
-        let client = ClientBuilder::from_env_with_progress(crate::cli::progress::ProgressManager::disabled())
-            .expect("well-formed OCX_MIRRORS must build a client");
-
-        assert!(
-            !client.mirrors.is_empty(),
-            "from_env_with_progress with OCX_MIRRORS set must produce a non-empty MirrorMap"
-        );
-    }
-
-    /// A malformed forwarded `OCX_MIRRORS` aborts the child `from_env*` path —
-    /// the SAME hard-error contract as the parent (`Context::try_init`).
-    ///
-    /// The child must never silently degrade to an identity map: a forwarded
-    /// map that fails to resolve could otherwise route reads to the
-    /// firewall-blocked origin, the exact anti-goal replace semantics prevent.
-    ///
-    /// Traces: review Cluster-1 fail-loud — child path aborts like the parent.
-    #[test]
-    fn from_env_with_progress_aborts_on_malformed_ocx_mirrors() {
-        let env = crate::test::env::lock();
-        env.set(crate::env::keys::OCX_MIRRORS, "this is not valid json {{{");
-
-        let error = ClientBuilder::from_env_with_progress(crate::cli::progress::ProgressManager::disabled())
-            .err()
-            .expect("a malformed forwarded OCX_MIRRORS must abort the child");
-        assert!(
-            matches!(error, MirrorConfigError::MalformedEnvJson { .. }),
-            "expected MalformedEnvJson, got: {error:?}"
-        );
     }
 
     /// `http://` mirror host flows to `plain_http_registries`.
@@ -433,62 +298,6 @@ mod tests {
         assert!(
             client.mirrors.get("ghcr.io").is_some(),
             "ghcr.io mirror entry must be present on the built client"
-        );
-    }
-
-    // ── T-arch-G2: index-only OCX_MIRRORS entry excluded from Client.mirrors ──
-    //
-    // Traces: mirror-invariant audit 2026-07-19, gap G2.
-    //
-    // `mirrors_from_env` takes only `resolved.registry` — the F5b union value
-    // lets a host declare an `index`-role-only endpoint
-    // (`{"index": "..."}`), which must never reach `Client.mirrors` (that map
-    // feeds the OCI-distribution read path only). The sibling test above
-    // (`from_env_with_progress_reads_ocx_mirrors_env`) only exercises the
-    // bare-string (both-roles) form; these two close the index-only and mixed
-    // gaps using the same env-injection + inspector mechanics.
-
-    /// An `OCX_MIRRORS` entry that declares ONLY the `index` role must leave
-    /// the built client's `mirrors` map empty — the registry (OCI
-    /// distribution) read path must never be rewritten by an index-only
-    /// mirror declaration.
-    #[test]
-    fn from_env_with_progress_index_only_entry_yields_empty_client_mirrors() {
-        let env = crate::test::env::lock();
-        env.set(
-            crate::env::keys::OCX_MIRRORS,
-            r#"{"ghcr.io":{"index":"https://mirror.corp/idx"}}"#,
-        );
-
-        let client = ClientBuilder::from_env_with_progress(crate::cli::progress::ProgressManager::disabled())
-            .expect("an index-role-only OCX_MIRRORS entry must still build a client");
-
-        assert!(
-            client.mirrors.is_empty(),
-            "an index-only mirror entry must never populate Client.mirrors — the registry role is empty"
-        );
-    }
-
-    /// One index-only entry alongside one registry-bearing entry: the built
-    /// client's `mirrors` map must contain ONLY the registry-bearing host.
-    #[test]
-    fn from_env_with_progress_mixed_entries_keep_only_registry_bearing_host() {
-        let env = crate::test::env::lock();
-        env.set(
-            crate::env::keys::OCX_MIRRORS,
-            r#"{"ghcr.io":{"index":"https://mirror.corp/idx"},"quay.io":"https://mirror.corp/quay-remote"}"#,
-        );
-
-        let client = ClientBuilder::from_env_with_progress(crate::cli::progress::ProgressManager::disabled())
-            .expect("a mix of index-only and registry-bearing OCX_MIRRORS entries must still build a client");
-
-        assert!(
-            client.mirrors.get("ghcr.io").is_none(),
-            "the index-only ghcr.io entry must not appear in Client.mirrors"
-        );
-        assert!(
-            client.mirrors.get("quay.io").is_some(),
-            "the registry-bearing quay.io entry must appear in Client.mirrors"
         );
     }
 }

--- a/crates/ocx_lib/src/oci/client/error.rs
+++ b/crates/ocx_lib/src/oci/client/error.rs
@@ -111,6 +111,53 @@ pub enum ClientError {
     /// A registry operation failed.
     #[error("registry operation failed: {0}")]
     Registry(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// The registry named a destination the transport refuses to contact.
+    ///
+    /// Exactly the two typed request-time guards, both of which name a
+    /// destination and both of which refuse it: an upload-session `Location`
+    /// off the registry's own origin (the credential and the blob body would go
+    /// to a host the caller never named — CWE-918) and a plaintext
+    /// authentication realm named by an HTTPS registry (the credential would
+    /// cross in the clear — CWE-319).
+    ///
+    /// A redirect the transport did not follow is [`Self::UnfollowedRedirect`],
+    /// not this — the two shapes share an exit code and nothing else, and half
+    /// of that set refuses nothing.
+    ///
+    /// Exit 65, alongside [`ClientError::DigestMismatch`] and
+    /// [`ClientError::NotAManifest`], for the same reason those two are there:
+    /// the registry served something wrong and a rerun reaches the same
+    /// answer. 69 would tell a CI retry wrapper to re-issue the push against
+    /// the same hostile `Location` until its budget runs out — the one thing
+    /// the guard exists to prevent — and would make a registry outage
+    /// indistinguishable from a credential-exfiltration attempt. 78 would be
+    /// wrong for a different reason: no config change fixes a `Location`
+    /// header, so it would send the operator to a file with nothing to edit.
+    #[error("registry named a destination the transport refuses: {0}")]
+    UnsafeDestination(#[source] Box<dyn std::error::Error + Send + Sync>),
+    /// The registry answered with a redirect the transport did not follow.
+    ///
+    /// Four causes, and the transport cannot tell them apart once the error
+    /// reaches this layer — two are refusals, two are not:
+    ///
+    /// - the redirect policy declining an `https` -> `http` hop;
+    /// - the upload path declining a mid-session handoff (its session-URL
+    ///   requests run on a no-redirect client precisely so the blob body is not
+    ///   replayed to a registry-chosen host);
+    /// - the hop chain exceeding the fork's limit;
+    /// - a redirect no client could act on at all — a missing or unparseable
+    ///   `Location`, or a body that cannot be replayed — which `tower-http`
+    ///   hands back as the 3xx itself on any client, whatever its policy.
+    ///
+    /// Split from [`Self::UnsafeDestination`] for the last two: they name no
+    /// destination and refuse nothing, so reporting them as a refused unsafe
+    /// destination sends an operator hunting for an attacker over a registry
+    /// that emitted a malformed `302`.
+    ///
+    /// Exit 65 for all four, the same as its sibling and for the same reason —
+    /// a rerun walks the same chain to the same answer.
+    #[error("registry answered with a redirect the transport did not follow: {0}")]
+    UnfollowedRedirect(#[source] Box<dyn std::error::Error + Send + Sync>),
     /// A registry operation failed for a reason that may not repeat: the
     /// connect never completed, a request timed out, or the registry answered
     /// 429 / 502 / 503 / 504.
@@ -300,6 +347,8 @@ impl ClassifyExitCode for ClientError {
             // a data fault either, so it carries its own code.
             Self::ReferrersUnsupported { .. } => ExitCode::ReferrersUnsupported,
             Self::DigestMismatch { .. }
+            | Self::UnsafeDestination(_)
+            | Self::UnfollowedRedirect(_)
             | Self::DecompressionCapExceeded { .. }
             | Self::UnexpectedManifestType
             | Self::InvalidManifest(_)

--- a/crates/ocx_lib/src/oci/client/native_transport.rs
+++ b/crates/ocx_lib/src/oci/client/native_transport.rs
@@ -101,19 +101,72 @@ impl NativeTransport {
 /// says exactly that, and says a rerun cannot fix it. Exit 69 says the opposite
 /// -- it invites a retry wrapper to fetch the same wrong bytes again, and it
 /// reports a mis-routed mirror as an unavailable registry.
-fn registry_error(e: oci_client::errors::OciDistributionError) -> ClientError {
+///
+/// # Why there is no `_` arm
+///
+/// The fork's `OciDistributionError` is not `#[non_exhaustive]` and is
+/// path-vendored, so ocx controls the version. A catch-all here would ship
+/// every future guard the fork grows silently mis-classified -- which is
+/// exactly how `CrossHostRefused` and `InsecureAuthRealm` first landed on
+/// "registry unreachable, retry with backoff". An exhaustive match turns that
+/// into a compile error at the next submodule bump, which is the only
+/// compile-time guarantee available.
+pub(crate) fn registry_error(e: oci_client::errors::OciDistributionError) -> ClientError {
     use oci_client::errors::DigestError as WireDigestError;
     use oci_client::errors::OciDistributionError::{
-        AuthenticationFailure, DigestError, RegistryError, RequestError, ServerError, UnauthorizedError,
-        UnexpectedContentType,
+        AuthenticationFailure, ConfigConversionError, CrossHostRefused, DigestError, GenericError, HeaderValueError,
+        ImageIndexParsingNoPlatformResolverError, ImageManifestNotFoundError, IncompatibleLayerMediaTypeError,
+        InsecureAuthRealm, IoError, JsonError, ManifestEncodingError, ManifestParsingError, PullNoLayersError,
+        PushLayerNoDataError, PushNoDataError, RegistryError, RegistryNoDigestError, RegistryNoLocationError,
+        RegistryTokenDecodeError, RequestError, ResponseTooLargeError, ServerError, SpecViolationError,
+        UnauthorizedError, UnexpectedContentType, UnsupportedMediaTypeError, UnsupportedSchemaVersionError,
+        UrlParseError, VersionedParsingError,
     };
     use oci_client::errors::OciErrorCode;
     match &e {
-        RequestError(request) if request.is_timeout() || request.is_connect() => {
-            ClientError::RegistryTransient(Box::new(e))
-        }
+        // A connect that never completed against an `https://` URL is the shape
+        // a plain-HTTP registry produces, and the scheme is itself the proof
+        // that the host is NOT in the plain-HTTP allowance -- a host that were
+        // would have been contacted over `http`. So the remediation can be
+        // named without knowing the allowance set here. It stays TempFail: a
+        // refused connection and a DNS failure are the common causes and both
+        // are retryable, and mis-labelling those as terminal would also stop
+        // `push_blob`'s transient-only retry.
+        RequestError(request) if request.is_connect() => match https_allowance_name(request.url()) {
+            Some(host) => ClientError::RegistryTransient(Box::new(PlainHttpAllowanceHint { host, source: e })),
+            None => ClientError::RegistryTransient(Box::new(e)),
+        },
+        RequestError(request) if request.is_timeout() => ClientError::RegistryTransient(Box::new(e)),
+        // The two typed guards -- the only two shapes that name a destination and
+        // refuse it. See `ClientError::UnsafeDestination` for why 65.
+        CrossHostRefused { .. } | InsecureAuthRealm { .. } => ClientError::UnsafeDestination(Box::new(e)),
+        // The fork's redirect policy ending a chain with `attempt.error(..)`:
+        // either an `https` -> `http` hop, or the hop count exceeding
+        // `MAX_REDIRECTS`. A closure inside reqwest, so a reqwest error rather
+        // than a typed variant.
+        //
+        // The limit branch reaches here only because it errors rather than
+        // stopping: `attempt.stop()` hands the 3xx back as an `Ok` response,
+        // which `error_for_status_ref` reads as success -- a blob behind an
+        // over-long chain then answered "exists" to a HEAD and its layer was
+        // never uploaded.
+        RequestError(request) if request.is_redirect() => ClientError::UnfollowedRedirect(Box::new(e)),
         AuthenticationFailure(_) | UnauthorizedError { .. } => ClientError::Authentication(Box::new(e)),
         ServerError { code: 401 | 403, .. } => ClientError::Authentication(Box::new(e)),
+        // A 3xx that reached ocx as a *status* is a redirect no client acted on,
+        // from either of two paths:
+        //
+        // - the upload path, which issues its registry-supplied session URLs on a
+        //   `Policy::none()` client precisely so a mid-session handoff surfaces
+        //   instead of replaying the blob body to a foreign host (CWE-918);
+        // - a redirect `tower-http` could not follow at all -- a missing or
+        //   unparseable `Location`, or a body it cannot clone -- which it hands
+        //   back as the 3xx itself on ANY client, whatever the policy.
+        //
+        // The two are indistinguishable here: both arrive as `ServerError`, and
+        // the second is a malformed answer, not a refusal. Both are terminal --
+        // a rerun walks the same chain to the same answer.
+        ServerError { code: 301..=308, .. } => ClientError::UnfollowedRedirect(Box::new(e)),
         ServerError {
             code: 429 | 502 | 503 | 504,
             ..
@@ -140,8 +193,87 @@ fn registry_error(e: oci_client::errors::OciDistributionError) -> ClientError {
             expected: expected.clone(),
             actual: actual.clone(),
         },
-        _ => ClientError::Registry(Box::new(e)),
+        // Everything the registry answered that ocx cannot use, enumerated so
+        // the next fork variant is a compile error rather than a silent 69.
+        ConfigConversionError(_)
+        | DigestError(_)
+        | GenericError(_)
+        | HeaderValueError(_)
+        | ImageManifestNotFoundError(_)
+        | ImageIndexParsingNoPlatformResolverError
+        | IncompatibleLayerMediaTypeError(_)
+        | IoError(_)
+        | JsonError(_)
+        | ManifestEncodingError(_)
+        | ManifestParsingError(_)
+        | PushNoDataError
+        | PushLayerNoDataError
+        | PullNoLayersError
+        | RegistryNoDigestError
+        | RegistryNoLocationError
+        | RegistryTokenDecodeError(_)
+        | RequestError(_)
+        | ServerError { .. }
+        | ResponseTooLargeError { .. }
+        | SpecViolationError(_)
+        | UrlParseError(_)
+        | UnsupportedMediaTypeError(_)
+        | UnsupportedSchemaVersionError(_)
+        | VersionedParsingError(_) => ClientError::Registry(Box::new(e)),
     }
+}
+
+/// The `[registries."<name>"]` key that would have licensed plain HTTP for the
+/// host this failed request was addressed to, when the request used `https`.
+///
+/// `None` for any other scheme or a URL with no host: the hint is only correct
+/// when TLS is what was attempted.
+///
+/// # One case where the hint under-quotes
+///
+/// This is the only one of the four plain-HTTP messages that DERIVES the name
+/// instead of quoting the configured string, and the two sides normalise
+/// differently. The `url` crate drops a scheme-default port at parse time, so
+/// `https://mirror.corp:443/` yields `mirror.corp` -- but `config::mirror`'s
+/// `parse_url` keeps the authority verbatim, and `resolve_registry()` passes it
+/// through unchanged, so a name configured as `mirror.corp:443` is what the gate
+/// actually compares. For that one redundant spelling the hint names a key that
+/// would grant nothing. `registry_error` holds only the post-parse `Url` and
+/// cannot recover the configured form, so this is stated rather than fixed.
+///
+/// Twin on the other side of the submodule boundary: the fork's `url_authority`
+/// derives the same `host[:port]` and decides whether a plaintext realm is
+/// ADMITTED, where this one tells the operator what to write to admit one. A
+/// crate boundary rules out sharing the function, so a change to either wants a
+/// look at the other.
+fn https_allowance_name(url: Option<&reqwest::Url>) -> Option<String> {
+    let url = url.filter(|url| url.scheme() == "https")?;
+    let host = url.host_str()?;
+    Some(match url.port() {
+        // `Url::port` is `None` on the scheme's default port, which is exactly
+        // when the allowance is written as the bare host.
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    })
+}
+
+/// Carries the plain-HTTP remediation on a failed HTTPS connect.
+///
+/// A registry that speaks plain HTTP answers a TLS `ClientHello` with an HTTP
+/// response, which rustls reports as "received corrupt message of type
+/// InvalidContentType" -- legible only to someone who has met it before, and
+/// naming neither of the two ways to allow plaintext. Wrapping rather than
+/// adding a `ClientError` variant keeps the transient bucket, and with it
+/// `push_blob`'s retry and `via_mirror`'s annotation, exactly as they were.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "could not connect to '{host}' over https; if it serves plain HTTP, set insecure = true \
+     under [registries.\"{host}\"] or add the host to OCX_INSECURE_REGISTRIES"
+)]
+struct PlainHttpAllowanceHint {
+    host: String,
+    #[source]
+    source: oci_client::errors::OciDistributionError,
 }
 
 /// Maps OCI distribution errors to [`ClientError::ManifestNotFound`] when the
@@ -907,6 +1039,187 @@ mod tests {
             url: "https://registry.test/v2/mirror/cmake/tags/list".to_string(),
             message: String::new(),
         }
+    }
+
+    /// Bind a loopback listener that answers exactly one connection with `raw`,
+    /// returning the port and the task handle so the caller can abort it.
+    async fn one_shot_http(raw: &'static [u8]) -> (u16, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let port = listener.local_addr().expect("addr").port();
+        let server = tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt as _;
+                let _ = socket.write_all(raw).await;
+                let _ = socket.flush().await;
+            }
+        });
+        (port, server)
+    }
+
+    /// The two typed guards are terminal refusals, not availability faults.
+    /// Before this they fell through the `_` arm to `Registry` (exit 69), which
+    /// tells a CI retry wrapper to re-issue the push against the same hostile
+    /// `Location` — the one thing the guard exists to prevent. Asserting they
+    /// are NOT `Registry` is what pins the arm; `UnsafeDestination` alone would
+    /// also hold if the whole taxonomy collapsed.
+    #[test]
+    fn the_forks_local_refusals_are_unsafe_destinations_not_registry_faults() {
+        let cross_host = OciDistributionError::CrossHostRefused {
+            url: "https://evil.example/v2/x/blobs/uploads/1".to_string(),
+            registry: "registry.test".to_string(),
+        };
+        let plaintext_realm = OciDistributionError::InsecureAuthRealm {
+            realm: "http://collector.example/token".to_string(),
+        };
+
+        for wire in [cross_host, plaintext_realm] {
+            let label = format!("{wire:?}");
+            let mapped = registry_error(wire);
+            assert!(
+                matches!(mapped, ClientError::UnsafeDestination(_)),
+                "{label} must map to UnsafeDestination, got {mapped:?}"
+            );
+        }
+    }
+
+    /// A declined hop reaches ocx as a reqwest *error*, not a typed fork
+    /// variant, because the policy is a closure inside reqwest. Driven through
+    /// a real client so the `is_redirect()` predicate is exercised against the
+    /// error reqwest actually builds, not an assumption about it.
+    ///
+    /// Loopback only — one accept, one hand-written `302`, no TLS needed: the
+    /// policy under test here is ocx's classification of the refusal, and the
+    /// fork owns the downgrade decision itself.
+    #[tokio::test]
+    async fn a_declined_redirect_hop_is_an_unfollowed_redirect_not_a_registry_fault() {
+        let (port, server) =
+            one_shot_http(b"HTTP/1.1 302 Found\r\nLocation: /elsewhere\r\nContent-Length: 0\r\n\r\n").await;
+
+        let wire = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::custom(|attempt| {
+                attempt.error(std::io::Error::other("refusing this hop"))
+            }))
+            .build()
+            .expect("client")
+            .get(format!("http://127.0.0.1:{port}/v2/"))
+            .send()
+            .await
+            .expect_err("a refused redirect must fail the request");
+        server.abort();
+
+        assert!(wire.is_redirect(), "precondition: reqwest must report a redirect error");
+
+        let mapped = registry_error(wire.into());
+        assert!(
+            matches!(mapped, ClientError::UnfollowedRedirect(_)),
+            "a declined hop must not read as an unavailable registry, got {mapped:?}"
+        );
+    }
+
+    /// A `Location`-less 3xx is handed back as the 3xx itself, by a client whose
+    /// policy would gladly have followed it — the shape that made the old
+    /// `UnsafeDestination` name a lie, since nothing was named and nothing was
+    /// refused. The precondition assertion is the load-bearing half: it proves
+    /// the arm is reachable on the ordinary follow-redirects client, so the
+    /// classification below is not a statement about the upload path alone.
+    #[tokio::test]
+    async fn a_location_less_redirect_is_an_unfollowed_redirect_on_a_following_client() {
+        let (port, server) = one_shot_http(b"HTTP/1.1 302 Found\r\nContent-Length: 0\r\n\r\n").await;
+
+        let response = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::limited(10))
+            .build()
+            .expect("client")
+            .get(format!("http://127.0.0.1:{port}/v2/"))
+            .send()
+            .await
+            .expect("a Location-less 3xx is handed back as a successful response, not an error");
+        server.abort();
+
+        assert_eq!(
+            response.status().as_u16(),
+            302,
+            "precondition: a following client cannot act on a Location-less redirect, so it \
+             surfaces the 3xx as the response"
+        );
+
+        // The fork's status handler turns any unhandled status into `ServerError`,
+        // carrying nothing that distinguishes this from the upload path's refusal.
+        let mapped = registry_error(server_error(response.status().as_u16()));
+        assert!(
+            matches!(mapped, ClientError::UnfollowedRedirect(_)),
+            "a malformed redirect must not read as a refused unsafe destination, got {mapped:?}"
+        );
+    }
+
+    /// The `host[:port]` the plain-HTTP allowance would be written as, derived
+    /// from the URL the failed request carried. `Url::port` is `None` on the
+    /// scheme default, which is exactly when the allowance is the bare host.
+    #[test]
+    fn the_allowance_name_is_derived_only_from_an_https_url() {
+        let name = |raw: &str| {
+            let url = reqwest::Url::parse(raw).expect("valid url");
+            https_allowance_name(Some(&url))
+        };
+
+        assert_eq!(
+            name("https://registry.corp:5000/v2/"),
+            Some("registry.corp:5000".into())
+        );
+        assert_eq!(name("https://registry.corp/v2/"), Some("registry.corp".into()));
+        assert_eq!(
+            name("https://registry.corp:443/v2/"),
+            Some("registry.corp".into()),
+            "the default port is not part of the name the allowance is written as"
+        );
+        assert_eq!(
+            name("http://registry.corp:5000/v2/"),
+            None,
+            "the hint is only correct when TLS is what was attempted"
+        );
+        assert_eq!(https_allowance_name(None), None);
+    }
+
+    /// End to end on a real `reqwest` connect failure: the refusal an operator
+    /// actually sees must name the config key and the env var. Loopback only —
+    /// the port is one the OS just told us is free, so the connect is refused
+    /// locally with no network and no DNS.
+    #[tokio::test]
+    async fn a_failed_https_connect_names_both_ways_to_allow_plain_http() {
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("bind a free port")
+            .local_addr()
+            .expect("local addr")
+            .port();
+
+        let wire = reqwest::Client::builder()
+            .build()
+            .expect("client")
+            .get(format!("https://127.0.0.1:{port}/v2/"))
+            .send()
+            .await
+            .expect_err("a connect to a closed port must fail");
+        assert!(wire.is_connect(), "precondition: this must be a connect failure");
+
+        let mapped = registry_error(wire.into());
+        let rendered = mapped.to_string();
+
+        assert!(
+            matches!(mapped, ClientError::RegistryTransient(_)),
+            "the bucket must not move — a refused connect is still retryable, got {mapped:?}"
+        );
+        assert!(
+            rendered.contains(&format!("[registries.\"127.0.0.1:{port}\"]")),
+            "the refusal must quote the exact config key that would grant it: {rendered}"
+        );
+        assert!(
+            rendered.contains("insecure = true"),
+            "the refusal must name the config spelling: {rendered}"
+        );
+        assert!(
+            rendered.contains("OCX_INSECURE_REGISTRIES"),
+            "the refusal must name the env spelling too: {rendered}"
+        );
     }
 
     /// Regression tests for issue #157 — `list_tags` errors must distinguish

--- a/crates/ocx_lib/src/oci/index/error.rs
+++ b/crates/ocx_lib/src/oci/index/error.rs
@@ -267,14 +267,15 @@ pub enum Error {
 
     /// An index-role traffic target (the `[registries."<namespace>"] index`
     /// base, or its `[mirrors."<host>"] index` role override) uses plain
-    /// `http://` but the target host is not in `OCX_INSECURE_REGISTRIES`. The
+    /// `http://` but the target host is in neither half of the insecure-host union
+    /// (`[registries."<host>"] insecure`, `OCX_INSECURE_REGISTRIES`). The
     /// root document is the index path's trust anchor (nothing pins it from
     /// above), so an on-path attacker on a plaintext index owns every
     /// downstream resolution — refuse loud rather than silently downgrade
     /// (CWE-319, same doctrine as the registry role).
     #[error(
-        "index traffic to '{host}' for registry '{namespace}' uses http:// but is not in OCX_INSECURE_REGISTRIES; \
-         add it to allow plain-HTTP transport"
+        "index traffic to '{host}' for registry '{namespace}' uses http:// but that host is not allowed plain HTTP; \
+         set insecure = true under [registries.\"{host}\"] or add the host to OCX_INSECURE_REGISTRIES"
     )]
     PlainHttpIndexNotAllowed { namespace: String, host: String },
 
@@ -479,5 +480,24 @@ mod tests {
     fn singleflight_timeout_classifies_as_temp_fail() {
         let error = Error::SingleflightFailed(crate::utility::singleflight::Error::Timeout);
         assert_eq!(crate::cli::classify_error(&error), ExitCode::TempFail);
+    }
+
+    /// The refusal has to name the config key, quoted with its port, or the
+    /// operator is told only half the fix. Every other test of this variant
+    /// matches on its shape, which the old env-var-only wording satisfied too.
+    #[test]
+    fn the_plain_http_index_refusal_names_both_ways_to_allow_it() {
+        let rendered = Error::PlainHttpIndexNotAllowed {
+            namespace: "ocx.sh".to_string(),
+            host: "index.corp:8080".to_string(),
+        }
+        .to_string();
+
+        assert!(rendered.contains("index.corp:8080"), "{rendered}");
+        assert!(
+            rendered.contains("set insecure = true under [registries.\"index.corp:8080\"]"),
+            "the exact TOML key, port included, is what an operator can paste: {rendered}"
+        );
+        assert!(rendered.contains("OCX_INSECURE_REGISTRIES"), "{rendered}");
     }
 }

--- a/crates/ocx_lib/src/oci/index/ocx_index.rs
+++ b/crates/ocx_lib/src/oci/index/ocx_index.rs
@@ -853,7 +853,7 @@ impl OcxIndex {
     /// | Scheme | Target |
     /// |---|---|
     /// | absent / `https` | [`ReqwestIndexTransport`] |
-    /// | `http` | [`ReqwestIndexTransport`], only when the final host is in `insecure_hosts` (`OCX_INSECURE_REGISTRIES`) — the root document is the index path's trust anchor, so a plaintext index is an on-path takeover (CWE-319), gated exactly like the registry role |
+    /// | `http` | [`ReqwestIndexTransport`], only when the final host is in `insecure_hosts` (the union of `[registries."<host>"] insecure` and `OCX_INSECURE_REGISTRIES`) — the root document is the index path's trust anchor, so a plaintext index is an on-path takeover (CWE-319), gated exactly like the registry role |
     /// | `file` | [`FileIndexTransport`](super::FileIndexTransport), as a **configured base only** — empty authority, absolute path, and no `[mirrors]` override (which is host-keyed, and a `file` base has no host) |
     /// | anything else | refused |
     ///
@@ -924,7 +924,7 @@ impl OcxIndex {
         // injected through `OCX_MIRRORS` — bypasses a base-only check (C-020).
         match target.protocol.as_str() {
             "https" => {}
-            "http" if insecure_hosts.iter().any(|host| host == &target.host) => {}
+            "http" if crate::allows_plain_http(insecure_hosts, &target.host) => {}
             "http" => {
                 return Err(super::error::Error::PlainHttpIndexNotAllowed {
                     namespace: namespace.to_string(),
@@ -2368,7 +2368,7 @@ mod tests {
                 .unwrap()
                 .url,
             "http://mirror.corp/ocx-index",
-            "an http base is allowed when its host is in OCX_INSECURE_REGISTRIES"
+            "an http base is allowed when its host is in the resolved plain-HTTP set"
         );
 
         // The default https base URL is never gated.
@@ -2378,6 +2378,41 @@ mod tests {
                 .url,
             DEFAULT_INDEX_BASE_URL,
             "https must pass the gate untouched"
+        );
+    }
+
+    /// The index gate is fed by the SHARED predicate, so a `[registries.<host>]
+    /// insecure = true` entry licenses a plain-HTTP index base with the
+    /// environment empty. Every other test of this gate hands it a literal
+    /// vector, which is equally satisfied by an env-only build of the set.
+    ///
+    /// The env is explicitly `&[]` in both halves — an inherited
+    /// `OCX_INSECURE_REGISTRIES` would make the green indistinguishable from
+    /// the config entry doing nothing.
+    #[test]
+    fn resolve_base_url_accepts_an_http_base_licensed_by_the_config_half_alone() {
+        let config: crate::config::Config = toml::from_str(
+            "[registries.\"ocx.sh\"]\nindex = \"http://index.corp:8080/ocx-index\"\n\
+             [registries.\"index.corp:8080\"]\ninsecure = true\n",
+        )
+        .unwrap();
+
+        let licensed = crate::insecure_hosts(&config, &[]);
+        assert_eq!(
+            licensed,
+            vec!["index.corp:8080".to_string()],
+            "precondition: the allowance comes from the config, not the environment"
+        );
+
+        assert_eq!(
+            OcxIndex::resolve_base_url(&config, "ocx.sh", &no_mirrors(), &licensed)
+                .expect("a config-licensed plain-HTTP index base must resolve")
+                .url,
+            "http://index.corp:8080/ocx-index",
+        );
+        assert!(
+            OcxIndex::resolve_base_url(&config, "ocx.sh", &no_mirrors(), &[]).is_err(),
+            "and it must still be refused when nothing licenses it"
         );
     }
 

--- a/crates/ocx_lib/src/project/resolve.rs
+++ b/crates/ocx_lib/src/project/resolve.rs
@@ -843,6 +843,11 @@ fn classify(client: &ClientError) -> ClientFailure {
         ClientError::InvalidManifest(_)
         | ClientError::NotAManifest(_)
         | ClientError::InvalidImageIndex(_)
+        // A registry-named destination the transport refused is terminal by
+        // construction: retrying re-issues the request against the same
+        // hostile value.
+        | ClientError::UnsafeDestination(_)
+        | ClientError::UnfollowedRedirect(_)
         | ClientError::DigestMismatch { .. }
         | ClientError::DecompressionCapExceeded { .. }
         | ClientError::UnexpectedManifestType
@@ -951,6 +956,30 @@ mod classify_tests {
         let pinned =
             PinnedIdentifier::try_from(id.clone_with_digest(Digest::Sha256("a".repeat(64)))).expect("valid pinned");
         assert_not_found(ClientError::BlobNotFound(pinned));
+    }
+
+    /// A destination the transport refused must never enter the retry budget.
+    /// This layer is the one place in the workspace that would actually re-issue
+    /// it: `ClientFailure::Transient` feeds `retry_fetch`'s sleep-and-retry loop,
+    /// so classifying a `CrossHostRefused` there would re-send the push to the
+    /// registry-named hostile `Location` until the budget ran out — the single
+    /// behaviour the guard exists to prevent.
+    ///
+    /// Its sibling `UnfollowedRedirect` is here for the same reason from the
+    /// other direction: a chain that ended in a refusal, a limit, or an
+    /// unusable `Location` walks to the same answer on every rerun, so a retry
+    /// buys nothing and a scheme-downgrade refusal would be re-issued.
+    ///
+    /// The exhaustive `match` in `classify` catches a *forgotten* variant, not a
+    /// variant *moved* between arms, which compiles clean.
+    #[test]
+    fn a_refused_destination_and_an_unfollowed_redirect_are_both_other() {
+        assert_other(ClientError::UnsafeDestination(Box::new(std::io::Error::other(
+            "cross-host upload session URL",
+        ))));
+        assert_other(ClientError::UnfollowedRedirect(Box::new(std::io::Error::other(
+            "too many redirects (limit 10)",
+        ))));
     }
 
     /// A mirror answering with a login portal must not be retried: the

--- a/test/tests/test_config_test.py
+++ b/test/tests/test_config_test.py
@@ -311,6 +311,30 @@ def test_config_test_allowed_plain_http_mirror_passes(ocx: OcxRunner, tmp_path: 
     assert "ghcr.io" in report["mirrors"]
 
 
+def test_config_test_plain_http_mirror_allowed_by_candidate_registries_entry(
+    ocx: OcxRunner, tmp_path: Path
+) -> None:
+    """The candidate's own ``[registries."<host>"] insecure = true`` entry
+    licenses its plain-HTTP mirror on its own, with ``OCX_INSECURE_REGISTRIES``
+    explicitly emptied so the config half cannot hide behind an inherited env
+    grant. The pair above drives only the env half of the union
+    (``OCX_INSECURE_REGISTRIES: ""`` vs. ``"mirror.corp"``) — this is the
+    config half, exercised end to end including the ``plain_http`` report
+    field."""
+    candidate = _write_candidate(
+        tmp_path,
+        '[mirrors."ghcr.io"]\nregistry = "http://mirror.corp"\n'
+        '[registries."mirror.corp"]\ninsecure = true\n',
+    )
+
+    report = ocx.json(
+        "config", "test", str(candidate), env_overrides={"OCX_INSECURE_REGISTRIES": ""}
+    )
+
+    assert "ghcr.io" in report["mirrors"]
+    assert report["plain_http"] == ["mirror.corp"]
+
+
 def test_config_test_rejects_empty_patch_registry_exit_78(ocx: OcxRunner, tmp_path: Path) -> None:
     """An empty `[patches] registry` is a no-op tier that would silently skip
     every companion — refused at resolve time, and the command's help promises

--- a/test/tests/test_index_ocx_sh.py
+++ b/test/tests/test_index_ocx_sh.py
@@ -245,6 +245,58 @@ def test_two_hop_resolve_snapshots_offline_and_hits_only_the_fixture(
     assert not (clean_home / "blobs").exists()
 
 
+def test_two_hop_resolve_licensed_by_config_registries_entry_alone(
+    ocx: OcxRunner,
+    unique_repo: str,
+    tmp_path: Path,
+    index_server: static_index.StaticIndexServer,
+) -> None:
+    """The plain-HTTP index gate accepts the config half of the union on its
+    own: ``[registries."<index host>"] insecure = true``, with
+    ``OCX_INSECURE_REGISTRIES`` licensing only the physical registry and never
+    the index host. Every other plain-HTTP-index case in this file
+    (``configure_index_source``) drives the gate through the env var alone —
+    this is the config half, exercised end to end through a real two-hop
+    resolve.
+    """
+    pkg = make_package(ocx, unique_repo, "1.0.0", tmp_path, new=True, index=False)
+    leaf_digest = fetch_platform_manifest_digest(ocx.registry, pkg.repo, pkg.tag)
+    os_name, arch_name = pkg.platform.split("/")
+
+    registry_host = ocx.registry.split(":", 1)[0]
+    config_path = Path(ocx.env["OCX_HOME"]) / "config.toml"
+    config_path.write_text(
+        f'[registries."ocx.sh"]\nindex = "{index_server.base_url}"\ntrusted_hosts = ["{registry_host}"]\n'
+        f'[registries."{index_server.host}"]\ninsecure = true\n'
+    )
+    # Deliberately NOT the index host: only the physical registry goes
+    # through the env half, so the index host's allowance can only have come
+    # from the config entry above.
+    ocx.env["OCX_INSECURE_REGISTRIES"] = ocx.registry
+
+    static_index.write_config(index_server.root)
+    repository = f"{unique_repo}/pkg"
+    entry = static_index.write_package(
+        index_server.root,
+        repository=repository,
+        tag="1.0.0",
+        physical_repository=f"oci://{ocx.registry}/{pkg.repo}",
+        platform_digest=leaf_digest,
+        os=os_name,
+        architecture=arch_name,
+    )
+
+    index_dir = tmp_path / "index_dir"
+    index_dir.mkdir()
+    ocx.plain("--index", str(index_dir), "index", "update", entry.logical_id)
+
+    requested_paths = [record.path for record in index_server.requests]
+    assert any(path.endswith("/config.json") for path in requested_paths), (
+        "the config-licensed index host must have been reached at all"
+    )
+    assert _root_document_path(index_dir, repository).is_file()
+
+
 def test_two_hop_resolve_under_a_non_ocx_sh_namespace(
     ocx: OcxRunner,
     unique_repo: str,

--- a/test/tests/test_login.py
+++ b/test/tests/test_login.py
@@ -376,6 +376,33 @@ def test_login_password_value_flag_rejected(ocx: OcxRunner, tmp_path: Path) -> N
     assert result.returncode == 64, f"exit {result.returncode}"
 
 
+def test_login_removed_insecure_flag_rejected(ocx: OcxRunner, tmp_path: Path) -> None:
+    """``--insecure`` no longer exists: the shared
+    ``[registries."<host>"] insecure`` / ``OCX_INSECURE_REGISTRIES`` gate every
+    other command uses is the only way to license plain HTTP now. Passing the
+    removed flag is an unknown-argument usage error, same shape as the
+    ``--password VALUE`` case above.
+
+    ``-u``/``--password-stdin``/stdin are all supplied (unlike the bare
+    positional above) so a build that still parses ``--insecure`` would run
+    the command instead of exiting 64 for the unrelated missing-credential
+    reason — that would make this pass for the wrong reason in both worlds.
+    """
+    docker_config_dir = tmp_path / "docker"
+    docker_config_dir.mkdir()
+    result = _run_login(
+        ocx,
+        "-u",
+        "u",
+        "--password-stdin",
+        "--insecure",
+        "ghcr.io",
+        docker_config_dir=docker_config_dir,
+        stdin="tok\n",
+    )
+    assert result.returncode == 64, f"exit {result.returncode}: {result.stderr}"
+
+
 # ---------------------------------------------------------------------------
 # Scenario 4: credentials rejected (Ping-then-Put invariant)
 # ---------------------------------------------------------------------------
@@ -420,6 +447,56 @@ def test_login_rejects_credentials_with_loginrejected(
     # Critical invariant: store must NOT have received the credential.
     assert not sidecar.exists(), (
         "Ping-then-Put invariant violated: bad credential reached the helper store"
+    )
+
+
+def test_login_against_plain_http_registry_is_tempfail_not_rejected_credentials(
+    ocx: OcxRunner, tmp_path: Path, registry: str
+) -> None:
+    """The default ``--verify`` path (no ``--no-verify``) pings the registry
+    with the real ``OciClientPing`` before it will store anything. Against a
+    registry that only speaks plain HTTP, with its host deliberately NOT in
+    ``OCX_INSECURE_REGISTRIES`` (the ``ocx`` fixture licenses it by default,
+    so this is the one call site that overrides it back out), the TLS
+    handshake never completes — the credential is never judged, so this must
+    NOT be ``AuthError::LoginRejected`` (exit 80, "rejected credentials"). It
+    classifies through the same ``ClientError`` taxonomy every other command
+    uses (``RegistryTransient``, exit 75), and the remediation names both ways
+    to license plain HTTP.
+    """
+    docker_config_dir = tmp_path / "docker"
+    docker_config_dir.mkdir()
+    env = dict(ocx.env)
+    env["DOCKER_CONFIG"] = str(docker_config_dir)
+    env["OCX_INSECURE_REGISTRIES"] = ""
+
+    result = subprocess.run(
+        [str(ocx.binary), "login", "-u", "u", "--password-stdin", registry],
+        capture_output=True,
+        text=True,
+        env=env,
+        input="tok\n",
+        timeout=40.0,
+    )
+
+    assert result.returncode == 75, (
+        "a failed HTTPS connect must be TempFail (75), not LoginRejected (80): "
+        f"exit {result.returncode}\nstderr: {result.stderr}"
+    )
+    assert "rejected credentials" not in result.stderr, (
+        f"must not misreport a connect failure as rejected credentials: {result.stderr}"
+    )
+    assert "insecure = true" in result.stderr, (
+        f"remediation must name the config spelling: {result.stderr}"
+    )
+    assert f'[registries."{registry}"]' in result.stderr, (
+        f"remediation must quote the exact TOML key, port included: {result.stderr}"
+    )
+    assert "OCX_INSECURE_REGISTRIES" in result.stderr, (
+        f"remediation must also name the env spelling: {result.stderr}"
+    )
+    assert not (docker_config_dir / "config.json").exists(), (
+        "Ping-then-Put invariant: a failed probe must not reach the store"
     )
 
 

--- a/test/tests/test_oci_registry_mirror.py
+++ b/test/tests/test_oci_registry_mirror.py
@@ -166,7 +166,8 @@ def test_mirror_install_routes_to_configured_mirror(
 
     # Install using the upstream identifier — OCX must route to the mirror.
     # The mirror is a plain-HTTP endpoint, so its host must be listed in
-    # OCX_INSECURE_REGISTRIES (ADR F2: the mirror host is what gets contacted).
+    # OCX_INSECURE_REGISTRIES (adr_oci_registry_mirror.md, Implementation Plan
+    # step 3 "Auth + insecure": the mirror host is what gets contacted).
     fq = f"{registry}/{unique_repo}:1.0.0"
     run_with_env(
         ocx,
@@ -230,7 +231,8 @@ def test_mirror_push_targets_canonical_registry_not_mirror(
     )
 
     # Configure the mirror so we prove push ignores it. The plain-HTTP mirror
-    # host must be listed in OCX_INSECURE_REGISTRIES (ADR F2) so the cascade
+    # host must be listed in OCX_INSECURE_REGISTRIES (adr_oci_registry_mirror.md,
+    # Implementation Plan step 3 "Auth + insecure") so the cascade
     # tag-listing read can reach it; the push itself stays canonical (ADR Q5).
     write_home_config(
         ocx,
@@ -321,8 +323,9 @@ def test_mirror_ocx_lock_records_canonical_host_and_digest(
         ocx,
         f'[mirrors]\n"{registry}" = "http://{mirror_registry}"\n',
     )
-    # Plain-HTTP mirror host must be in OCX_INSECURE_REGISTRIES (ADR F2) so the
-    # lock resolution read can reach it.
+    # Plain-HTTP mirror host must be in OCX_INSECURE_REGISTRIES
+    # (adr_oci_registry_mirror.md, Implementation Plan step 3 "Auth + insecure")
+    # so the lock resolution read can reach it.
     ocx.env["OCX_INSECURE_REGISTRIES"] = f"{registry},{mirror_registry}"
 
     # Create a project and lock it.
@@ -399,7 +402,8 @@ def test_mirror_library_prefix_repo_routes_verbatim(
     )
 
     # Install with the library/ prefix in the identifier. The plain-HTTP mirror
-    # host must be listed in OCX_INSECURE_REGISTRIES (ADR F2).
+    # host must be listed in OCX_INSECURE_REGISTRIES (adr_oci_registry_mirror.md,
+    # Implementation Plan step 3 "Auth + insecure").
     fq = f"{registry}/{library_repo}:1.0.0"
     run_with_env(
         ocx,
@@ -437,7 +441,8 @@ def test_plain_http_mirror_with_insecure_flag_succeeds(
     succeeds.
 
     Traces: plan scenario 6 — "plain-HTTP mirror with host in
-    OCX_INSECURE_REGISTRIES → install succeeds"; ADR F2 footgun mitigation.
+    OCX_INSECURE_REGISTRIES → install succeeds"; adr_oci_registry_mirror.md,
+    Implementation Plan step 3 "Auth + insecure" footgun mitigation.
     """
     # Push to the mirror (plain-HTTP registry) only.
     mirror_ocx = OcxRunner(ocx.binary, ocx.ocx_home, mirror_registry)
@@ -460,6 +465,61 @@ def test_plain_http_mirror_with_insecure_flag_succeeds(
         "install",
         fq,
         extra_env={"OCX_INSECURE_REGISTRIES": f"{registry},{mirror_registry}"},
+    )
+
+    home = Path(ocx.env["OCX_HOME"])
+    from src.assertions import assert_symlink_exists  # noqa: PLC0415
+    assert_symlink_exists(
+        home
+        / "symlinks"
+        / _registry_slug(registry)
+        / unique_repo
+        / "candidates"
+        / "1.0.0"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6c — plain-HTTP mirror allowed by config alone, no env var
+# ---------------------------------------------------------------------------
+
+
+def test_plain_http_mirror_with_config_insecure_entry_succeeds(
+    ocx: OcxRunner,
+    registry: str,
+    mirror_registry: str,
+    unique_repo: str,
+    tmp_path: Path,
+) -> None:
+    """``[registries."<host>"] insecure = true`` alone licenses the plain-HTTP
+    mirror — with ``OCX_INSECURE_REGISTRIES`` explicitly emptied.
+
+    The env half of the union is what scenario 6a exercises; this is the
+    config half on its own. Emptying the variable is the whole point: the
+    runner sets it per instance, so leaving it inherited would make the
+    config entry unobservable and the green indistinguishable from 6a.
+    """
+    mirror_ocx = OcxRunner(ocx.binary, ocx.ocx_home, mirror_registry)
+    make_package(mirror_ocx, unique_repo, "1.0.0", tmp_path)
+
+    assert head_manifest(registry, unique_repo, "1.0.0") == 404, (
+        "upstream must be empty"
+    )
+
+    write_home_config(
+        ocx,
+        f'[mirrors]\n"{registry}" = "http://{mirror_registry}"\n'
+        f'[registries."{registry}"]\ninsecure = true\n'
+        f'[registries."{mirror_registry}"]\ninsecure = true\n',
+    )
+
+    fq = f"{registry}/{unique_repo}:1.0.0"
+    run_with_env(
+        ocx,
+        "package",
+        "install",
+        fq,
+        extra_env={"OCX_INSECURE_REGISTRIES": ""},
     )
 
     home = Path(ocx.env["OCX_HOME"])
@@ -536,6 +596,16 @@ def test_plain_http_mirror_without_insecure_flag_gives_actionable_error(
     )
     assert mirror_registry in combined, (
         "error message must name the offending mirror host, got:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    # Both spellings are named because either one fixes it — the old wording
+    # named only OCX_INSECURE_REGISTRIES, telling an operator half the fix.
+    assert "insecure = true" in combined, (
+        "error message must name the config spelling too, got:\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert f'[registries."{mirror_registry}"]' in combined, (
+        "error message must quote the exact TOML key, port included, got:\n"
         f"stdout: {result.stdout}\nstderr: {result.stderr}"
     )
 
@@ -721,7 +791,8 @@ def test_mirror_install_clean_reachability_is_mirror_agnostic(
     # host against OCX_INSECURE_REGISTRIES) at command startup, before any
     # network work — so every subsequent command in this test, even purely
     # local ones like `clean`, needs the mirror host listed here as long as
-    # the [mirrors] config stays on disk (ADR F2 fail-loud gate).
+    # the [mirrors] config stays on disk (adr_oci_registry_mirror.md,
+    # Implementation Plan step 3 "Auth + insecure" fail-loud gate).
     ocx.env["OCX_INSECURE_REGISTRIES"] = f"{registry},{mirror_registry}"
 
     fq = f"{registry}/{unique_repo}:1.0.0"

--- a/website/src/docs/authoring/building-pushing.md
+++ b/website/src/docs/authoring/building-pushing.md
@@ -22,6 +22,27 @@ ocx package push mytool-1.0.0.tar.xz
 Before pushing, verify the package works locally with [`ocx package test`][authoring-testing]. It runs the same install pipeline — dep resolution, extraction, env composition — in a temp directory with no registry round-trip. Exit code is forwarded from the command you run, so CI can gate on it. See [Testing locally][authoring-testing] for the full workflow.
 :::
 
+## Redirect Refusals {#redirect-refusals}
+
+An upload session in the [OCI Distribution Specification][oci-dist-spec] hands control to the registry mid-request: `push` opens a session, and the registry answers with a `Location` header naming where the next chunk or the commit request goes. That header is registry-supplied, not something OCX chose — a compromised or misconfigured registry, or an on-path party editing the header in flight, can point it anywhere.
+
+OCX refuses to follow it blindly. Four specific handoffs are checked before the next request goes out, and a failed check aborts the push rather than completing it silently over a route you didn't intend. All four exit [65 (DataError)][exit-codes] — the registry served something OCX will not act on, and a rerun reaches the same answer:
+
+- **A different registry.** The upload session's `Location` names a host other than the one you are pushing to. Following it would send that host your registry credentials and the blob body ([CWE-918][cwe-918]) — an internal address included, since nothing about the header requires it to be a public one.
+- **A plaintext credential realm.** OCX sends Basic or Bearer credentials to a `WWW-Authenticate` realm only when the realm is `https://`, its host matches the registry's own, or that realm host is itself declared plaintext-eligible. Anything else is refused, naming the realm URL ([CWE-319][cwe-319]) — most commonly an HTTPS registry naming a plaintext realm, but also a plain-HTTP registry whose token service sits on a different, undeclared host or port.
+- **A downgraded redirect.** Any request — not only the upload session — gets redirected from `https://` to `http://` mid-flight. OCX follows redirects (registries commonly hand blob downloads off to a CDN this way), but never one that drops TLS.
+- **A redirected upload request.** The requests that upload each chunk and commit the session never follow a redirect at all, not even a same-host one. (Opening the session is an ordinary request and still follows redirects; it carries no blob body, and the `Location` it comes back with is vetted before anything is sent to it.) If a registry answers one of them with a `3xx` after the session was already vetted as same-host, that status comes back as a refusal instead of being followed — closing the gap a one-time host check alone leaves open. This applies to uploads only; blob *pulls* still follow redirects, since that's how registries hand blobs off to a CDN. No registry redirects an upload write — it computes the blob's digest as the bytes stream past, which it can't do for a write it handed off elsewhere — so this refusal is not expected to fire against a correctly behaving registry.
+
+The first and last cases are specific to `push`'s upload-session flow. The middle two can surface on any authenticated request — `pull`, `install`, and `login` included — since they are checked at the transport layer, not the push path specifically.
+
+One more case lands in the same exit code without being a refusal at all: a redirect no client could act on — a missing or unparseable `Location`, or a body it can't replay — reaches any request, `pull` included. A registry emitting a malformed redirect looks identical to the fourth case from here; it isn't evidence of an attack, just a broken response.
+
+The cross-host, redirected-upload, and downgraded-redirect refusals are not something a plain-HTTP allowance opens back up: [`insecure = true`][config-registries-insecure] (or [`OCX_INSECURE_REGISTRIES`][env-insecure-registries]) only changes which registries OCX is willing to *dial* over HTTP, not which host an upload session may redirect to, whether it may redirect at all, or which host a TLS connection may downgrade to. The realm check is the exception — it does consult the allowance, for the realm's own host. See [`insecure`][config-registries-insecure] for what to declare when a plain-HTTP registry's token service lives on a separate host or port.
+
+:::info Reporting it
+The cross-host session, the redirected upload request, and the downgraded redirect are registry-side problems, not something to route around client-side — a same-registry upload session should never redirect at all, and nothing should ever downgrade to plain HTTP; if you hit any of the three, the registry (or a mirror/proxy in front of it) is misconfigured or compromised. A refused realm on an already-plain-HTTP registry is different: it's your own config missing an entry for the realm's host, fixed the same way as any other undeclared host — see the [`insecure`][config-registries-insecure] field.
+:::
+
 ## Bring Your Own Archives {#byo-archives}
 
 [`ocx package push`][cmd-package-push] does not bundle a directory for you. Every file layer must be a pre-built `.tar.gz` / `.tar.xz` / `.tar.zst` archive (the aliases `.tgz`, `.txz`, `.tzst`, and `.tar.zstd` are also accepted) — and that asymmetry is deliberate. Re-bundling the same content yields a non-deterministic digest (timestamps, compression entropy), and the registry treats every distinct digest as a fresh layer. Bundle once with [`ocx package create`][cmd-package-create] (see [Bundle Anatomy][authoring-bundle-anatomy]), then reference that archive across every subsequent push.
@@ -143,12 +164,15 @@ For command flags, token-source precedence, and exit codes see the
 <!-- external -->
 [oci-image-index]: https://github.com/opencontainers/image-spec/blob/main/image-index.md
 [oci-annotations]: https://github.com/opencontainers/image-spec/blob/main/annotations.md
+[oci-dist-spec]: https://github.com/opencontainers/distribution-spec/blob/main/spec.md
 [ghcr-repo-link]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
 [github-actions-docs]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/using-pre-written-building-blocks-in-your-workflow
 [mirror-pipeline]: https://github.com/ocx-sh/ocx/tree/main/crates/ocx_mirror
 [oci-referrers-spec]: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers
 [sigstore]: https://www.sigstore.dev/
 [rekor]: https://github.com/sigstore/rekor
+[cwe-918]: https://cwe.mitre.org/data/definitions/918.html
+[cwe-319]: https://cwe.mitre.org/data/definitions/319.html
 
 <!-- commands -->
 [cmd-package-create]: ../reference/command-line.md#package-create
@@ -163,6 +187,9 @@ For command flags, token-source precedence, and exit codes see the
 
 <!-- reference -->
 [reference-manifest-pins]: ../reference/metadata.md#dependencies-manifest-pins
+[config-registries-insecure]: ../reference/configuration.md#keys-registries-insecure
+[env-insecure-registries]: ../reference/environment.md#ocx-insecure-registries
+[exit-codes]: ../reference/command-line.md#exit-codes
 
 <!-- in-depth -->
 [in-depth-storage-layers]: ../in-depth/storage.md#layers

--- a/website/src/docs/reference/command-line.md
+++ b/website/src/docs/reference/command-line.md
@@ -309,7 +309,7 @@ The sysexits.h convention originates in BSD Unix and is documented at [man.freeb
 | 0 | Success | — | Successful completion | — |
 | 1 | Failure | — | Generic failure — only when no specific code applies | Inspect stderr |
 | 64 | UsageError | EX_USAGE | Bad CLI invocation: unknown flag, wrong argument count, invalid syntax; `package verify` given only one of `--certificate-identity` / `--certificate-oidc-issuer`, or given neither with no matching [`[[trust.policy]]`][config-trust] scope | Check the command syntax |
-| 65 | DataError | EX_DATAERR | Input data malformed: bad identifier, invalid digest, corrupted manifest, tampered Sigstore bundle; also a manifest fetch that got back something other than a manifest — an HTML page from a misconfigured [mirror][config-mirrors], for instance — refused by its content type before digest verification ever runs; also registry-served content whose digest does not match the descriptor; also a platform feature mismatch — the package ships for the host os/arch but no candidate's `os.features` are a subset of the host's (e.g. glibc vs musl), see [`--platform`](#package-install); also an ambiguous selection — a dual-libc host matched two equally-specific candidates (see [libc differentiation][authoring-libc]) | Validate identifiers and file contents; for a mirror serving a non-manifest response, check the mirror's own health and its `[mirrors]` routing; for a feature mismatch or ambiguous selection, override with `--platform` |
+| 65 | DataError | EX_DATAERR | Input data malformed: bad identifier, invalid digest, corrupted manifest, tampered Sigstore bundle; also a manifest fetch that got back something other than a manifest — an HTML page from a misconfigured [mirror][config-mirrors], for instance — refused by its content type before digest verification ever runs; also registry-served content whose digest does not match the descriptor; also a platform feature mismatch — the package ships for the host os/arch but no candidate's `os.features` are a subset of the host's (e.g. glibc vs musl), see [`--platform`](#package-install); also an ambiguous selection — a dual-libc host matched two equally-specific candidates (see [libc differentiation][authoring-libc]); also a registry-controlled redirect or auth realm that OCX refuses to follow during push or pull — a session URL or redirect naming a different registry host, a plaintext credential realm, a redirect that would drop TLS, or a redirect on an upload request at all (see [Redirect Refusals][authoring-building-pushing-redirect-refusals]) | Validate identifiers and file contents; for a mirror serving a non-manifest response, check the mirror's own health and its `[mirrors]` routing; for a feature mismatch or ambiguous selection, override with `--platform`; for a refused redirect or realm, see [Redirect Refusals][authoring-building-pushing-redirect-refusals] — it is a registry-side problem or a missing `insecure` entry, never one a rerun fixes |
 | 69 | Unavailable | EX_UNAVAILABLE | The registry answered, but not usefully — and a rerun will not change that. Also a local resource that cannot be reached | Inspect stderr; fix the registry or the URL before retrying |
 | 74 | IoError | EX_IOERR | I/O error: filesystem permission denied, disk full, read/write failure | Check filesystem permissions and free space |
 | 75 | TempFail | EX_TEMPFAIL | Temporary failure that may succeed on retry: registry connect failure or timeout, 429, 502, 503, 504, rate limit, transient network, or a layer blob that arrived short of its manifest-declared size | Retry with backoff |
@@ -1537,7 +1537,7 @@ ocx login [OPTIONS] [REGISTRY]
 
 :::details Reserved flags
 
-`--auth-type <TYPE>` is reserved for a future v2 OIDC / browser-OAuth flow. Passing it today emits a usage error (exit 64). Plain HTTP registries are enabled via `OCX_INSECURE_REGISTRIES` environment variable rather than a login flag.
+`--auth-type <TYPE>` is reserved for a future v2 OIDC / browser-OAuth flow. Passing it today emits a usage error (exit 64). Plain HTTP is not a login flag: `ocx login` probes the registry over whatever scheme the rest of the binary would use, which is HTTPS unless the host is named by [`[registries.<name>] insecure`][config-registries-insecure] or [`OCX_INSECURE_REGISTRIES`][env-insecure-registries].
 
 :::
 
@@ -5070,7 +5070,10 @@ wins over the machine's own.
 
 Past parsing, the merged result is run through the same gates every ocx invocation applies to
 its own config: an invalid `[mirrors."<host>"]` entry — an unparseable URL, or a plain-HTTP
-scheme not covered by an insecure-registries allowlist — fails the command (any forwarded
+scheme whose host the candidate does not declare plaintext-eligible (its own
+[`[registries.<name>] insecure`][config-registries-insecure], or
+[`OCX_INSECURE_REGISTRIES`][env-insecure-registries] on the testing machine) — fails the
+command (any forwarded
 [`OCX_MIRRORS`][env-ocx-mirrors] entries are folded in first, same as ordinary resolution),
 and so does an empty `[patches] registry = ""`. A payload that parses cleanly can still be one
 no machine could actually start under; catching that is the point of previewing. `[patches]`
@@ -5098,11 +5101,18 @@ ocx config test <CONFIG>
 | `CONFIG` | Path to the candidate config file to check. Required. |
 
 **Output** — plain: a `Field`/`Value` table; rows with no payload for this candidate (no
-`[patches]`, no configured `[managed]` tier, no unknown keys) are omitted. JSON: a fixed
-shape (`candidate`, `valid`, `registry_default`, `registries`, `mirrors`, `patches`,
-`managed`, `unknown_keys`) — every field is always present, with `null`/`[]` where a tier is
-unconfigured, so a consumer can key on `.valid`/`.unknown_keys` without probing for the
-field first.
+`[registries.<name>]`, no `[mirrors]`, no plain-HTTP host, no `[patches]`, no configured
+`[managed]` tier, no unknown keys) are omitted; a `Plain HTTP` row appears once per plain-HTTP
+host. JSON: a fixed shape (`candidate`, `valid`, `registry_default`, `registries`, `mirrors`,
+`plain_http`, `patches`, `managed`, `unknown_keys`) — every field is always present, with
+`null`/`[]` where a tier is unconfigured, so a consumer can key on `.valid`/`.unknown_keys`
+without probing for the field first. `plain_http` is the resolved union this candidate would
+actually get: its own `[registries.<name>] insecure = true` entries plus this machine's
+`OCX_INSECURE_REGISTRIES`, minus anything a system-tier explicit `insecure = false` subtracts,
+sorted. It's the answer to "did my `insecure` entry take effect?" — each host appears exactly
+as written, which is what the transport compares against, so a mis-spelled
+`[registries.<name>]` key is visible as itself (`private` where you meant
+`private.corp:5000`) rather than silently granting nothing.
 
 **Exit codes**
 
@@ -5467,9 +5477,14 @@ or a registry error) — the report then degrades to a local-state-only summary
 [authoring-libc]: ../authoring/multi-platform.md#libc
 [authoring-multi-platform]: ../authoring/multi-platform.md
 [authoring-building-pushing-dependency-pins]: ../authoring/building-pushing.md#dependency-pins
+[authoring-building-pushing-redirect-refusals]: ../authoring/building-pushing.md#redirect-refusals
 
 <!-- faq -->
 [faq-gcompat]: ../faq.md#linux-gcompat
+
+<!-- commands (login) -->
+[config-registries-insecure]: ./configuration.md#keys-registries-insecure
+[env-insecure-registries]: ./environment.md#ocx-insecure-registries
 
 <!-- commands (package announce) -->
 [cmd-package-announce]: #package-announce

--- a/website/src/docs/reference/configuration.md
+++ b/website/src/docs/reference/configuration.md
@@ -103,12 +103,12 @@ When `[registry]` is declared at the system scope (`/etc/ocx/config.toml`), it i
 
 ### `[registries.<name>]` {#keys-registries}
 
-Per-registry settings, keyed by a friendly name. Each entry configures one registry; [`[registry] default`](#keys-registry-default) can then reference it by name rather than by hostname.
+Per-registry settings, keyed by the registry's identifier prefix — the same `host[:port]` string your package identifiers carry, matched exactly (`ocx.sh`, `ghcr.io`, `registry.corp:5000`). This is not a free-form alias: a key that matches no registry name configures nothing.
 
 The plural form (`registries`, not `registry`) is deliberate: it mirrors [Cargo's convention][cargo-registries] and avoids a TOML collision with the singular [`[registry]`](#keys-registry) global-settings section.
 
 ::: info v1 scope
-`index` and `trusted_hosts` are defined in v1. The `[registries.<name>]` table is reserved for per-registry settings — future fields (`insecure`, `location` rewrite, `timeout`, auth) will slot into the same entry without breaking existing configs. Unknown fields inside an entry are ignored, like unknown keys and sections everywhere else in the file — see [Unknown keys and sections](#unknown-keys).
+`index`, `trusted_hosts`, and `insecure` are defined in v1. The `[registries.<name>]` table is reserved for per-registry settings — future fields (`location` rewrite, `timeout`, auth) will slot into the same entry without breaking existing configs. Unknown fields inside an entry are ignored, like unknown keys and sections everywhere else in the file — see [Unknown keys and sections](#unknown-keys).
 :::
 
 #### `index` {#keys-registries-index}
@@ -172,7 +172,7 @@ The named index is the sole authority for its namespace — a yanked tag, a tamp
 :::
 
 ::: info Why the resolved physical pointer uses `oci://`, never `http(s)`
-A [derived index's][in-depth-indices-dispatch] local root document — the file `ocx index update` writes under `$OCX_HOME/index/<source>/p/<ns>/<pkg>.json` — records the package's resolved physical location as `oci://<host>/<repository>`, not `http://` or `https://`. That scheme marks the reference *kind* — "an OCI registry repository" — not a transport to dial. Transport is a host-side decision: it comes from a [`[mirrors]`](#keys-mirrors) entry's own scheme for that host, or the plain-HTTP allowance in [`OCX_INSECURE_REGISTRIES`][env-insecure-registries]. If the pointer itself carried `http://` or `https://` instead, a publisher able to write that shared identity data could force every consumer resolving it down to plaintext — a scheme belongs to the operator who configures the host, never to data that travels with a package's identity.
+A [derived index's][in-depth-indices-dispatch] local root document — the file `ocx index update` writes under `$OCX_HOME/index/<source>/p/<ns>/<pkg>.json` — records the package's resolved physical location as `oci://<host>/<repository>`, not `http://` or `https://`. That scheme marks the reference *kind* — "an OCI registry repository" — not a transport to dial. Transport is a host-side decision: it comes from a [`[mirrors]`](#keys-mirrors) entry's own scheme for that host, or the plain-HTTP allowance the host carries — [`insecure = true`](#keys-registries-insecure) on its `[registries.<name>]` entry, or [`OCX_INSECURE_REGISTRIES`][env-insecure-registries]. If the pointer itself carried `http://` or `https://` instead, a publisher able to write that shared identity data could force every consumer resolving it down to plaintext — a scheme belongs to the operator who configures the host, never to data that travels with a package's identity.
 :::
 
 ##### `file://` bases {#keys-registries-index-file}
@@ -233,9 +233,31 @@ trusted_hosts = ["10.0.0.0/8", "registry.corp"]
 
 The guard is default-on and needs no configuration for public registries. There is no command-line flag to widen the trust set — the exemption lives only on the config entry, so a [system-locked](#keys-registries-system-lock) entry's `trusted_hosts` cannot be broadened by a lower tier or a CLI override. A refused host exits with a configuration error that names the host and points back to `trusted_hosts`.
 
+#### `insecure` {#keys-registries-insecure}
+
+**Type**: boolean  
+**Default**: `false` (HTTPS)
+
+Contact this registry over plain HTTP. This is the per-registry spelling of what [`OCX_INSECURE_REGISTRIES`][env-insecure-registries] says as a flat list, and the two are a **union** — a host named in either is plaintext-eligible:
+
+```toml
+[registries."registry.corp:5000"]
+insecure = true
+```
+
+Neither source can take a host back out of the set on its own — `insecure = false` at the user or [`$OCX_HOME`][env-ocx-home] tier states the default explicitly, it does not revoke a host the environment granted. The one exception is the system tier: an `insecure = false` entry declared at system scope is [locked](#keys-registries-system-lock) and subtracts that host from the union, [`OCX_INSECURE_REGISTRIES`][env-insecure-registries] included — the platform engineer's lever for forbidding plaintext to a host outright. A system tier that says nothing about `insecure` for a host locks nothing and subtracts nothing; only an explicit `false` at that scope does.
+
+The name is matched **exactly, `host[:port]` together** — the same comparison the transport makes. An entry for `registry.corp` does not cover `registry.corp:5001`, and case matters. Write the resolved registry host — the one exception is `docker.io`, which resolves to `index.docker.io` and is never served over plain HTTP, so no spelling of it is accepted here.
+
+The allowance covers transport and nothing else. An HTTPS registry that answers with a plaintext token-service realm is still refused, an `insecure` entry for one host never licenses cleartext for another, and an HTTPS request that is redirected to `http://` is refused rather than followed. Plain HTTP sends registry credentials in the clear on the wire — the entry exists for a lab or an isolated corporate network, not for reaching a registry across the public internet.
+
+A plaintext realm is allowed only when its host matches the registry's own, or that realm host is itself declared plaintext-eligible. If your plain-HTTP registry's authentication realm lives on a different host or port — a separate token service, for instance — declare that host too: one `[registries.<name>] insecure = true` entry per host, or both hosts listed in [`OCX_INSECURE_REGISTRIES`][env-insecure-registries]. An entry for the registry alone does not cover it, and `registry.corp:5000` / `registry.corp:5001` are different hosts here, same as everywhere else in this feature.
+
 #### System-locked {#keys-registries-system-lock}
 
-Each `[registries.<name>]` entry declared at the system scope is locked the same way as [`[registry]`](#keys-registry-system-lock) — unconditionally, per entry, covering both `index` and `trusted_hosts`. A lower tier cannot flip a locked entry's resolution protocol or widen its SSRF trust set.
+Each `[registries.<name>]` entry declared at the system scope is locked the same way as [`[registry]`](#keys-registry-system-lock) — unconditionally, per entry, covering `index`, `trusted_hosts`, and `insecure`. For `index` and `trusted_hosts` the lock is absolute: a lower tier cannot flip a locked entry's resolution protocol or widen its SSRF trust set, and neither field has an environment-variable counterpart to work around it.
+
+`insecure` is the one field with such a counterpart — [`OCX_INSECURE_REGISTRIES`][env-insecure-registries] normally unions with every config tier rather than being bound by them. The system tier is where that changes: a system-scope `insecure = false` entry additionally subtracts its host from the environment variable's contribution, the one case where a config tier can narrow the union instead of only widening it. A system tier that is silent about `insecure` for a host — no entry, or an entry that never mentions the field — locks nothing and subtracts nothing; only an explicit `false` at that scope does.
 
 ### `[mirrors]` {#keys-mirrors}
 
@@ -299,7 +321,7 @@ Older Nexus deployments expose each repository on a per-repository port. Those u
 
 **Scheme default.** When a role's value has no `scheme://` prefix (e.g., `"nexus.corp/docker-proxy"`), OCX defaults to `https`. Explicit `https://` is recommended for clarity.
 
-**Plain-HTTP mirrors.** A role value starting with `http://` requires the mirror host to be listed in [`OCX_INSECURE_REGISTRIES`][env-insecure-registries] — the same gate applies to both the registry and index roles. If the mirror host is absent, OCX exits at startup with an actionable error naming the variable and the mirror host — it does not silently downgrade TLS. The check runs before any network activity.
+**Plain-HTTP mirrors.** A role value starting with `http://` requires the mirror host to be plaintext-eligible — either [`insecure = true`](#keys-registries-insecure) on its own `[registries.<name>]` entry or a listing in [`OCX_INSECURE_REGISTRIES`][env-insecure-registries]. The same gate applies to both the registry and index roles. If the mirror host is in neither, OCX exits at startup with an actionable error naming the mirror host and both ways to allow it — it does not silently downgrade TLS. The check runs before any network activity.
 
 ::: info Malformed values
 `[mirrors]` values parse against a named shape — a string, or an object with only `registry`/`index` fields — with per-field errors rather than an opaque "did not match any variant" message. A role with a non-string value (`{ registry = 5 }`) is a parse error naming the offending host and field.
@@ -969,7 +991,7 @@ This table shows which OCX environment variables map to config file fields. Vari
 | [`OCX_OFFLINE`][env-offline] | None | Per-invocation mode, not a persistent setting |
 | [`OCX_REMOTE`][env-remote] | None | Per-invocation debugging mode, not a persistent setting |
 | [`OCX_BINARY_PIN`][env-ocx-binary-pin] | None | Subprocess-only: set automatically by ocx on every spawn so child ocx invocations pin to the same binary |
-| [`OCX_INSECURE_REGISTRIES`][env-insecure-registries] | None (deferred) | Will move to a per-entry `insecure` field under [`[registries.<name>]`](#keys-registries) once the flag is implemented; the env var remains the source of truth today |
+| [`OCX_INSECURE_REGISTRIES`][env-insecure-registries] | [`[registries.<name>] insecure`](#keys-registries-insecure) | **Union**, not an override: a host named in either source is plaintext-eligible, and neither can take one back out |
 | [`OCX_NO_UPDATE_CHECK`][env-no-update-check] | None | CI-only concern; env var is sufficient |
 | [`OCX_NO_MODIFY_PATH`][env-no-modify-path] | None | Install-time concern; env var is sufficient |
 
@@ -1129,15 +1151,14 @@ OCX publishes JSON Schemas for every config, project, and patch file at stable U
 
 These sections are documented here so the format design is stable before they land. They do not exist in the current release.
 
-### Per-registry fields beyond `index` and `trusted_hosts` {#future-registries-fields}
+### Per-registry fields beyond `index`, `trusted_hosts`, and `insecure` {#future-registries-fields}
 
-The [`[registries.<name>]`](#keys-registries) table is live in v1 with [`index`](#keys-registries-index) and [`trusted_hosts`](#keys-registries-trusted-hosts). Future per-registry fields will slot in without breaking existing configs:
+The [`[registries.<name>]`](#keys-registries) table is live in v1 with [`index`](#keys-registries-index), [`trusted_hosts`](#keys-registries-trusted-hosts), and [`insecure`](#keys-registries-insecure). Future per-registry fields will slot in without breaking existing configs:
 
 ```toml
-# Future shape (not in v1 — only index and trusted_hosts are implemented today):
-[registries.private]
+# Future shape (not in v1):
+[registries."registry.company.example"]
 index = "https://index.company.example"
-insecure = false                 # per-registry TLS opt-out
 location = "mirror.company.example"  # URL rewrite / mirror
 ```
 

--- a/website/src/docs/reference/environment.md
+++ b/website/src/docs/reference/environment.md
@@ -342,13 +342,19 @@ A comma-separated list of registry hostnames (with optional port) that should be
 export OCX_INSECURE_REGISTRIES="localhost:5000,registry.local:8080"
 ```
 
-The same list gates a second case: a plain-`http://` [`[mirrors]`][config-mirrors] target. A
+The variable is one half of a **union** with the [`[registries.<name>] insecure`][config-registries-insecure] config key: a host named in either source is plaintext-eligible. Only one thing narrows that set: an `insecure = false` entry declared at the [system config scope](./configuration.md#keys-registries-system-lock) subtracts its host from this variable's contribution too. Every other `insecure` value — including an explicit `false` below the system scope — only ever adds to the union, never removes from it. Prefer the config key for a host your machine always talks to over plain HTTP; the variable is the ambient, per-invocation half, and it is what a subprocess inherits.
+
+Names are matched exactly, `host[:port]` together — the same comparison the transport makes. `registry.corp` does not cover `registry.corp:5001`.
+
+The same set gates a second case: a plain-`http://` [`[mirrors]`][config-mirrors] target. A
 mirror value — for either the `registry` role or the `index` role — that starts with `http://` is
-refused unless the mirror's own host appears here; `https://` mirror targets never need this
-variable, regardless of which role they cover.
+refused unless the mirror's own host is in the set; `https://` mirror targets never need it,
+regardless of which role they cover.
 
 ::: warning
-This variable disables TLS for the listed registries. Only use it for local development registries that do not support HTTPS.
+This disables TLS for the listed registries, so credentials travel the wire in the clear. Only use it for local development registries that do not support HTTPS.
+
+It covers transport and nothing else: an HTTPS registry that names a plaintext token-service realm is still refused, an HTTPS request redirected to `http://` is refused rather than followed, and listing one host never licenses cleartext for another. See [Redirect Refusals][authoring-redirect-refusals] for what these refusals look like from the command line and why widening this list does not change them.
 :::
 
 ### `OCX_MIRRORS` {#ocx-mirrors}
@@ -380,7 +386,7 @@ A malformed `OCX_MIRRORS` value is a **hard startup error**. OCX aborts with an 
 
 - The value is not valid JSON
 - A per-host value is neither a string URL nor an object with only `registry`/`index` string fields
-- A mirror value starts with `http://` but the mirror host is not listed in [`OCX_INSECURE_REGISTRIES`][env-insecure-registries-ref]
+- A mirror value starts with `http://` but the mirror host is not plaintext-eligible — neither [`OCX_INSECURE_REGISTRIES`][env-insecure-registries-ref] nor an `insecure = true` entry in [`[registries.<name>]`][config-registries-insecure] names it
 
 OCX never silently continues with an empty mirror map when `OCX_MIRRORS` is set — falling back to no mirrors would silently route reads to the firewall-blocked origin, which is the exact failure replace semantics are designed to prevent.
 :::
@@ -844,6 +850,7 @@ The format for this variable is the same as for [`OCX_LOG`](#ocx-log).
 [config-ref]: ./configuration.md
 [config-home-tier]: ../in-depth/configuration.md#tier-ocx-home
 [config-mirrors]: ./configuration.md#keys-mirrors
+[config-registries-insecure]: ./configuration.md#keys-registries-insecure
 [config-patches]: ./configuration.md#keys-patches
 [config-managed]: ./configuration.md#keys-managed
 [config-managed-refresh]: ./configuration.md#keys-managed-refresh
@@ -869,3 +876,4 @@ The format for this variable is the same as for [`OCX_LOG`](#ocx-log).
 
 <!-- authoring -->
 [authoring-testing-scripted]: ../authoring/testing.md#scripted-tests
+[authoring-redirect-refusals]: ../authoring/building-pushing.md#redirect-refusals


### PR DESCRIPTION
Closes #272.

Two commits. Depends on [ocx-sh/rust-oci-client#6](https://github.com/ocx-sh/rust-oci-client/pull/6) — the gitlink moves to `21ded5e` on that branch, so **merge the fork PR first**.

## `[registries.<name>].insecure`

The first-class way to say a registry is reachable over plain HTTP. Unions with `OCX_INSECURE_REGISTRIES` behind one shared predicate, replacing four ad-hoc host checks that each parsed the environment their own way. `<name>` matches exactly, `host[:port]` together.

One source subtracts, and only one: a **system-tier** entry that explicitly states `insecure = false` locks that host shut against the env list too. A tier that does not mention `insecure` subtracts nothing — `Some(false)` is a decision, `None` is silence.

**The two directions normalise differently, on purpose.** Granting compares bytes, so a mis-spelled entry licenses nothing and fails closed. Revoking compares the host case-folded and the port numerically, because exactness there fails **open** — a lock on `registry.corp:5000` has to catch `Registry.Corp:5000` and `registry.corp:05000`, both of which reach the same socket. Both bypasses were found in review, the second by the cross-model gate after the first was fixed.

Known residual, documented at the predicate: default-port elision (`registry.corp` vs `registry.corp:443`) is not folded, because the right default depends on a scheme the predicate cannot see.

The managed tier may set `insecure`. That was considered and deliberately kept; `adr_managed_config_tier.md` is amended to record that Decision I's "loosening structurally blocked by G" was never true for `[registries.<name>]`, and to state the residual exposure plainly.

## Transport refusals

The fork now refuses four registry-supplied destinations rather than following them. Ocx-side, they carry two error variants:

- `UnsafeDestination` — the two guards that **name a destination and refuse it**: a cross-host upload-session `Location`, a plaintext auth realm from an HTTPS registry.
- `UnfollowedRedirect` — the redirect shapes: a TLS-dropping hop, a 3xx answer to an upload request, the hop limit, and a redirect no client could act on.

The split exists because a registry emitting a `Location`-less `302` on an ordinary pull also lands here, and calling that an *unsafe destination* sends an operator hunting for an attacker over a malformed response.

> [!WARNING]
> **BREAKING — these exit 65 (data error), not 69.** 69 said "registry unreachable; retry with backoff", which is wrong for a deliberate refusal a rerun reaches identically — and would tell a CI wrapper to re-issue the push against the same hostile `Location`. 78 was rejected because no config an operator can write lifts these; `insecure = true` does not unblock the realm or redirect guards.

The `_ =>` catch-all that produced the 69 is gone, so the next fork variant is a compile error here rather than a silent misclassification.

> [!WARNING]
> **BREAKING — the hidden no-op `--insecure` flag on `ocx login` is deleted.** It now exits 64.

## `ocx login`

**It widened plaintext eligibility to every host on earth.** The probe was built with the blanket `ClientProtocol::Http`, whose `scheme_for` ignores its argument — so the transport's auth-realm guard, which accepts a plaintext realm on any *plaintext-eligible* host, matched unconditionally. Declaring one host insecure turned the guard off for all of them, on the one command in the binary holding a raw password. It now uses `HttpsExcept`: same scheme for the probe, guard scoped to the declared hosts.

It also no longer reports "rejected credentials" at exit 80 when the credentials were never sent. A failed HTTPS connect keeps its cause and names both `[registries."<host>"] insecure = true` and `OCX_INSECURE_REGISTRIES`; every command hitting that wire failure gets the same remediation.

## `ocx config test`

Gains an additive `plain_http` field reporting the resolved union, each host spelled exactly as the transport compares it — so a key that grants nothing is visible as itself (`private` where `private.corp:5000` was meant) rather than silently inert.

## Testing

`task verify` exit 0 — **5596 unit, 2285 acceptance**. Five acceptance cases added, including the config half of the plain-HTTP index gate, which every existing case had exercised only through the env var.

Discrimination for the acceptance cases was proven against an isolated reference binary built from the commit **before** the feature, rather than by mutating the shared tree. The login case's red is the original bug verbatim:

```
AssertionError: a failed HTTPS connect must be TempFail (75), not LoginRejected (80): exit 80
stderr: ERROR registry 'localhost:5000' rejected credentials
```

Unrelated find: `test/.venv` was pinned to Python 3.10, so `test_index_ocx_sh.py`'s unconditional `tomllib` import failed **collection** — that whole module had been silently not running. Rebuilt under 3.13.

## Review

Four implementation agents, then a three-reviewer panel (security read-site audit, quality, traceability), four fix rounds, and a cross-model adversarial gate. Every behavioural fix is mutation-proven red → restore-proven → green.

The security pass enumerated all 24 sites where a registry-supplied URL, host or `Location` reaches a request builder across both trees, with a verdict each — that table is what established the refusal set is complete, rather than an argument that it is.

## Known, not fixed here

- A **same-origin `307` during registry failover** now exits 65, so a CI retry wrapper will not retry it. The classification comment argues these are terminal; failover is the case it does not address. Flagged deliberately rather than changed silently.
- `task verify` is flaky on `main` at roughly 1 run in 3 — `a_symlink_planted_during_the_retry_loop_is_refused`, from `bef7428b`, reproduced 2/6 on a pristine worktree. Not introduced here; the test asserts a guarantee `refuse_symlink_at`'s own doc says it does not make.
- [#336](https://github.com/ocx-sh/ocx/issues/336) is closed incidentally by the fork PR's construction-path test — no TLS fixture needed after all.
