### PR TITLE
ci: invoke the toolchain with ocx run until a release ships exec

### DIFF
--- a/.github/workflows/verify-basic.yml
+++ b/.github/workflows/verify-basic.yml
@@ -48,10 +48,10 @@ jobs:
         with:
           version: '0.5.2'
       - name: Lint workflows
-        # `ocx exec` composes the project toolchain (actionlint + shellcheck +
+        # `ocx run` composes the project toolchain (actionlint + shellcheck +
         # go-task) from ocx.lock and runs the task hermetically — same gate as
         # local `task ci:actionlint`.
-        run: ocx exec -- task ci:actionlint
+        run: ocx run -- task ci:actionlint
 
   smoke:
     name: Smoke (Linux)


### PR DESCRIPTION
`Workflow Lint` is failing on `main` and therefore on every PR branched from it.

## Cause

[fed200c6](https://github.com/ocx-sh/ocx/commit/fed200c6) renamed `ocx run` to `ocx exec` and updated `.github/workflows/verify-basic.yml:54` along with it. But that step runs against a **bootstrapped release binary** (`setup-ocx`, pinned at `0.5.2` on line 49), and no released ocx has `exec` yet — `0.5.8` is current and still spells it `run`.

```
ERROR unknown subcommand 'exec'; if `ocx-exec` is an official OCX plugin, install it with
`ocx --global add ocx.sh/ocx/exec`, otherwise put an `ocx-exec` binary on your PATH
exit code 64
```

Bumping the pin does not help: the rename is unreleased, so every published version still has `run`.

## Fix

One call site, invocation only. The rename itself is untouched — this restores the spelling that works against a released binary. Swap it back to `exec` once a release carries it.

Verified: `.github/workflows/verify-basic.yml:54` is the only `ocx exec` in `.github/workflows/` (line 51 is its comment); `verify-deep.yml` has none, which is why Deep passes unaffected.

## Noted, not fixed here

`verify-basic.yml` pins `setup-ocx` at `0.5.2` in two places (lines 49 and 116) while `0.5.8` is current. Independent of this failure and left alone to keep the diff to the blocker.
